### PR TITLE
Fixed broken unit tests related to num_docs

### DIFF
--- a/pyserini/search/pysearch.py
+++ b/pyserini/search/pysearch.py
@@ -71,9 +71,7 @@ class SimpleSearcher:
 
     def __init__(self, index_dir: str):
         self.object = JSimpleSearcher(JString(index_dir))
-
-    def num_docs(self):
-        return self.object.getTotalNumDocuments()
+        self.num_docs = self.object.getTotalNumDocuments()
 
     def search(self, q: Union[str, JQuery], k: int=10, t: int=-1,
                query_generator: JQueryGenerator=None) -> List[JSimpleSearcherResult]:

--- a/pyserini/search/pysearch.py
+++ b/pyserini/search/pysearch.py
@@ -71,7 +71,9 @@ class SimpleSearcher:
 
     def __init__(self, index_dir: str):
         self.object = JSimpleSearcher(JString(index_dir))
-        self.num_docs = self.object.getTotalNumDocuments()
+
+    def num_docs(self):
+        return self.object.getTotalNumDocuments()
 
     def search(self, q: Union[str, JQuery], k: int=10, t: int=-1,
                query_generator: JQueryGenerator=None) -> List[JSimpleSearcherResult]:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -45,7 +45,7 @@ class TestSearch(unittest.TestCase):
     def test_basic(self):
         hits = self.searcher.search('information retrieval')
 
-        self.assertEqual(3204, self.searcher.num_docs())
+        self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
 
         self.assertTrue(isinstance(hits[0], JSimpleSearcherResult))
@@ -78,7 +78,7 @@ class TestSearch(unittest.TestCase):
     def test_batch(self):
         results = self.searcher.batch_search(['information retrieval', 'search'], ['q1', 'q2'], threads=2)
 
-        self.assertEqual(3204, self.searcher.num_docs())
+        self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(results, Dict))
 
         self.assertTrue(isinstance(results['q1'], List))
@@ -102,7 +102,7 @@ class TestSearch(unittest.TestCase):
     def test_basic_k(self):
         hits = self.searcher.search('information retrieval', k=100)
 
-        self.assertEqual(3204, self.searcher.num_docs())
+        self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
         self.assertTrue(isinstance(hits[0], JSimpleSearcherResult))
         self.assertEqual(len(hits), 100)
@@ -110,7 +110,7 @@ class TestSearch(unittest.TestCase):
     def test_batch_k(self):
         results = self.searcher.batch_search(['information retrieval', 'search'], ['q1', 'q2'], k=100, threads=2)
 
-        self.assertEqual(3204, self.searcher.num_docs())
+        self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(results, Dict))
         self.assertTrue(isinstance(results['q1'], List))
         self.assertTrue(isinstance(results['q1'][0], JSimpleSearcherResult))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -45,6 +45,7 @@ class TestSearch(unittest.TestCase):
     def test_basic(self):
         hits = self.searcher.search('information retrieval')
 
+        self.assertEqual(3204, self.searcher.num_docs())
         self.assertTrue(isinstance(hits, List))
 
         self.assertTrue(isinstance(hits[0], JSimpleSearcherResult))
@@ -77,6 +78,7 @@ class TestSearch(unittest.TestCase):
     def test_batch(self):
         results = self.searcher.batch_search(['information retrieval', 'search'], ['q1', 'q2'], threads=2)
 
+        self.assertEqual(3204, self.searcher.num_docs())
         self.assertTrue(isinstance(results, Dict))
 
         self.assertTrue(isinstance(results['q1'], List))
@@ -100,6 +102,7 @@ class TestSearch(unittest.TestCase):
     def test_basic_k(self):
         hits = self.searcher.search('information retrieval', k=100)
 
+        self.assertEqual(3204, self.searcher.num_docs())
         self.assertTrue(isinstance(hits, List))
         self.assertTrue(isinstance(hits[0], JSimpleSearcherResult))
         self.assertEqual(len(hits), 100)
@@ -107,6 +110,7 @@ class TestSearch(unittest.TestCase):
     def test_batch_k(self):
         results = self.searcher.batch_search(['information retrieval', 'search'], ['q1', 'q2'], k=100, threads=2)
 
+        self.assertEqual(3204, self.searcher.num_docs())
         self.assertTrue(isinstance(results, Dict))
         self.assertTrue(isinstance(results['q1'], List))
         self.assertTrue(isinstance(results['q1'][0], JSimpleSearcherResult))


### PR DESCRIPTION
@Chriskamphuis @PepijnBoers I'd appreciate a sanity check on this... just _odd_.

On current HEAD, unit tests are broken: try with `python -m unittest`.

However, somewhat inexplicably, this patch fixes the bug...  and unit tests pass.

I don't really understand why... I suspect there's an underlying concurrency bug with how the `IndexReader` and `IndexSearcher` is being initialized on the Java end... any thoughts?

