### PR TITLE
Refactoring of analyzers

### DIFF
--- a/pyserini/analysis/pyanalysis.py
+++ b/pyserini/analysis/pyanalysis.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from ..pyclass import JAnalyzerUtils
 from ..pyclass import JArabicAnalyzer
 from ..pyclass import JBengaliAnalyzer
 from ..pyclass import JCJKAnalyzer
@@ -7,46 +26,81 @@ from ..pyclass import JFrenchAnalyzer
 from ..pyclass import JGermanAnalyzer
 from ..pyclass import JHindiAnalyzer
 from ..pyclass import JSpanishAnalyzer
-from ..pyclass import JTweetAnalyzer
 from ..pyclass import JString
+from ..pyclass import JTweetAnalyzer
 
 
-def get_analyzer(analyzer, stemmer='porter'):
+def get_lucene_analyzer(name='english', stemming=True, stemmer='porter'):
     """
     Parameters
     ----------
-    analyzer : String
-        Name of analyzer to get
-
-    stemmer : String
-        Name of stemmer that analyzer needs to use (not all analyzers allow for a stemmer to be provided)
+    name : Str
+        Name of analyzer.
+    stemming : Bool
+        Whether or not to stem.
+    stemmer : Str
+        Stemmer to use.
 
     Returns
     -------
     result : org.apache.lucene.document.Analyzer
         Java Analyzer object
     """
-    if analyzer == 'arabic':
+    if name.lower() == 'arabic':
         return JArabicAnalyzer()
-    elif analyzer == 'bengali':
+    elif name.lower() == 'bengali':
         return JBengaliAnalyzer()
-    elif analyzer == 'cjk':
+    elif name.lower() == 'cjk':
         return JCJKAnalyzer()
-    elif analyzer == 'german':
+    elif name.lower() == 'german':
         return JGermanAnalyzer()
-    elif analyzer == 'spanish':
+    elif name.lower() == 'spanish':
         return JSpanishAnalyzer()
-    elif analyzer == 'french':
+    elif name.lower() == 'french':
         return JFrenchAnalyzer()
-    elif analyzer == 'hindi':
+    elif name.lower() == 'hindi':
         return JHindiAnalyzer()
-    elif analyzer == 'english':
-        return JDefaultEnglishAnalyzer.newDefaultInstance()
-    elif analyzer == 'freebase':
+    elif name.lower() == 'freebase':
         return JFreebaseAnalyzer()
-    elif analyzer == 'tokenize':
-        return JDefaultEnglishAnalyzer.newNonStemmingInstance()
-    elif analyzer == 'tweet':
+    elif name.lower() == 'tweet':
         return JTweetAnalyzer()
+    elif name.lower() == 'english':
+        if stemming == True:
+            return JDefaultEnglishAnalyzer.newStemmingInstance(JString(stemmer))
+        else:
+            return JDefaultEnglishAnalyzer.newNonStemmingInstance()
     else:
-        return JDefaultEnglishAnalyzer.newStemmingInstance(JString('porter'))
+        raise ValueError('Invalid configuration.')
+
+
+class Analyzer:
+    """
+    Python wrapper around a Lucene Analyzer for easy analysis.
+
+    Parameters
+    ----------
+    analyzer : org.apache.lucene.document.Analyzer
+        Lucene Analyzer.
+    """
+
+    def __init__(self, analyzer):
+        self.analyzer = analyzer
+
+    def analyze(self, text: str) -> List[str]:
+        """Analyzes a piece of text.
+
+        Parameters
+        ----------
+        text : str
+            The piece of text to analyze.
+
+        Returns
+        -------
+        List[str]
+            List of tokens corresponding to the output of the analyzer.
+        """
+        results = JAnalyzerUtils.analyze(self.analyzer, JString(text.encode('utf-8')))
+        tokens = []
+        for token in results.toArray():
+            tokens.append(token)
+        return tokens

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,13 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import shutil
 import tarfile
 import unittest
 from random import randint
 from urllib.request import urlretrieve
