### PR TITLE
Add/Refactoring IndexUtils #2

### DIFF
--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -17,8 +17,7 @@
 '''
 Module for providing python interface to Anserini index utils
 '''
-from enum import Enum
-from ..pyclass import JIndexUtils, JString
+from ..pyclass import JIndexUtils, JDocumentVectorWeight, JString
 
 import logging
 
@@ -38,17 +37,17 @@ class IndexUtils:
     def __init__(self, index_dir):
         self.object = JIndexUtils(JString(index_dir))
 
-    class DocVectorWeight(Enum):
-        NONE = 0
-        TF_IDF = 1
+    class DocumentVectorWeight:
+        NONE = JDocumentVectorWeight.NONE
+        TF_IDF = JDocumentVectorWeight.TF_IDF
 
-    def dumpDocumentVectors(self, reqDocidsPath: str, weight: DocVectorWeight):
+    def dump_document_vectors(self, reqDocidsPath: str, weight: DocumentVectorWeight):
         '''
         Parameters
         ----------
         reqDocidsPath : str
             dumps the document vector for all documents in reqDocidsPath
-        weight : DocVectorWeight
+        weight : DocumentVectorWeight
             the weight for dumped document vector(s)
         '''
-        self.object.dumpDocumentVectors(reqDocidsPath, weight.value)
+        self.object.dumpDocumentVectors(reqDocidsPath, weight)

--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Module for providing python interface to Anserini index utils
+'''
+from enum import Enum
+from ..pyclass import JIndexUtils, JString
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class IndexUtils:
+    '''
+    Wrapper class for Anserini's IndexUtils.
+
+    Parameters
+    ----------
+    index_dir : str
+        Path to Lucene index directory
+    '''
+
+    def __init__(self, index_dir):
+        self.object = JIndexUtils(JString(index_dir))
+
+    class DocVectorWeight(Enum):
+        NONE = 0
+        TF_IDF = 1
+
+    def dumpDocumentVectors(self, reqDocidsPath: str, weight: DocVectorWeight):
+        '''
+        Parameters
+        ----------
+        reqDocidsPath : str
+            dumps the document vector for all documents in reqDocidsPath
+        weight : DocVectorWeight
+            the weight for dumped document vector(s)
+        '''
+        self.object.dumpDocumentVectors(reqDocidsPath, weight.value)

--- a/pyserini/pyclass.py
+++ b/pyserini/pyclass.py
@@ -46,6 +46,7 @@ JTopicReader = autoclass('io.anserini.search.topicreader.TopicReader')
 
 ## IndexUtils
 JIndexUtils = autoclass('io.anserini.index.IndexUtils')
+JDocumentVectorWeight = autoclass('io.anserini.index.IndexUtils$DocumentVectorWeight')
 
 ### Generator
 

--- a/pyserini/pyclass.py
+++ b/pyserini/pyclass.py
@@ -23,7 +23,7 @@ Module for hiding Python-Java calls via Pyjnius
 from .setup import configure_classpath, os
 # If the environment variable isn't defined, look in the current directory.
 configure_classpath(os.environ['ANSERINI_CLASSPATH'] if 'ANSERINI_CLASSPATH' in os.environ else os.path.join(os.path.split(__file__)[0], 'resources/jars/'))
-    
+
 from jnius import autoclass, cast
 from enum import Enum
 
@@ -43,6 +43,9 @@ JSearcher = autoclass('io.anserini.search.SimpleSearcher')
 
 JTopics = autoclass('io.anserini.search.topicreader.TopicReader$Topics')
 JTopicReader = autoclass('io.anserini.search.topicreader.TopicReader')
+
+## IndexUtils
+JIndexUtils = autoclass('io.anserini.index.IndexUtils')
 
 ### Generator
 


### PR DESCRIPTION
Since DocVectorWeight enum is private in Anserini I couldn't port properly. This issue creates output files with wrong names(text.txt.docvector.(0-1).tar.gz). So it would be better to make DocVectorWeight public in IndexUtils.java. However, this piece of code works correctly.