### PR TITLE
Exposes TREC COVID topics in Python

### DIFF
--- a/pyserini/search/pysearch.py
+++ b/pyserini/search/pysearch.py
@@ -259,11 +259,18 @@ def get_topics(collection_name):
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_DOC_DEV)
     elif collection_name == 'msmarco_passage_dev_subset':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_DEV_SUBSET)
+    elif collection_name == 'covid_round1':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.COVID_ROUND1)
     else:
         return {}
     t = {}
     for topic in topics.keySet().toArray():
-        t[topic] = {}
+        # Try and parse the keys into integers
+        try:
+            topic_key = int(topic)
+        except ValueError:
+            topic_key = topic
+        t[topic_key] = {}
         for key in topics.get(topic).keySet().toArray():
-            t[topic][key] = topics.get(topic).get(key)
+            t[topic_key][key] = topics.get(topic).get(key)
     return t

--- a/tests/test_loadtopics.py
+++ b/tests/test_loadtopics.py
@@ -24,30 +24,42 @@ class TestLoadTopics(unittest.TestCase):
     def test_robust04(self):
         topics = pysearch.get_topics('robust04')
         self.assertEqual(len(topics), 250)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_core17(self):
         topics = pysearch.get_topics('core17')
         self.assertEqual(len(topics), 50)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_core18(self):
         topics = pysearch.get_topics('core18')
         self.assertEqual(len(topics), 50)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_car15(self):
         topics = pysearch.get_topics('car17v1.5_benchmarkY1test')
         self.assertEqual(len(topics), 2125)
+        self.assertFalse(isinstance(next(iter(topics.keys())), int))
 
     def test_car20(self):
         topics = pysearch.get_topics('car17v2.0_benchmarkY1test')
         self.assertEqual(len(topics), 2254)
+        self.assertFalse(isinstance(next(iter(topics.keys())), int))
 
     def test_msmarco_doc(self):
         topics = pysearch.get_topics('msmarco_doc_dev')
         self.assertEqual(len(topics), 5193)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_msmarco_passage(self):
         topics = pysearch.get_topics('msmarco_passage_dev_subset')
         self.assertEqual(len(topics), 6980)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+    def test_covid_round1(self):
+        topics = pysearch.get_topics('covid_round1')
+        self.assertEqual(len(topics), 30)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Something like this works now!

```python
from pyserini.search import pysearch

topics = pysearch.get_topics('covid_round1')
print(f'{len(topics)} queries total')

for topic_id in sorted(topics.keys()):
    print(topics[topic_id]['query'])
```