### PR TITLE
Expose Anserini's IndexUtils (print stats only)

### DIFF
--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -23,7 +23,7 @@ and methods provided are meant only to provide tools for examining an index and 
 import logging
 from typing import Dict, Iterator, List, Tuple
 
-from ..pyclass import JIndexReaderUtils, JString, JAnalyzerUtils
+from ..pyclass import JIndexReaderUtils, JString, JAnalyzerUtils, JIndexUtils
 from ..search.pysearch import Document
 from ..analysis.pyanalysis import get_lucene_analyzer
 
@@ -336,3 +336,21 @@ class IndexReaderUtils:
             The Lucene internal ``docid`` corresponding to the external collection ``docid``.
         """
         return self.object.convertDocidToLuceneDocid(self.reader, docid)
+
+
+class IndexUtils:
+    """
+    Wrapper class for ``IndexUtils`` in Anserini.
+
+    Parameters
+    ----------
+    index_dir : str
+        Path to Lucene index directory.
+    """
+
+    def __init__(self, index_dir):
+        self.object = JIndexUtils(JString(index_dir))
+
+    def print_index_stats(self):
+        """Print index statistics"""        
+        self.object.printIndexStats()

--- a/pyserini/pyclass.py
+++ b/pyserini/pyclass.py
@@ -69,6 +69,9 @@ JTopics = autoclass('io.anserini.search.topicreader.Topics')
 JIndexReaderUtils = autoclass('io.anserini.index.IndexReaderUtils')
 JDocumentVectorWeight = autoclass('io.anserini.index.IndexReaderUtils$DocumentVectorWeight')
 
+## IndexUtils
+JIndexUtils = autoclass('io.anserini.index.IndexUtils')
+
 JAnalyzerUtils = autoclass('io.anserini.analysis.AnalyzerUtils')
 
 ### Generator


### PR DESCRIPTION
Makes Anserini's printing index stats available.

Might cause some confusion when naming the IndexReaderUtils as `index_utils` (e.g. in the README).

This would probably be clearer:
```python
from pyserini.index import pyutils

index_reader_utils = pyutils.IndexReaderUtils('indexes/index-robust04-20191213/')

index_utils = pyutils.IndexUtils('indexes/index-robust04-20191213/')
index_utils.print_index_stats()
```
