### PR TITLE
Better alignment of API in SimpleSearcher and IndexReaderUtils for access docs

### DIFF
--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -208,6 +208,24 @@ class IndexReaderUtils:
         """
         return Document(self.object.document(self.reader, JString(docid)))
 
+    def doc_by_field(self, field: str, q: str) -> str:
+        """Returns the :class:`Document` based on a ``field`` with ``id``. For example, this method can be used to fetch
+        document based on alternative primary keys that have been indexed, such as an article's DOI.
+
+        Parameters
+        ----------
+        field : str
+            The field to look up.
+        q : str
+            The document's unique id.
+
+        Returns
+        -------
+        Document
+            :class:`Document` whose ``field`` is ``id``.
+        """
+        return Document(self.object.documentByField(self.reader, JString(field), JString(q)))
+
     def doc_raw(self, docid: str) -> str:
         """Returns the raw document contents for a collection ``docid``.
 

--- a/pyserini/search/pysearch.py
+++ b/pyserini/search/pysearch.py
@@ -42,6 +42,10 @@ class Document:
     def docid(self: JDocument) -> str:
         return self.object.getField('id').stringValue()
 
+    def id(self: JDocument) -> str:
+        # Convenient alias for docid()
+        return self.object.getField('id').stringValue()
+
     def lucene_document(self: JDocument) -> JDocument:
         return self.object
 
@@ -50,6 +54,9 @@ class Document:
 
     def raw(self: JDocument) -> str:
         return self.object.get('raw')
+
+    def get(self: JDocument, field: str) -> str:
+        return self.object.get(field)
 
 
 class SimpleSearcher:
