### PR TITLE
Introduce new BM25Vectorizer

### DIFF
--- a/pyserini/vectorizer.py
+++ b/pyserini/vectorizer.py
@@ -157,19 +157,20 @@ class BM25Vectorizer(Vectorizer):
             if index % 1000 == 0 and num_docs > 1000 and self.verbose:
                 print(f'Vectorizing: {index}/{len(docids)}')
 
+            # Term Frequency
             tf = self.index_utils.get_document_vector(doc_id)
+            if tf is None:
+                continue
 
             # Filter out in-eligible terms
             tf = {t: tf[t] for t in tf if t in self.term_to_index}
 
-            # Retrieve bm25 term weight
-            tf = {term: self.index_utils.compute_bm25_term_weight(doc_id, term, analyzer=None) for term in tf.keys()}
-
             # Convert from dict to sparse matrix
             for term in tf:
+                bm25_weight = self.index_utils.compute_bm25_term_weight(doc_id, term, analyzer=None)
                 matrix_row.append(index)
                 matrix_col.append(self.term_to_index[term])
-                matrix_data.append(tf[term])
+                matrix_data.append(bm25_weight)
 
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
         return self._l2normalize(vectors)

--- a/pyserini/vectorizer.py
+++ b/pyserini/vectorizer.py
@@ -23,6 +23,18 @@ from pyserini.index import pyutils
 
 
 class VectorizerBase:
+    """Base class for vectorizer implemented on top of Pyserini.
+
+    Parameters
+    ----------
+    lucene_index_path : str
+        Path to lucene index folder
+    min_df : int
+        Minimum acceptable document frequency
+    verbose : bool
+        Whether to print out debugging information
+    """
+
     def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False) -> None:
         self.min_df: int = min_df
         self.verbose: bool = verbose

--- a/pyserini/vectorizer.py
+++ b/pyserini/vectorizer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +20,7 @@ from pyserini.search import pysearch
 from pyserini.index import pyutils
 
 
-class VectorizerBase:
+class Vectorizer:
     """Base class for vectorizer implemented on top of Pyserini.
 
     Parameters
@@ -35,7 +33,7 @@ class VectorizerBase:
         Whether to print out debugging information
     """
 
-    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False) -> None:
+    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
         self.min_df: int = min_df
         self.verbose: bool = verbose
         self.index_utils = pyutils.IndexReaderUtils(lucene_index_path)
@@ -44,9 +42,7 @@ class VectorizerBase:
 
         # build vocabulary
         self.vocabulary_ = set()
-        self.idf_ = {}
         for term in self.index_utils.terms():
-            self.idf_[term.term] = math.log(self.num_docs / term.df)
             if term.df > self.min_df:
                 self.vocabulary_.add(term.term)
 
@@ -57,7 +53,7 @@ class VectorizerBase:
         self.vocabulary_size = len(self.vocabulary_)
 
         if self.verbose:
-            print(f'Found {self.vocabulary_size} terms')
+            print(f'Found {self.vocabulary_size} terms with min_df={self.min_df}')
 
     def _l2normalize(self, a):
         norm_rows = np.sqrt(np.add.reduceat(a.data * a.data, a.indptr[:-1]))
@@ -66,7 +62,7 @@ class VectorizerBase:
         return a
 
 
-class TfidfVectorizer(VectorizerBase):
+class TfidfVectorizer(Vectorizer):
     """Wrapper class for tf-idf vectorizer implemented on top of Pyserini.
 
     Parameters
@@ -79,15 +75,19 @@ class TfidfVectorizer(VectorizerBase):
         Whether to print out debugging information
     """
 
-    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False) -> None:
-        super().__init__(lucene_index_path, verbose, min_df)
+    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
+        super().__init__(lucene_index_path, min_df, verbose)
 
