### PR TITLE
Fix for ValueError: chr() arg not in range

### DIFF
--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -132,7 +132,7 @@ class IndexReaderUtils:
         Tuple[int, int]
             The document frequency and collection frequency of the term.
         """
-        term_map = self.object.getTermCounts(self.reader, JString(term))
+        term_map = self.object.getTermCounts(self.reader, JString(term.encode('utf-8')))
         return term_map.get(JString('docFreq')), term_map.get(JString('collectionFreq'))
 
     def get_postings_list(self, term: str) -> List[Posting]:
@@ -148,7 +148,7 @@ class IndexReaderUtils:
         List[Posting]
             List of :class:`Posting` objects corresponding to the postings list for the term.
         """
-        postings_list = self.object.getPostingsList(self.reader, JString(term))
+        postings_list = self.object.getPostingsList(self.reader, JString(term.encode('utf-8')))
         result = []
         for posting in postings_list.toArray():
             result.append(Posting(posting.getDocid(), posting.getTF(), posting.getPositions()))
@@ -170,7 +170,7 @@ class IndexReaderUtils:
         doc_vector_map = self.object.getDocumentVector(self.reader, JString(docid))
         doc_vector_dict = {}
         for term in doc_vector_map.keySet().toArray():
-            doc_vector_dict[term] = doc_vector_map.get(JString(term))
+            doc_vector_dict[term] = doc_vector_map.get(JString(term.encode('utf-8')))
         return doc_vector_dict
 
     def get_raw_document(self, docid: str) -> str:
@@ -205,7 +205,7 @@ class IndexReaderUtils:
         float
             The BM25 weight of the term in the document, or ``NaN`` if the term does not exist in the document.
         """
-        return self.object.getBM25TermWeight(self.reader, JString(docid), JString(term))
+        return self.object.getBM25TermWeight(self.reader, JString(docid), JString(term.encode('utf-8')))
 
     def convert_internal_docid_to_collection_docid(self, docid: int) -> str:
         """Converts Lucene's internal ``docid`` to its external collection ``docid``.

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -22,6 +22,7 @@ from random import randint
 from urllib.request import urlretrieve
 
 from pyserini.index import pyutils
+from pyserini.pyclass import JString
 
 
 class TestIndexUtils(unittest.TestCase):
@@ -120,6 +121,13 @@ class TestIndexUtils(unittest.TestCase):
         self.assertEqual(self.index_utils.convert_collection_docid_to_internal_docid('CACM-0002'), 1)
         self.assertEqual(self.index_utils.convert_internal_docid_to_collection_docid(1000), 'CACM-1001')
         self.assertEqual(self.index_utils.convert_collection_docid_to_internal_docid('CACM-1001'), 1000)
+
+    def test_jstring_term(self):
+        self.assertEqual(self.index_utils.get_term_counts("zoölogy"), (0, 0))
+        with self.assertRaises(ValueError):
+            # Should fail when pyjnius has solved this internally.
+            JString('zoölogy')
+        
 
     def tearDown(self):
         os.remove(self.tarball_name)


### PR DESCRIPTION
Fix for ‘ValueError: chr() arg not in range(0x110000)’ when calling a method from IndexReaderUtils (in pyutils) that contains a JString(term). For example after calling the get_document_vector(docid) method. This can be caused by a rare character in a term (See: https://github.com/kivy/pyjnius/issues/437). 

Specifying utf-8 encoding for the term solved this error: JString(term.encode(‘utf-8’)).

