### PR TITLE
Exposes methods for converting between internal Lucene docid and external collection docid

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('..'))
-
+sys.path.insert(0, os.path.abspath('../..'))
 
 # -- Project information -----------------------------------------------------
 

--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''
+"""
 Module for providing python interface to Anserini index reader utils
-'''
+"""
+
 from ..pyclass import JIndexReaderUtils, JDocumentVectorWeight, JString
 
 import logging
@@ -25,14 +26,14 @@ logger = logging.getLogger(__name__)
 
 
 class IndexReaderUtils:
-    '''
+    """
     Wrapper class for Anserini's IndexReaderUtils.
 
     Parameters
     ----------
     index_dir : str
         Path to Lucene index directory
-    '''
+    """
 
     def __init__(self, index_dir):
         self.object = JIndexReaderUtils()
@@ -42,32 +43,17 @@ class IndexReaderUtils:
         NONE = JDocumentVectorWeight.NONE
         TF_IDF = JDocumentVectorWeight.TF_IDF
 
-    class Posting:
-        '''
-        Basic Posting class for Postings List
-        '''
-        def __init__(self, docid, term_freq, positions):
-            self.docid = docid
-            self.term_freq = term_freq
-            self.positions = positions
-
-        def __repr__(self):
-            repr = '(' + str(self.docid) + ', ' + str(self.term_freq) + ')'
-            if self.positions:
-                repr += ' [' + ','.join([str(p) for p in self.positions]) + ']'
-            return repr
-
     class IndexTerm:
-        '''
+        """
         Basic IndexTerm class to represent each term in index
-        '''
+        """
         def __init__(self, term, doc_freq, total_term_freq):
             self.term = term
             self.doc_freq = doc_freq
             self.total_term_freq = total_term_freq
 
     def analyze(self, text):
-        '''
+        """
         Parameters
         ----------
         term : str
@@ -75,7 +61,7 @@ class IndexReaderUtils:
         -------
         result : str
             List of stemmed tokens
-        '''
+        """
         stemmed = self.object.analyze(JString(text))
         token_list = []
         for token in stemmed.toArray():
@@ -83,16 +69,16 @@ class IndexReaderUtils:
         return token_list
 
     def terms(self):
-        '''
+        """
         :return: generator over terms
-        '''
+        """
         term_iterator = self.object.getTerms(self.reader)
         while term_iterator.hasNext():
             cur_term = term_iterator.next()
             yield self.IndexTerm(cur_term.getTerm(), cur_term.getDF(), cur_term.getTotalTF())
 
     def get_term_counts(self, term):
-        '''
+        """
         Parameters
         ----------
         term : str
@@ -101,12 +87,12 @@ class IndexReaderUtils:
         -------
         result : long, long
             Collection frequency and document frequency of term
-        '''
+        """
         term_map = self.object.getTermCounts(self.reader, JString(term))
         return term_map.get(JString('collectionFreq')), term_map.get(JString('docFreq'))
 
     def get_postings_list(self, term):
-        '''
+        """
         Parameters
         ----------
         term : str
@@ -114,15 +100,15 @@ class IndexReaderUtils:
         -------
         result : list<Posting>
             Postings list for term
-        '''
+        """
         postings_list = self.object.getPostingsList(self.reader, JString(term))
         result = []
         for posting in postings_list.toArray():
-            result.append(self.Posting(posting.getDocid(), posting.getTF(), posting.getPositions()))
+            result.append(Posting(posting.getDocid(), posting.getTF(), posting.getPositions()))
         return result
 
     def get_document_vector(self, docid):
-        '''
+        """
         Parameters
         ----------
         docid : str
@@ -131,7 +117,7 @@ class IndexReaderUtils:
         -------
         result : dict
             Terms and their respective frequencies in document
-        '''
+        """
         doc_vector_map = self.object.getDocumentVector(self.reader, JString(docid))
         doc_vector_dict = {}
         for term in doc_vector_map.keySet().toArray():
@@ -139,7 +125,7 @@ class IndexReaderUtils:
         return doc_vector_dict
 
     def get_raw_document(self, docid):
-        '''
+        """
         Parameters
         ----------
         docid : str
@@ -147,11 +133,11 @@ class IndexReaderUtils:
         Returns
         -------
         result : raw document given its collection docid
-        '''
+        """
         return self.object.getRawDocument(self.reader, JString(docid))
 
     def get_bm25_term_weight(self, docid, term):
-        '''
+        """
         Parameters
         ----------
         docid : str
@@ -161,16 +147,70 @@ class IndexReaderUtils:
         -------
         result : float
             BM25 score (NaN if no documents match)
-        '''
+        """
         return self.object.getBM25TermWeight(self.reader, JString(docid), JString(term))
 
     def dump_document_vectors(self, reqDocidsPath, weight):
