### PR TITLE
Set up Sphinx documentation stubs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Pyserini'
+copyright = '2019, Jimmy Lin'
+author = 'Jimmy Lin'
+
+# The full version, including alpha/beta/rc tags
+release = '0.7.0.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'sphinx.ext.napoleon' ]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. Pyserini documentation master file, created by
+   sphinx-quickstart on Mon Dec 30 07:00:32 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Pyserini's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+pyserini
+========
+
+.. toctree::
+   :maxdepth: 4
+
+   pyserini

--- a/docs/source/pyserini.collection.rst
+++ b/docs/source/pyserini.collection.rst
@@ -1,0 +1,22 @@
+pyserini.collection package
+===========================
+
+Submodules
+----------
+
+pyserini.collection.pycollection module
+---------------------------------------
+
+.. automodule:: pyserini.collection.pycollection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pyserini.collection
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/pyserini.index.rst
+++ b/docs/source/pyserini.index.rst
@@ -1,0 +1,30 @@
+pyserini.index package
+======================
+
+Submodules
+----------
+
+pyserini.index.pygenerator module
+---------------------------------
+
+.. automodule:: pyserini.index.pygenerator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyserini.index.pyutils module
+-----------------------------
+
+.. automodule:: pyserini.index.pyutils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pyserini.index
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/pyserini.rst
+++ b/docs/source/pyserini.rst
@@ -1,0 +1,47 @@
+pyserini package
+================
+
+Subpackages
+-----------
+
+.. toctree::
+
+   pyserini.collection
+   pyserini.index
+   pyserini.search
+
+Submodules
+----------
+
+pyserini.multithreading module
+------------------------------
+
+.. automodule:: pyserini.multithreading
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyserini.pyclass module
+-----------------------
+
+.. automodule:: pyserini.pyclass
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyserini.setup module
+---------------------
+
+.. automodule:: pyserini.setup
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pyserini
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/pyserini.search.rst
+++ b/docs/source/pyserini.search.rst
@@ -1,0 +1,22 @@
+pyserini.search package
+=======================
+
+Submodules
+----------
+
+pyserini.search.pysearch module
+-------------------------------
+
+.. automodule:: pyserini.search.pysearch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: pyserini.search
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Created using Sphinx 2.3.0; primarily used for automatically-generated API documentation from docstrings. For a high-level user guide, the README.md appears adequate, at least for now.