+
 from pyserini.analysis import pyanalysis
-from pyserini.search import pysearch
 from pyserini.index import pyutils
 from pyserini.pyclass import JString, JAnalyzerUtils
+from pyserini.search import pysearch
 
 
 class TestAnalyzers(unittest.TestCase):
@@ -28,20 +45,46 @@ class TestAnalyzers(unittest.TestCase):
         self.index_utils = pyutils.IndexReaderUtils(f'{self.index_dir}lucene-index.cacm')
 
     def test_different_analyzers_are_different(self):
-        self.searcher.set_analyzer(pyanalysis.get_analyzer('tokenize'))
+        self.searcher.set_analyzer(pyanalysis.get_lucene_analyzer(stemming=False))
         hits_first = self.searcher.search('information retrieval')
-        self.searcher.set_analyzer(pyanalysis.get_analyzer(''))
+        self.searcher.set_analyzer(pyanalysis.get_lucene_analyzer())
         hits_second = self.searcher.search('information retrieval')
         self.assertNotEqual(hits_first, hits_second)
 
     def test_analyze_with_analyzer(self):
-        tokenizer = pyanalysis.get_analyzer('tokenize')
+        tokenizer = pyanalysis.get_lucene_analyzer(stemming=False)
         query = JString('information retrieval')
         only_tokenization = JAnalyzerUtils.analyze(tokenizer, query)
         token_list = []
         for token in only_tokenization.toArray():
             token_list.append(token)
         self.assertEqual(token_list, ['information', 'retrieval'])
+
+    def test_analysis(self):
+        # Default is Porter stemmer
+        analyzer = pyanalysis.Analyzer(pyanalysis.get_lucene_analyzer())
+        tokens = analyzer.analyze('City buses are running on time.')
+        self.assertEqual(tokens, ['citi', 'buse', 'run', 'time'])
+
+        # Specify Porter stemmer explicitly
+        analyzer = pyanalysis.Analyzer(pyanalysis.get_lucene_analyzer(stemmer='porter'))
+        tokens = analyzer.analyze('City buses are running on time.')
+        self.assertEqual(tokens, ['citi', 'buse', 'run', 'time'])
+
+        # Specify Krovetz stemmer explicitly
+        analyzer = pyanalysis.Analyzer(pyanalysis.get_lucene_analyzer(stemmer='krovetz'))
+        tokens = analyzer.analyze('City buses are running on time.')
+        self.assertEqual(tokens, ['city', 'bus', 'running', 'time'])
+
+        # No stemming
+        analyzer = pyanalysis.Analyzer(pyanalysis.get_lucene_analyzer(stemming=False))
+        tokens = analyzer.analyze('City buses are running on time.')
+        self.assertEqual(tokens, ['city', 'buses', 'running', 'time'])
+
+    def test_invalid_analysis(self):
+        # Invalid configuration, make sure we get an exception.
+        with self.assertRaises(ValueError):
+            pyanalysis.Analyzer(pyanalysis.get_lucene_analyzer('blah'))
 
     def tearDown(self):
         self.searcher.close()

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -63,7 +63,7 @@ class TestIndexUtils(unittest.TestCase):
         self.assertEqual(' '.join(self.index_utils.analyze('retrieval')), 'retriev')
         self.assertEqual(' '.join(self.index_utils.analyze('rapid retrieval, space economy')),
                          'rapid retriev space economi')
-        tokenizer = pyanalysis.get_analyzer('tokenize')
+        tokenizer = pyanalysis.get_lucene_analyzer(stemming=False)
         self.assertEqual(' '.join(self.index_utils.analyze('retrieval', analyzer=tokenizer)), 'retrieval')
         self.assertEqual(' '.join(self.index_utils.analyze('rapid retrieval, space economy', analyzer=tokenizer)),
                          'rapid retrieval space economy')


### PR DESCRIPTION
`get_analyzer` returns the actual Lucene Analyzer, this PR adds an `Analyzer` Python class for performing actual analysis.

`get_analyzer` renamed `get_lucene_analyzer`, changed invocation.