### PR TITLE
Remove encoding info in boilerplate

### DIFF
--- a/pyserini/analysis/pyanalysis.py
+++ b/pyserini/analysis/pyanalysis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/collection/pycollection.py
+++ b/pyserini/collection/pycollection.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/index/pygenerator.py
+++ b/pyserini/index/pygenerator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/index/pyutils.py
+++ b/pyserini/index/pyutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/multithreading.py
+++ b/pyserini/multithreading.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/pyclass.py
+++ b/pyserini/pyclass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/search/pyquerybuilder.py
+++ b/pyserini/search/pyquerybuilder.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/search/pysearch.py
+++ b/pyserini/search/pysearch.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/search/reranker.py
+++ b/pyserini/search/reranker.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyserini/setup.py
+++ b/pyserini/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/classifier_prf/cross_validate.py
+++ b/scripts/classifier_prf/cross_validate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/verify_simplesearcher.py
+++ b/scripts/verify_simplesearcher.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_loadtopics.py
+++ b/tests/test_loadtopics.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_nnsearch.py
+++ b/tests/test_nnsearch.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_querybuilding.py
+++ b/tests/test_querybuilding.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Based on [pep8](https://pep8.org/#source-file-encoding), 

> Files using ASCII (in Python 2) or UTF-8 (in Python 3) should not have an encoding declaration.