-    def get_vectors(self, doc_ids: List[str]):
-        """Get the tf-idf vectors given a list of doc_ids
+        self.idf_ = {}
+        for term in self.index_utils.terms():
+            self.idf_[term.term] = math.log(self.num_docs / term.df)
+
+    def get_vectors(self, docids: List[str]):
+        """Get the tf-idf vectors given a list of docids
 
         Parameters
         ----------
-        doc_ids : List[str]
+        docids : List[str]
             The piece of text to analyze.
 
         Returns
@@ -96,11 +96,11 @@ class TfidfVectorizer(VectorizerBase):
             L2 normalized sparse matrix representation of tf-idf vectors
         """
         matrix_row, matrix_col, matrix_data = [], [], []
-        num_docs = len(doc_ids)
+        num_docs = len(docids)
 
-        for index, doc_id in enumerate(doc_ids):
+        for index, doc_id in enumerate(docids):
             if index % 1000 == 0 and num_docs > 1000 and self.verbose:
-                print(f'Vectorizing: {index}/{len(doc_ids)}')
+                print(f'Vectorizing: {index}/{len(docids)}')
 
             # Term Frequency
             tf = self.index_utils.get_document_vector(doc_id)
@@ -121,8 +121,8 @@ class TfidfVectorizer(VectorizerBase):
         return self._l2normalize(vectors)
 
 
-class BM25Vectorizer(VectorizerBase):
-    """Wrapper class for bm25 vectorizer implemented on top of Pyserini.
+class BM25Vectorizer(Vectorizer):
+    """Wrapper class for BM25 vectorizer implemented on top of Pyserini.
 
     Parameters
     ----------
@@ -134,30 +134,35 @@ class BM25Vectorizer(VectorizerBase):
         Whether to print out debugging information
     """
 
-    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False) -> None:
-        super().__init__(lucene_index_path, verbose, min_df)
+    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
+        super().__init__(lucene_index_path, min_df, verbose)
 
-    def get_vectors(self, doc_ids: List[str]):
-        """Get the bm25 vectors given a list of doc_ids
+    def get_vectors(self, docids: List[str]):
+        """Get the BM25 vectors given a list of docids
 
         Parameters
         ----------
-        doc_ids : List[str]
+        docids : List[str]
             The piece of text to analyze.
 
         Returns
         -------
         csr_matrix
-            L2 normalized sparse matrix representation of bm25 vectors
+            L2 normalized sparse matrix representation of BM25 vectors
         """
         matrix_row, matrix_col, matrix_data = [], [], []
-        num_docs = len(doc_ids)
+        num_docs = len(docids)
 
-        for index, doc_id in enumerate(doc_ids):
+        for index, doc_id in enumerate(docids):
             if index % 1000 == 0 and num_docs > 1000 and self.verbose:
-                print(f'Vectorizing: {index}/{len(doc_ids)}')
+                print(f'Vectorizing: {index}/{len(docids)}')
 
             tf = self.index_utils.get_document_vector(doc_id)
+
+            # Filter out in-eligible terms
+            tf = {t: tf[t] for t in tf if t in self.term_to_index}
+
+            # Retrieve bm25 term weight
             tf = {term: self.index_utils.compute_bm25_term_weight(doc_id, term, analyzer=None) for term in tf.keys()}
 
             # Convert from dict to sparse matrix

--- a/pyserini/vectorizer.py
+++ b/pyserini/vectorizer.py
@@ -22,7 +22,39 @@ from pyserini.search import pysearch
 from pyserini.index import pyutils
 
 
-class TfidfVectorizer:
+class VectorizerBase:
+    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False) -> None:
+        self.min_df: int = min_df
+        self.verbose: bool = verbose
+        self.index_utils = pyutils.IndexReaderUtils(lucene_index_path)
+        self.searcher = pysearch.SimpleSearcher(lucene_index_path)
+        self.num_docs: int = self.searcher.num_docs
+
+        # build vocabulary
+        self.vocabulary_ = set()
+        self.idf_ = {}
+        for term in self.index_utils.terms():
+            self.idf_[term.term] = math.log(self.num_docs / term.df)
+            if term.df > self.min_df:
+                self.vocabulary_.add(term.term)
+
+        # build term to index mapping
+        self.term_to_index = {}
+        for index, term in enumerate(self.vocabulary_):
+            self.term_to_index[term] = index
+        self.vocabulary_size = len(self.vocabulary_)
+
+        if self.verbose:
+            print(f'Found {self.vocabulary_size} terms')
+
+    def _l2normalize(self, a):
+        norm_rows = np.sqrt(np.add.reduceat(a.data * a.data, a.indptr[:-1]))
+        nnz_per_row = np.diff(a.indptr)
+        a.data /= np.repeat(norm_rows, nnz_per_row)
+        return a
+
+
+class TfidfVectorizer(VectorizerBase):
     """Wrapper class for tf-idf vectorizer implemented on top of Pyserini.
 
     Parameters
