### PR TITLE
fixed searcher.doc not using correct Anserini method

### DIFF
--- a/pyserini/search/pysearch.py
+++ b/pyserini/search/pysearch.py
@@ -211,7 +211,7 @@ class SimpleSearcher:
         Document
             :class:`Document` corresponding to the ``docid``.
         """
-        return Document(self.object.doc(docid))
+        return Document(self.object.document(docid))
 
     def close(self):
         self.object.close()


### PR DESCRIPTION
`SimpleSearcher.doc` should use Anserini's `SimpleSearcher.document()`.