@@ -218,6 +225,24 @@ class SimpleSearcher:
             :class:`Document` corresponding to the ``docid``.
         """
         return Document(self.object.document(docid))
+
+    def doc_by_field(self, field: str, q: str) -> str:
+        """Returns the :class:`Document` based on a ``field`` with ``id``. For example, this method can be used to fetch
+        document based on alternative primary keys that have been indexed, such as an article's DOI.
+
+        Parameters
+        ----------
+        field : str
+            The field to look up.
+        q : str
+            The document's unique id.
+
+        Returns
+        -------
+        Document
+            :class:`Document` whose ``field`` is ``id``.
+        """
+        return Document(self.object.documentByField(JString(field), JString(q)))
 
     def close(self):
         self.object.close()

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -85,7 +85,6 @@ class TestIndexUtils(unittest.TestCase):
         df_no_stopword, cf_no_stopword = self.index_utils.get_term_counts('on', analyzer)
         self.assertEqual(df_no_stopword, 326)
         self.assertEqual(cf_no_stopword, 443)
-        
 
     def test_postings1(self):
         term = 'retrieval'
@@ -143,7 +142,7 @@ class TestIndexUtils(unittest.TestCase):
                 # The tf values should match.
                 self.assertEqual(postings_list[i].tf, 8)
 
-    def test_document_raw1(self):
+    def test_doc_raw(self):
         raw = self.index_utils.doc('CACM-3134').raw()
         self.assertTrue(isinstance(raw, str))
         lines = raw.splitlines()
@@ -153,15 +152,29 @@ class TestIndexUtils(unittest.TestCase):
         self.assertEqual(lines[4], 'The Use of Normal Multiplication Tables')
         self.assertEqual(lines[29], 'rapid retrieval, space economy')
 
-    def test_document_raw2(self):
-        raw = self.index_utils.doc_raw('CACM-3134')
-        self.assertTrue(isinstance(raw, str))
-        lines = raw.splitlines()
-        self.assertEqual(len(lines), 55)
-        # Note that the raw document contents will still have HTML tags.
-        self.assertEqual(lines[0], '<html>')
-        self.assertEqual(lines[4], 'The Use of Normal Multiplication Tables')
-        self.assertEqual(lines[29], 'rapid retrieval, space economy')
+        # Now that we've verified the 'raw', check that alternative ways of fetching give the same results.
+        self.assertEqual(raw, self.index_utils.doc_raw('CACM-3134'))
+        self.assertEqual(raw, self.index_utils.doc('CACM-3134').raw())
+        self.assertEqual(raw, self.index_utils.doc('CACM-3134').get('raw'))
+        self.assertEqual(raw, self.index_utils.doc('CACM-3134').lucene_document().get('raw'))
+
+    def test_doc_contents(self):
+        contents = self.index_utils.doc('CACM-3134').contents()
+        self.assertTrue(isinstance(contents, str))
+        lines = contents.splitlines()
+        self.assertEqual(len(lines), 48)
+        self.assertEqual(lines[0], 'The Use of Normal Multiplication Tables')
+        self.assertEqual(lines[47], '3134\t5\t3134')
+
+        # Now that we've verified the 'raw', check that alternative ways of fetching give the same results.
+        self.assertEqual(contents, self.index_utils.doc_contents('CACM-3134'))
+        self.assertEqual(contents, self.index_utils.doc('CACM-3134').contents())
+        self.assertEqual(contents, self.index_utils.doc('CACM-3134').get('contents'))
+        self.assertEqual(contents, self.index_utils.doc('CACM-3134').lucene_document().get('contents'))
+
+    def test_doc_by_field(self):
+        self.assertEqual(self.index_utils.doc('CACM-3134').docid(),
+                         self.index_utils.doc_by_field('id', 'CACM-3134').docid())
 
     def test_bm25_weight(self):
         self.assertAlmostEqual(self.index_utils.compute_bm25_term_weight('CACM-3134', 'inform'), 1.925014, places=5)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -50,7 +50,7 @@ class TestSearch(unittest.TestCase):
         self.assertTrue(isinstance(hits[0], JResult))
         self.assertEqual(hits[0].docid, 'CACM-3134')
         self.assertEqual(hits[0].lucene_docid, 3133)
-        self.assertEqual(hits[0].contents, None)
+        self.assertEqual(len(hits[0].contents), 1500)
         self.assertEqual(len(hits[0].raw), 1532)
         self.assertAlmostEqual(hits[0].score, 4.76550, places=5)
 
@@ -118,22 +118,52 @@ class TestSearch(unittest.TestCase):
     def test_doc_int(self):
         # The doc method is overloaded: if input is int, it's assumed to be a Lucene internal docid.
         doc = self.searcher.doc(1)
-
         self.assertTrue(isinstance(doc, pysearch.Document))
-        self.assertEqual(doc.docid(), 'CACM-0002')
 
-        self.assertEqual(doc.lucene_document().getField('id').stringValue(), 'CACM-0002')
-        self.assertEqual(len(doc.lucene_document().getField('raw').stringValue()), 186)
+        # These are all equivalent ways to get the docid.
+        self.assertEqual('CACM-0002', doc.id())
+        self.assertEqual('CACM-0002', doc.docid())
+        self.assertEqual('CACM-0002', doc.get('id'))
+        self.assertEqual('CACM-0002', doc.lucene_document().getField('id').stringValue())
+
+        # These are all equivalent ways to get the 'raw' field
+        self.assertEqual(186, len(doc.raw()))
+        self.assertEqual(186, len(doc.get('raw')))
+        self.assertEqual(186, len(doc.lucene_document().get('raw')))
+        self.assertEqual(186, len(doc.lucene_document().getField('raw').stringValue()))
+
+        # These are all equivalent ways to get the 'contents' field
+        self.assertEqual(154, len(doc.contents()))
+        self.assertEqual(154, len(doc.get('contents')))
+        self.assertEqual(154, len(doc.lucene_document().get('contents')))
+        self.assertEqual(154, len(doc.lucene_document().getField('contents').stringValue()))
 
     def test_doc_str(self):
         # The doc method is overloaded: if input is str, it's assumed to be an external collection docid.
         doc = self.searcher.doc('CACM-0002')
-
         self.assertTrue(isinstance(doc, pysearch.Document))
-        self.assertEqual(doc.docid(), 'CACM-0002')
 
+        # These are all equivalent ways to get the docid.
         self.assertEqual(doc.lucene_document().getField('id').stringValue(), 'CACM-0002')
-        self.assertEqual(len(doc.lucene_document().getField('raw').stringValue()), 186)
+        self.assertEqual(doc.id(), 'CACM-0002')
+        self.assertEqual(doc.docid(), 'CACM-0002')
+        self.assertEqual(doc.get('id'), 'CACM-0002')
+
+        # These are all equivalent ways to get the 'raw' field
+        self.assertEqual(186, len(doc.raw()))
+        self.assertEqual(186, len(doc.get('raw')))
+        self.assertEqual(186, len(doc.lucene_document().get('raw')))
+        self.assertEqual(186, len(doc.lucene_document().getField('raw').stringValue()))
+
+        # These are all equivalent ways to get the 'contents' field
+        self.assertEqual(154, len(doc.contents()))
+        self.assertEqual(154, len(doc.get('contents')))
+        self.assertEqual(154, len(doc.lucene_document().get('contents')))
+        self.assertEqual(154, len(doc.lucene_document().getField('contents').stringValue()))
+
+    def test_doc_by_field(self):
+        self.assertEqual(self.searcher.doc('CACM-3134').docid(),
+                         self.searcher.doc_by_field('id', 'CACM-3134').docid())
 
     def tearDown(self):
         self.searcher.close()


### PR DESCRIPTION
Better testing. Uploaded new version of CACM index with `contents` stored, and thus, testable.