@@ -36,36 +68,7 @@ class TfidfVectorizer:
     """
 
     def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False) -> None:
-        self.verbose: bool = verbose
-        self.min_df: int = min_df
-        self.index_utils = pyutils.IndexReaderUtils(lucene_index_path)
-
-        # get num_docs
-        self.searcher = pysearch.SimpleSearcher(lucene_index_path)
-        self.num_docs: int = self.searcher.num_docs
-
-        # pre-processing
-        self.vocabulary_ = set()
-        self.idf_ = {}
-
-        for term in self.index_utils.terms():
-            self.idf_[term.term] = math.log(self.num_docs / term.df)
-            if term.df > self.min_df:
-                self.vocabulary_.add(term.term)
-
-        self.term_to_index = {}
-        for index, term in enumerate(self.vocabulary_):
-            self.term_to_index[term] = index
-        self.vocabulary_size = len(self.vocabulary_)
-
-        if self.verbose:
-            print(f'Found {self.vocabulary_size} terms')
-
-    def l2norm(self, a):
-        norm_rows = np.sqrt(np.add.reduceat(a.data * a.data, a.indptr[:-1]))
-        nnz_per_row = np.diff(a.indptr)
-        a.data /= np.repeat(norm_rows, nnz_per_row)
-        return a
+        super().__init__(lucene_index_path, verbose, min_df)
 
     def get_vectors(self, doc_ids: List[str]):
         """Get the tf-idf vectors given a list of doc_ids
@@ -103,4 +106,53 @@ class TfidfVectorizer:
                 matrix_data.append(tfidf)
 
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
-        return self.l2norm(vectors)
+        return self._l2normalize(vectors)
+
+
+class BM25Vectorizer(VectorizerBase):
+    """Wrapper class for bm25 vectorizer implemented on top of Pyserini.
+
+    Parameters
+    ----------
+    lucene_index_path : str
+        Path to lucene index folder
+    min_df : int
+        Minimum acceptable document frequency
+    verbose : bool
+        Whether to print out debugging information
+    """
+
+    def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False) -> None:
+        super().__init__(lucene_index_path, verbose, min_df)
+
+    def get_vectors(self, doc_ids: List[str]):
+        """Get the bm25 vectors given a list of doc_ids
+
+        Parameters
+        ----------
+        doc_ids : List[str]
+            The piece of text to analyze.
+
+        Returns
+        -------
+        csr_matrix
+            L2 normalized sparse matrix representation of bm25 vectors
+        """
+        matrix_row, matrix_col, matrix_data = [], [], []
+        num_docs = len(doc_ids)
+
+        for index, doc_id in enumerate(doc_ids):
+            if index % 1000 == 0 and num_docs > 1000 and self.verbose:
+                print(f'Vectorizing: {index}/{len(doc_ids)}')
+
+            tf = self.index_utils.get_document_vector(doc_id)
+            tf = {term: self.index_utils.compute_bm25_term_weight(doc_id, term, analyzer=None) for term in tf.keys()}
+
+            # Convert from dict to sparse matrix
+            for term in tf:
+                matrix_row.append(index)
+                matrix_col.append(self.term_to_index[term])
+                matrix_data.append(tf[term])
+
+        vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
+        return self._l2normalize(vectors)

