### PR TITLE
Flexible class loader

### DIFF
--- a/pyserini/pyclass.py
+++ b/pyserini/pyclass.py
@@ -113,3 +113,7 @@ class JCollections(Enum):
     WashingtonPostCollection = autoclass('io.anserini.collection.WashingtonPostCollection')
     WikipediaCollection = autoclass('io.anserini.collection.WikipediaCollection')
 
+
+def add_class(class_name):
+    return autoclass(class_name)
+

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -76,6 +76,10 @@ class TestIndexUtils(unittest.TestCase):
         self.assertEqual(df, 138)
         self.assertEqual(cf, 275)
 
+        df, cf = self.index_utils.get_term_counts('information retrieval')
+        self.assertEqual(df, 74)
+        self.assertEqual(cf, None)
+
         analyzer = pyanalysis.get_lucene_analyzer(stemming=False, stopwords=False)
         df_no_stem, cf_no_stem = self.index_utils.get_term_counts('retrieval', analyzer)
         # 'retrieval' does not occur as a stemmed word, only 'retriev' does.


### PR DESCRIPTION
Now its not possible to load classes through pyclass and also load in custom classes through Pyjnius, as it is not possible to configure the classpath twice. Using this helper function it also possible to load new Java classes through pyclass. 