-        '''
+        """
         Parameters
         ----------
         reqDocidsPath : str
             dumps the document vector for all documents in reqDocidsPath
         weight : DocumentVectorWeight
             the weight for dumped document vector(s)
-        '''
+        """
         self.object.dumpDocumentVectors(self.reader, reqDocidsPath, weight)
+
+    def convert_internal_docid_to_collection_docid(self, docid: int) -> str:
+        """Converts Lucene's internal ``docid`` to its external collection ``docid``.
+
+        Parameters
+        ----------
+        docid : int
+            A Lucene internal ``docid``.
+
+        Returns
+        -------
+        str
+            The external collection ``docid`` corresponding to Lucene's internal ``docid``.
+        """
+        return self.object.convertLuceneDocidToDocid(self.reader, docid)
+
+    def convert_collection_docid_to_internal_docid(self, docid: str) -> int:
+        """Converts an external collection ``docid`` to its Lucene's internal ``docid``.
+
+        Parameters
+        ----------
+        docid : str
+            An external collection ``docid``.
+
+        Returns
+        -------
+        str
+            The Lucene internal ``docid`` corresponding to the external collection ``docid``.
+        """
+        return self.object.convertDocidToLuceneDocid(self.reader, docid)
+
+
+class Posting:
+    """Class representing a posting in a postings list.
+
+    Parameters
+    ----------
+    docid : int
+        The ``docid`` associated with this posting.
+    tf : int
+        The term frequency associated with this posting.
+    positions : List[int]
+        The list of positions associated with this posting.
+    """
+    def __init__(self, docid, tf, positions):
+        self.docid = docid
+        self.tf = tf
+        self.positions = positions
+
+    def __repr__(self):
+        repr = '(' + str(self.docid) + ', ' + str(self.tf) + ')'
+        if self.positions:
+            repr += ' [' + ','.join([str(p) for p in self.positions]) + ']'
+        return repr

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -42,16 +42,34 @@ class TestIndexUtils(unittest.TestCase):
         self.assertEqual(len(postings_list), 138)
 
         self.assertEqual(postings_list[0].docid, 238)
-        self.assertEqual(postings_list[0].term_freq, 1)
+        self.assertEqual(self.index_utils.convert_internal_docid_to_collection_docid(postings_list[0].docid), 'CACM-0239')
+        self.assertEqual(postings_list[0].tf, 1)
+        self.assertEqual(len(postings_list[0].positions), 1)
 
         self.assertEqual(postings_list[-1].docid, 3168)
-        self.assertEqual(postings_list[-1].term_freq, 1)
+        self.assertEqual(self.index_utils.convert_internal_docid_to_collection_docid(postings_list[-1].docid), 'CACM-3169')
+        self.assertEqual(postings_list[-1].tf, 1)
+        self.assertEqual(len(postings_list[-1].positions), 1)
 
     def test_doc_vector(self):
         doc_vector = self.index_utils.get_document_vector('CACM-3134')
         self.assertEqual(len(doc_vector), 94)
         self.assertEqual(doc_vector['inform'], 8)
         self.assertEqual(doc_vector['retriev'], 7)
+
+    def test_doc_vector_matches_index(self):
+        # From the document vector, look up the term frequency of "information".
+        doc_vector = self.index_utils.get_document_vector('CACM-3134')
+        self.assertEqual(doc_vector['inform'], 8)
+
+        # Now look up the postings list for "information".
+        term = 'information'
+        postings_list = list(self.index_utils.get_postings_list(term))
+
+        for i in range(len(postings_list)):
+            if self.index_utils.convert_internal_docid_to_collection_docid(postings_list[i].docid) == 'CACM-3134':
+                # The tf values should match.
+                self.assertEqual(postings_list[i].tf, 8)
 
     def test_raw_doc(self):
         lines = self.index_utils.get_raw_document('CACM-3134').splitlines()
@@ -62,6 +80,12 @@ class TestIndexUtils(unittest.TestCase):
     def test_bm25_weight(self):
         self.assertAlmostEqual(self.index_utils.get_bm25_term_weight('CACM-3134', 'inform'), 1.925014, places=5)
         self.assertAlmostEqual(self.index_utils.get_bm25_term_weight('CACM-3134', 'retriev'), 2.496352, places=5)
+
+    def test_docid_converstion(self):
+        self.assertEqual(self.index_utils.convert_internal_docid_to_collection_docid(1), 'CACM-0002')
+        self.assertEqual(self.index_utils.convert_collection_docid_to_internal_docid('CACM-0002'), 1)
+        self.assertEqual(self.index_utils.convert_internal_docid_to_collection_docid(1000), 'CACM-1001')
+        self.assertEqual(self.index_utils.convert_collection_docid_to_internal_docid('CACM-1001'), 1000)
 
     def tearDown(self):
         os.remove(self.tarball_name)


### PR DESCRIPTION
Closes #33 

Minor tweaks along the way; made Posting a top-level class, not hidden inside `IndexReaderUtils`.