--- a/scripts/20newsgroups-replication.py
+++ b/scripts/20newsgroups-replication.py
@@ -1,9 +1,11 @@
 import sys
 sys.path.insert(0, './')
-
-from sklearn import metrics
-from sklearn.naive_bayes import MultinomialNB
+import argparse
 import os
+from enum import Enum
+from sklearn import metrics
+from sklearn.linear_model import LogisticRegression
+from pyserini.vectorizer import BM25Vectorizer
 from pyserini.vectorizer import TfidfVectorizer
 
 
@@ -19,43 +21,44 @@ def get_info(path):
     return (docs, targets)
 
 
+class VectorizerType(Enum):
+    TFIDF = 'tfidf'
+    BM25 = 'bm25'
+
+
 if __name__ == '__main__':
-    target_names = [
-        'alt.atheism',
-        'comp.graphics',
-        'comp.os.ms-windows.misc',
-        'comp.sys.ibm.pc.hardware',
-        'comp.sys.mac.hardware',
-        'comp.windows.x',
-        'misc.forsale',
-        'rec.autos',
-        'rec.motorcycles',
-        'rec.sport.baseball',
-        'rec.sport.hockey',
-        'sci.crypt',
-        'sci.electronics',
-        'sci.med',
-        'sci.space',
-        'soc.religion.christian',
-        'talk.politics.guns',
-        'talk.politics.mideast',
-        'talk.politics.misc',
-        'talk.religion.misc',
-    ]
+    parser = argparse.ArgumentParser(
+        description='Replication script of pyserini vectorizer')
+    parser.add_argument('-vectorizer', type=VectorizerType, required=True, help='which vectorizer to use')
+    args = parser.parse_args()
+
+    target_names = ['alt.atheism', 'comp.graphics', 'comp.os.ms-windows.misc', 'comp.sys.ibm.pc.hardware', 'comp.sys.mac.hardware', 'comp.windows.x', 'misc.forsale', 'rec.autos', 'rec.motorcycles', 'rec.sport.baseball',
+                    'rec.sport.hockey', 'sci.crypt', 'sci.electronics', 'sci.med', 'sci.space', 'soc.religion.christian', 'talk.politics.guns', 'talk.politics.mideast', 'talk.politics.misc', 'talk.religion.misc', ]
 
     target_to_index = {t: i for i, t in enumerate(target_names)}
 
     train_docs, train_labels = get_info('./20newsgroups/20news-bydate-train/')
     test_docs, test_labels = get_info('./20newsgroups/20news-bydate-test/')
 
-    vectorizer = TfidfVectorizer(
-        './20newsgroups/lucene-index.20newsgroup.pos+docvectors+raw', min_df=5)
+    lucene_index_path = '20newsgroups/lucene-index.20newsgroup.pos+docvectors+raw'
+    vectorizer = None
+    if args.vectorizer == VectorizerType.TFIDF:
+        vectorizer = TfidfVectorizer(lucene_index_path, min_df=5, verbose=True)
+    elif args.vectorizer == VectorizerType.BM25:
+        vectorizer = BM25Vectorizer(lucene_index_path)
+
     train_vectors = vectorizer.get_vectors(train_docs)
     test_vectors = vectorizer.get_vectors(test_docs)
 
     # classifier
-    clf = MultinomialNB()
+    clf = LogisticRegression()
     clf.fit(train_vectors, train_labels)
     pred = clf.predict(test_vectors)
     score = metrics.f1_score(test_labels, pred, average='macro')
     print(f'f1 score: {score}')
