### PR TITLE
Vectorizer handles term_freq is None

### DIFF
--- a/pyserini/vectorizer.py
+++ b/pyserini/vectorizer.py
@@ -45,6 +45,8 @@ class TfidfVectorizer:
 
             # Term Frequency
             tf = self.index_utils.get_document_vector(doc_id)
+            if tf is None:
+                continue
 
             # Filter out in-eligible terms
             tf = {t: tf[t] for t in tf if t in self.term_to_index}


### PR DESCRIPTION
- After [PR 112](https://github.com/castorini/pyserini/pull/112), adopt `pyserini/vectorizer.py` to handle the scenario when term frequency `get_document_vector` return `None`.