### PR TITLE
Optional analyser in get_term_counts and skip stopword option in analyzer.

### DIFF
--- a/pyserini/analysis/pyanalysis.py
+++ b/pyserini/analysis/pyanalysis.py
@@ -28,9 +28,10 @@ from ..pyclass import JHindiAnalyzer
 from ..pyclass import JSpanishAnalyzer
 from ..pyclass import JString
 from ..pyclass import JTweetAnalyzer
+from ..pyclass import JCharArraySet
 
 
-def get_lucene_analyzer(name='english', stemming=True, stemmer='porter'):
+def get_lucene_analyzer(name='english', stemming=True, stemmer='porter', stopwords=True):
     """
     Parameters
     ----------
@@ -40,6 +41,8 @@ def get_lucene_analyzer(name='english', stemming=True, stemmer='porter'):
         Whether or not to stem.
     stemmer : Str
         Stemmer to use.
+    stopwords : Bool
+        Whether or not to filter stopwords.
 
     Returns
     -------
@@ -66,9 +69,15 @@ def get_lucene_analyzer(name='english', stemming=True, stemmer='porter'):
         return JTweetAnalyzer()
     elif name.lower() == 'english':
         if stemming == True:
-            return JDefaultEnglishAnalyzer.newStemmingInstance(JString(stemmer))
+            if stopwords == True:
+                return JDefaultEnglishAnalyzer.newStemmingInstance(JString(stemmer))
+            else:
+                return JDefaultEnglishAnalyzer.newStemmingInstance(JString(stemmer), JCharArraySet.EMPTY_SET)
         else:
-            return JDefaultEnglishAnalyzer.newNonStemmingInstance()
+            if stopwords == True:
+                return JDefaultEnglishAnalyzer.newNonStemmingInstance()
+            else:
+                return JDefaultEnglishAnalyzer.newNonStemmingInstance(JCharArraySet.EMPTY_SET)
     else:
         raise ValueError('Invalid configuration.')
 

--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -123,20 +123,27 @@ class IndexReaderUtils:
             cur_term = term_iterator.next()
             yield IndexTerm(cur_term.getTerm(), cur_term.getDF(), cur_term.getTotalTF())
 
-    def get_term_counts(self, term: str) -> Tuple[int, int]:
-        """Returns the document frequency and collection frequency of a term.
+    def get_term_counts(self, term: str, analyzer=None) -> Tuple[int, int]:      
+        """Returns the document frequency and collection frequency of a term 
+        (applies Anserini's default Lucene analyzer if analyzer is not specified).
 
         Parameters
         ----------
         term : str
             The raw (unanalyzed) term.
+        analyzer : analyzer
+            The analyzer to apply.
 
         Returns
         -------
         Tuple[int, int]
             The document frequency and collection frequency of the term.
         """
-        term_map = self.object.getTermCounts(self.reader, JString(term.encode('utf-8')))
+        if analyzer is None:
+            term_map = self.object.getTermCounts(self.reader, JString(term.encode('utf-8')))
+        else:
+            term_map = self.object.getTermCountsWithAnalyzer(self.reader, JString(term.encode('utf-8')), analyzer)
+        
         return term_map.get(JString('docFreq')), term_map.get(JString('collectionFreq'))
 
     def get_postings_list(self, term: str, analyze=True) -> List[Posting]:

--- a/pyserini/pyclass.py
+++ b/pyserini/pyclass.py
@@ -46,6 +46,8 @@ JSpanishAnalyzer = autoclass('org.apache.lucene.analysis.es.SpanishAnalyzer')
 JFrenchAnalyzer = autoclass('org.apache.lucene.analysis.fr.FrenchAnalyzer')
 JHindiAnalyzer = autoclass('org.apache.lucene.analysis.hi.HindiAnalyzer')
 
+JCharArraySet = autoclass('org.apache.lucene.analysis.CharArraySet')
+
 JDefaultEnglishAnalyzer = autoclass('io.anserini.analysis.DefaultEnglishAnalyzer')
 JFreebaseAnalyzer = autoclass('io.anserini.analysis.FreebaseAnalyzer')
 JTweetAnalyzer = autoclass('io.anserini.analysis.TweetAnalyzer')

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -81,6 +81,16 @@ class TestAnalyzers(unittest.TestCase):
         tokens = analyzer.analyze('City buses are running on time.')
         self.assertEqual(tokens, ['city', 'buses', 'running', 'time'])
 
+        # No stopword filter, no stemming
+        analyzer = pyanalysis.Analyzer(pyanalysis.get_lucene_analyzer(stemming=False, stopwords=False))
+        tokens = analyzer.analyze('City buses are running on time.')
+        self.assertEqual(tokens, ['city', 'buses', 'are', 'running', 'on', 'time'])
+
+        # No stopword filter, with stemming
+        analyzer = pyanalysis.Analyzer(pyanalysis.get_lucene_analyzer(stemming=True, stopwords=False))
+        tokens = analyzer.analyze('City buses are running on time.')
+        self.assertEqual(tokens, ['citi', 'buse', 'ar', 'run', 'on', 'time'])
+
     def test_invalid_analysis(self):
         # Invalid configuration, make sure we get an exception.
         with self.assertRaises(ValueError):

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -76,6 +76,17 @@ class TestIndexUtils(unittest.TestCase):
         self.assertEqual(df, 138)
         self.assertEqual(cf, 275)
 
+        analyzer = pyanalysis.get_lucene_analyzer(stemming=False, stopwords=False)
+        df_no_stem, cf_no_stem = self.index_utils.get_term_counts('retrieval', analyzer)
+        # 'retrieval' does not occur as a stemmed word, only 'retriev' does.
+        self.assertEqual(df_no_stem, 0)
+        self.assertEqual(cf_no_stem, 0)
+
+        df_no_stopword, cf_no_stopword = self.index_utils.get_term_counts('on', analyzer)
+        self.assertEqual(df_no_stopword, 326)
+        self.assertEqual(cf_no_stopword, 443)
+        
+
     def test_postings1(self):
         term = 'retrieval'
         postings = list(self.index_utils.get_postings_list(term))


### PR DESCRIPTION
- Implemented https://github.com/castorini/anserini/pull/1031 in Pyserini. 
- In order to get the term counts for stopwords, I added an option to the analyzer that allows to specify whether stopwords are filtered.