+
+    score = round(score, 7)
+    if args.vectorizer == VectorizerType.TFIDF:
+        assert score == 0.8341188, "tf-idf vectorizer score mismatch"
+    elif args.vectorizer == VectorizerType.BM25:
+        assert score == 0.8441544, "bm25 vectorizer score mismatch"

--- a/scripts/20newsgroups-replication.py
+++ b/scripts/20newsgroups-replication.py
@@ -1,12 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 sys.path.insert(0, './')
-import argparse
-import os
-from enum import Enum
-from sklearn import metrics
-from sklearn.linear_model import LogisticRegression
-from pyserini.vectorizer import BM25Vectorizer
+
 from pyserini.vectorizer import TfidfVectorizer
+from pyserini.vectorizer import BM25Vectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn import metrics
+from enum import Enum
+import os
+import argparse
 
 
 def get_info(path):

--- a/scripts/20newsgroups-replication.py
+++ b/scripts/20newsgroups-replication.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from sklearn.linear_model import LogisticRegression
+from sklearn import metrics
+import os
+import importlib
+import argparse
 import sys
 sys.path.insert(0, './')
-
-import argparse
-import importlib
-import os
-from sklearn import metrics
-from sklearn.linear_model import LogisticRegression
-from pyserini.vectorizer import BM25Vectorizer
-from pyserini.vectorizer import TfidfVectorizer
 
 
 def get_info(path):
@@ -67,8 +64,8 @@ if __name__ == '__main__':
 
     score = round(score, 7)
     if args.vectorizer == 'TfidfVectorizer':
-        assert score == 0.8341188, "tf-idf vectorizer score mismatch"
+        assert score == 0.8359058, "tf-idf vectorizer score mismatch"
     elif args.vectorizer == 'BM25Vectorizer':
-        assert score == 0.8441544, "bm25 vectorizer score mismatch"
+        assert score == 0.8421606, "bm25 vectorizer score mismatch"
     else:
         print('No matching f1 score assertion')

--- a/scripts/20newsgroups-replication.py
+++ b/scripts/20newsgroups-replication.py
@@ -18,7 +18,6 @@ sys.path.insert(0, './')
 import argparse
 import importlib
 import os
-from enum import Enum
 from sklearn import metrics
 from sklearn.linear_model import LogisticRegression
 from pyserini.vectorizer import BM25Vectorizer
@@ -35,11 +34,6 @@ def get_info(path):
             targets.append(target_to_index[category])
 
     return docs, targets
-
-
-class VectorizerType(Enum):
-    TFIDF = 'tfidf'
-    BM25 = 'bm25'
 
 
 if __name__ == '__main__':
@@ -72,7 +66,9 @@ if __name__ == '__main__':
     print(f'f1 score: {score}')
 
     score = round(score, 7)
-    if args.vectorizer == VectorizerType.TFIDF:
+    if args.vectorizer == 'TfidfVectorizer':
         assert score == 0.8341188, "tf-idf vectorizer score mismatch"
-    elif args.vectorizer == VectorizerType.BM25:
+    elif args.vectorizer == 'BM25Vectorizer':
         assert score == 0.8441544, "bm25 vectorizer score mismatch"
+    else:
+        print('No matching f1 score assertion')


### PR DESCRIPTION
- Introduce new BM25Vectorizer
- Refactor Common logic of vectorizer to `Class VectorizerBase`
- Add test case in `20newsgroups-replication.py` with f1 score assertion
- Replace `MultinomialNB` with `LogisticRegression`, which renders better results


----------------------------

tfidf vectorizer with Linear Regression model score: 0.8359058
bm25 vectorizer with Linear Regression model score: 0.8421606


----------------------------
```
python scripts/20newsgroups-replication.py --vectorizer TfidfVectorizer
python scripts/20newsgroups-replication.py --vectorizer BM25Vectorizer
```