### PR TITLE
Fixed broken tests due to Anserini 0.7.3-SNAPSHOT

### DIFF
--- a/pyserini/collection/pycollection.py
+++ b/pyserini/collection/pycollection.py
@@ -40,12 +40,11 @@ class Collection:
         self.collection_class = collection_class
         self.collection_path = JPaths.get(collection_path)
         self.object = self._get_collection()
-        self.object.setCollectionPath(self.collection_path)
         self.collection_iterator = self.object.iterator()
 
     def _get_collection(self):
         try:
-            return JCollections[self.collection_class].value()
+            return JCollections[self.collection_class].value(self.collection_path)
         except:
             raise ValueError(self.collection_class)
 

--- a/pyserini/search/pysearch.py
+++ b/pyserini/search/pysearch.py
@@ -106,7 +106,9 @@ class SimpleSearcher:
             jqid = JString(qid)
             qid_strings.add(jqid)
 
-        results = self.object.batchSearch(query_strings, qid_strings, int(k), int(t), int(threads)).entrySet().toArray()
+        # TODO: currently, we're just ignore t here, because there isn't a batchSearch method in Anserini that exposes
+        # the same method signature
+        results = self.object.batchSearch(query_strings, qid_strings, int(k), int(threads)).entrySet().toArray()
         return {r.getKey(): r.getValue() for r in results}
 
     def search_fields(self, q, f, boost, k):


### PR DESCRIPTION
We've made changes to Anserini head that are breaking changes to Pyserini. These break existing Pyserini unit tests.

After merging PR, we'll have the opposite problem: Pyserini unit tests will now fail on the official Maven Anserini 0.7.2 artifact.

There's no good way around this issue.
