### PR TITLE
Refactoring and cleanup of pyclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,13 @@ By manually constructing queries, it is possible to define the boost for each qu
 For example:
 
 ```python
-boost1 = pyquerybuilder.get_boost_query(term1, 2.)
-boost2 = pyquerybuilder.get_boost_query(term2, 1.)
-boost3 = pyquerybuilder.get_boost_query(term3, 1.)
+boost1 = querybuilder.get_boost_query(term1, 2.)
+boost2 = querybuilder.get_boost_query(term2, 1.)
+boost3 = querybuilder.get_boost_query(term3, 1.)
 
-should = pyquerybuilder.JBooleanClauseOccur['should'].value
+should = querybuilder.JBooleanClauseOccur['should'].value
 
-boolean_query_builder = pyquerybuilder.get_boolean_query_builder()
+boolean_query_builder = querybuilder.get_boolean_query_builder()
 boolean_query_builder.add(boost1, should)
 boolean_query_builder.add(boost2, should)
 boolean_query_builder.add(boost3, should)

--- a/pyserini/analysis/__init__.py
+++ b/pyserini/analysis/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-from ._base import get_lucene_analyzer, Analyzer
+from ._base import get_lucene_analyzer, Analyzer, JAnalyzerUtils
 
-__all__ = ['get_lucene_analyzer', 'Analyzer']
+__all__ = ['get_lucene_analyzer', 'Analyzer', 'JAnalyzerUtils']

--- a/pyserini/analysis/_base.py
+++ b/pyserini/analysis/_base.py
@@ -16,19 +16,24 @@
 
 from typing import List
 
-from ..pyclass import JAnalyzerUtils
-from ..pyclass import JArabicAnalyzer
-from ..pyclass import JBengaliAnalyzer
-from ..pyclass import JCJKAnalyzer
-from ..pyclass import JDefaultEnglishAnalyzer
-from ..pyclass import JFreebaseAnalyzer
-from ..pyclass import JFrenchAnalyzer
-from ..pyclass import JGermanAnalyzer
-from ..pyclass import JHindiAnalyzer
-from ..pyclass import JSpanishAnalyzer
-from ..pyclass import JString
-from ..pyclass import JTweetAnalyzer
-from ..pyclass import JCharArraySet
+from ..pyclass import autoclass, JString
+
+
+# Wrappers around Lucene classes
+JArabicAnalyzer = autoclass('org.apache.lucene.analysis.ar.ArabicAnalyzer')
+JBengaliAnalyzer = autoclass('org.apache.lucene.analysis.bn.BengaliAnalyzer')
+JCJKAnalyzer = autoclass('org.apache.lucene.analysis.cjk.CJKAnalyzer')
+JGermanAnalyzer = autoclass('org.apache.lucene.analysis.de.GermanAnalyzer')
+JSpanishAnalyzer = autoclass('org.apache.lucene.analysis.es.SpanishAnalyzer')
+JFrenchAnalyzer = autoclass('org.apache.lucene.analysis.fr.FrenchAnalyzer')
+JHindiAnalyzer = autoclass('org.apache.lucene.analysis.hi.HindiAnalyzer')
+JDefaultEnglishAnalyzer = autoclass('io.anserini.analysis.DefaultEnglishAnalyzer')
+JCharArraySet = autoclass('org.apache.lucene.analysis.CharArraySet')
+
+# Wrappers around Anserini classes
+JAnalyzerUtils = autoclass('io.anserini.analysis.AnalyzerUtils')
+JFreebaseAnalyzer = autoclass('io.anserini.analysis.FreebaseAnalyzer')
+JTweetAnalyzer = autoclass('io.anserini.analysis.TweetAnalyzer')
 
 
 def get_lucene_analyzer(name='english', stemming=True, stemmer='porter', stopwords=True):

--- a/pyserini/collection/_base.py
+++ b/pyserini/collection/_base.py
@@ -16,11 +16,27 @@
 
 import logging
 import re
+from enum import Enum
 
 from ..multithreading import Counters
-from ..pyclass import JCollections, JPaths, cast
+from ..pyclass import autoclass, cast, JPaths
 
 logger = logging.getLogger(__name__)
+
+
+class JCollections(Enum):
+    CarCollection = autoclass('io.anserini.collection.CarCollection')
+    Cord19AbstractCollection = autoclass('io.anserini.collection.Cord19AbstractCollection')
+    ClueWeb09Collection = autoclass('io.anserini.collection.ClueWeb09Collection')
+    ClueWeb12Collection = autoclass('io.anserini.collection.ClueWeb12Collection')
+    HtmlCollection = autoclass('io.anserini.collection.HtmlCollection')
+    JsonCollection = autoclass('io.anserini.collection.JsonCollection')
+    NewYorkTimesCollection = autoclass('io.anserini.collection.NewYorkTimesCollection')
+    TrecCollection = autoclass('io.anserini.collection.TrecCollection')
+    TrecwebCollection = autoclass('io.anserini.collection.TrecwebCollection')
+    TweetCollection = autoclass('io.anserini.collection.TweetCollection')
+    WashingtonPostCollection = autoclass('io.anserini.collection.WashingtonPostCollection')
+    WikipediaCollection = autoclass('io.anserini.collection.WikipediaCollection')
 
 
 class Collection:

--- a/pyserini/index/_base.py
+++ b/pyserini/index/_base.py
@@ -21,14 +21,39 @@ and methods provided are meant only to provide tools for examining an index and 
 """
 
 import logging
+from enum import Enum
 from typing import Dict, Iterator, List, Tuple
 
-from ..analysis import get_lucene_analyzer
-from ..pyclass import JIndexHelpers, JGenerators
-from ..pyclass import JIndexReaderUtils, JString, JAnalyzerUtils
+from ..analysis import get_lucene_analyzer, JAnalyzerUtils
+from ..pyclass import autoclass, JString
 from ..search import Document
 
 logger = logging.getLogger(__name__)
+
+
+# Wrappers around Anserini classes
+JIndexReader = autoclass('io.anserini.index.IndexReaderUtils')
+JDocumentVectorWeight = autoclass('io.anserini.index.IndexReaderUtils$DocumentVectorWeight')
+
+
+class JIndexHelpers:
+    def JArgs():
+        args = autoclass('io.anserini.index.IndexArgs')()
+        args.storeContents = True
+        args.storeRaw = True
+        args.dryRun = True ## So that indexing will be skipped
+        return args
+
+    def JCounters():
+        IndexCollection = autoclass('io.anserini.index.IndexCollection')
+        Counters = autoclass('io.anserini.index.IndexCollection$Counters')
+        return Counters(IndexCollection)
+
+
+class JGenerators(Enum):
+    DefaultLuceneDocumentGenerator = autoclass('io.anserini.index.generator.DefaultLuceneDocumentGenerator')
+    TweetGenerator = autoclass('io.anserini.index.generator.TweetGenerator')
+    WapoGenerator = autoclass('io.anserini.index.generator.WashingtonPostGenerator')
 
 
 class Generator:
@@ -124,7 +149,7 @@ class IndexReader:
     """
 
     def __init__(self, index_dir):
-        self.object = JIndexReaderUtils()
+        self.object = JIndexReader()
         self.reader = self.object.getReader(JString(index_dir))
 
     def analyze(self, text: str, analyzer=None) -> List[str]:

--- a/pyserini/pyclass.py
+++ b/pyserini/pyclass.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,111 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 """
 Module for hiding Python-Java calls via Pyjnius
 """
 
-### Pyjnius setup
-
 from .setup import configure_classpath, os
 
 # If the environment variable isn't defined, look in the current directory.
-configure_classpath(os.environ['ANSERINI_CLASSPATH'] if 'ANSERINI_CLASSPATH' in os.environ else os.path.join(os.path.split(__file__)[0], 'resources/jars/'))
+configure_classpath(os.environ['ANSERINI_CLASSPATH'] if 'ANSERINI_CLASSPATH' in os.environ else
+                    os.path.join(os.path.split(__file__)[0], 'resources/jars/'))
 
 from jnius import autoclass, cast
-from enum import Enum
 
-### Java
-
+# Base Java classes
 JString = autoclass('java.lang.String')
 JPath = autoclass('java.nio.file.Path')
 JPaths = autoclass('java.nio.file.Paths')
 JList = autoclass('java.util.List')
 JArrayList = autoclass('java.util.ArrayList')
-
-### Analysis
-
-JArabicAnalyzer = autoclass('org.apache.lucene.analysis.ar.ArabicAnalyzer')
-JBengaliAnalyzer = autoclass('org.apache.lucene.analysis.bn.BengaliAnalyzer')
-JCJKAnalyzer = autoclass('org.apache.lucene.analysis.cjk.CJKAnalyzer')
-JGermanAnalyzer = autoclass('org.apache.lucene.analysis.de.GermanAnalyzer')
-JSpanishAnalyzer = autoclass('org.apache.lucene.analysis.es.SpanishAnalyzer')
-JFrenchAnalyzer = autoclass('org.apache.lucene.analysis.fr.FrenchAnalyzer')
-JHindiAnalyzer = autoclass('org.apache.lucene.analysis.hi.HindiAnalyzer')
-
-JCharArraySet = autoclass('org.apache.lucene.analysis.CharArraySet')
-
-JDefaultEnglishAnalyzer = autoclass('io.anserini.analysis.DefaultEnglishAnalyzer')
-JFreebaseAnalyzer = autoclass('io.anserini.analysis.FreebaseAnalyzer')
-JTweetAnalyzer = autoclass('io.anserini.analysis.TweetAnalyzer')
-
-### Search
-
-JDocument = autoclass('org.apache.lucene.document.Document')
-JSimpleSearcher = autoclass('io.anserini.search.SimpleSearcher')
-JSimpleSearcherResult = autoclass('io.anserini.search.SimpleSearcher$Result')
-JSimpleNearestNeighborSearcher = autoclass('io.anserini.search.SimpleNearestNeighborSearcher')
-JSimpleNearestNeighborSearcherResult = autoclass('io.anserini.search.SimpleNearestNeighborSearcher$Result')
-
-### Topics
-
-JTopicReader = autoclass('io.anserini.search.topicreader.TopicReader')
-JTopics = autoclass('io.anserini.search.topicreader.Topics')
-
-## IndexReaderUtils
-JIndexReaderUtils = autoclass('io.anserini.index.IndexReaderUtils')
-JDocumentVectorWeight = autoclass('io.anserini.index.IndexReaderUtils$DocumentVectorWeight')
-
-JAnalyzerUtils = autoclass('io.anserini.analysis.AnalyzerUtils')
-
-### Generator
-
-class JIndexHelpers:
-
-    def JArgs():
-        args = autoclass('io.anserini.index.IndexArgs')()
-        args.storeContents = True
-        args.storeRaw = True
-        args.dryRun = True ## So that indexing will be skipped
-        return args
-
-    def JCounters():
-        IndexCollection = autoclass('io.anserini.index.IndexCollection')
-        Counters = autoclass('io.anserini.index.IndexCollection$Counters')
-        return Counters(IndexCollection)
-
-class JGenerators(Enum):
-    DefaultLuceneDocumentGenerator = autoclass('io.anserini.index.generator.DefaultLuceneDocumentGenerator')
-    TweetGenerator = autoclass('io.anserini.index.generator.TweetGenerator')
-    WapoGenerator = autoclass('io.anserini.index.generator.WashingtonPostGenerator')
-
-# Query Generators
-JQueryGenerator = autoclass('io.anserini.search.query.QueryGenerator')
-JBagOfWordsQueryGenerator = autoclass('io.anserini.search.query.BagOfWordsQueryGenerator')
-JCovid19QueryGenerator = autoclass('io.anserini.search.query.Covid19QueryGenerator')
-
-# Query building
-JQueryGeneratorUtils = autoclass('io.anserini.search.query.QueryGeneratorUtils')
-
-JTerm = autoclass('org.apache.lucene.index.Term')
-JBooleanClause = autoclass('org.apache.lucene.search.BooleanClause')
-JBoostQuery = autoclass('org.apache.lucene.search.BoostQuery')
-JTermQuery = autoclass('org.apache.lucene.search.TermQuery')
-JQuery = autoclass('org.apache.lucene.search.Query')
-
-### Collection
-
-class JCollections(Enum):
-    CarCollection = autoclass('io.anserini.collection.CarCollection')
-    Cord19AbstractCollection = autoclass('io.anserini.collection.Cord19AbstractCollection')
-    ClueWeb09Collection = autoclass('io.anserini.collection.ClueWeb09Collection')
-    ClueWeb12Collection = autoclass('io.anserini.collection.ClueWeb12Collection')
-    HtmlCollection = autoclass('io.anserini.collection.HtmlCollection')
-    JsonCollection = autoclass('io.anserini.collection.JsonCollection')
-    NewYorkTimesCollection = autoclass('io.anserini.collection.NewYorkTimesCollection')
-    TrecCollection = autoclass('io.anserini.collection.TrecCollection')
-    TrecwebCollection = autoclass('io.anserini.collection.TrecwebCollection')
-    TweetCollection = autoclass('io.anserini.collection.TweetCollection')
-    WashingtonPostCollection = autoclass('io.anserini.collection.WashingtonPostCollection')
-    WikipediaCollection = autoclass('io.anserini.collection.WikipediaCollection')

--- a/pyserini/search/__init__.py
+++ b/pyserini/search/__init__.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 #
 
-from ._base import Document, get_topics
-from ._searcher import SimpleSearcher, LuceneSimilarities
-from ._nearest_neighbor import SimpleNearestNeighborSearcher
+from ._base import Document, JDocument, JQuery, get_topics
+from ._searcher import JSimpleSearcherResult, LuceneSimilarities, SimpleSearcher
+from ._nearest_neighbor import SimpleNearestNeighborSearcher, JSimpleNearestNeighborSearcherResult
 
-__all__ = ['Document', 'SimpleSearcher', 'LuceneSimilarities', 'SimpleNearestNeighborSearcher', 'get_topics']
+__all__ = ['Document', 'JDocument', 'JQuery', 'LuceneSimilarities',
+           'SimpleSearcher', 'JSimpleSearcherResult',
+           'SimpleNearestNeighborSearcher', 'JSimpleNearestNeighborSearcherResult', 'get_topics']

--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -21,9 +21,21 @@ class, which wraps the Java class with the same name in Anserini.
 
 import logging
 
-from ..pyclass import JDocument, JTopics, JTopicReader
+from ..pyclass import autoclass
 
 logger = logging.getLogger(__name__)
+
+
+# Wrappers around Lucene classes
+JQuery = autoclass('org.apache.lucene.search.Query')
+JDocument = autoclass('org.apache.lucene.document.Document')
+
+# Wrappers around Anserini classes
+JTopicReader = autoclass('io.anserini.search.topicreader.TopicReader')
+JTopics = autoclass('io.anserini.search.topicreader.Topics')
+JQueryGenerator = autoclass('io.anserini.search.query.QueryGenerator')
+JBagOfWordsQueryGenerator = autoclass('io.anserini.search.query.BagOfWordsQueryGenerator')
+JCovid19QueryGenerator = autoclass('io.anserini.search.query.Covid19QueryGenerator')
 
 
 class Document:

--- a/pyserini/search/_nearest_neighbor.py
+++ b/pyserini/search/_nearest_neighbor.py
@@ -22,9 +22,14 @@ class, which wraps the Java class with the same name in Anserini.
 import logging
 from typing import List
 
-from ..pyclass import JString, JSimpleNearestNeighborSearcherResult, JSimpleNearestNeighborSearcher
+from ..pyclass import autoclass, JString
 
 logger = logging.getLogger(__name__)
+
+
+# Wrappers around Anserini classes
+JSimpleNearestNeighborSearcher = autoclass('io.anserini.search.SimpleNearestNeighborSearcher')
+JSimpleNearestNeighborSearcherResult = autoclass('io.anserini.search.SimpleNearestNeighborSearcher$Result')
 
 
 class SimpleNearestNeighborSearcher:

--- a/pyserini/search/_searcher.py
+++ b/pyserini/search/_searcher.py
@@ -22,10 +22,15 @@ class, which wraps the Java class with the same name in Anserini.
 import logging
 from typing import Dict, List, Union
 
-from ._base import Document
-from ..pyclass import JSimpleSearcher, JSimpleSearcherResult, JString, JArrayList, JQueryGenerator, JQuery, autoclass
+from ._base import Document, JQuery, JQueryGenerator
+from ..pyclass import autoclass, JString, JArrayList
 
 logger = logging.getLogger(__name__)
+
+
+# Wrappers around Anserini classes
+JSimpleSearcher = autoclass('io.anserini.search.SimpleSearcher')
+JSimpleSearcherResult = autoclass('io.anserini.search.SimpleSearcher$Result')
 
 
 class SimpleSearcher:
@@ -190,7 +195,7 @@ class SimpleSearcher:
         """
         return self.object.getSimilarity()
 
-    def doc(self, docid: Union[str, int]) -> Document:
+    def doc(self, docid: Union[str, int]) -> Union[Document, None]:
         """Returns the :class:`Document` corresponding to ``docid``. The ``docid`` is overloaded: if it is of type
         ``str``, it is treated as an external collection ``docid``; if it is of type ``int``, it is treated as an
         internal Lucene ``docid``. Returns ``None`` if the ``docid`` does not exist in the index.
@@ -211,7 +216,7 @@ class SimpleSearcher:
             return None
         return Document(lucene_document)
 
-    def doc_by_field(self, field: str, q: str) -> str:
+    def doc_by_field(self, field: str, q: str) -> Union[Document, None]:
         """Returns the :class:`Document` based on a ``field`` with ``id``. For example, this method can be used to fetch
         document based on alternative primary keys that have been indexed, such as an article's DOI. Returns ``None`` if
         no such document exists.

--- a/pyserini/search/querybuilder.py
+++ b/pyserini/search/querybuilder.py
@@ -21,8 +21,19 @@ import logging
 from enum import Enum
 
 from ..analysis import get_lucene_analyzer, Analyzer
-from ..pyclass import JQueryGeneratorUtils, JTermQuery, JTerm, JBoostQuery
+from ..pyclass import autoclass
+
 logger = logging.getLogger(__name__)
+
+
+# Wrapper around Lucene clases
+JTerm = autoclass('org.apache.lucene.index.Term')
+JBooleanClause = autoclass('org.apache.lucene.search.BooleanClause')
+JBoostQuery = autoclass('org.apache.lucene.search.BoostQuery')
+JTermQuery = autoclass('org.apache.lucene.search.TermQuery')
+
+# Wrappers around Anserini classes
+JQueryGeneratorUtils = autoclass('io.anserini.search.query.QueryGeneratorUtils')
 
 
 class JBooleanClauseOccur(Enum):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import os
 import shutil
@@ -20,7 +22,8 @@ from random import randint
 from urllib.request import urlretrieve
 
 from pyserini import analysis, index, search
-from pyserini.pyclass import JString, JAnalyzerUtils
+from pyserini.analysis import JAnalyzerUtils
+from pyserini.pyclass import JString
 
 
 class TestAnalyzers(unittest.TestCase):
@@ -32,7 +35,7 @@ class TestAnalyzers(unittest.TestCase):
         self.tarball_name = 'lucene-index.cacm-{}.tar.gz'.format(r)
         self.index_dir = 'index{}/'.format(r)
 
-        filename, headers = urlretrieve(self.collection_url, self.tarball_name)
+        _, _ = urlretrieve(self.collection_url, self.tarball_name)
 
         tarball = tarfile.open(self.tarball_name)
         tarball.extractall(self.index_dir)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import os
 import shutil
@@ -29,15 +31,15 @@ class TestIterateCollection(unittest.TestCase):
         r = randint(0, 10000000)
         url = 'https://github.com/castorini/anserini/blob/master/src/main/resources/cacm/cacm.tar.gz?raw=true'
         tarball_name = 'cacm{}.tar.gz'.format(r)
-        dir = 'collection{}/'.format(r)
+        directory = 'collection{}/'.format(r)
 
-        filename, headers = urlretrieve(url, tarball_name)
+        _, _ = urlretrieve(url, tarball_name)
 
         tarball = tarfile.open(tarball_name)
-        tarball.extractall(dir)
+        tarball.extractall(directory)
         tarball.close()
 
-        cacm = collection.Collection('HtmlCollection', dir)
+        cacm = collection.Collection('HtmlCollection', directory)
         generator = index.Generator('DefaultLuceneDocumentGenerator')
 
         cnt = 0
@@ -68,7 +70,7 @@ class TestIterateCollection(unittest.TestCase):
 
         # Clean up
         os.remove(tarball_name)
-        shutil.rmtree(dir)
+        shutil.rmtree(directory)
 
 
 if __name__ == '__main__':

--- a/tests/test_index_reader.py
+++ b/tests/test_index_reader.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,15 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import os
 import shutil
 import tarfile
 import unittest
 from random import randint
+from urllib.request import urlretrieve
+
 from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import MultinomialNB
-from urllib.request import urlretrieve
 
 from pyserini import analysis, index, search
 from pyserini.pyclass import JString
@@ -34,7 +37,7 @@ class TestIndexUtils(unittest.TestCase):
         self.tarball_name = 'lucene-index.cacm-{}.tar.gz'.format(r)
         self.index_dir = 'index{}/'.format(r)
 
-        filename, headers = urlretrieve(self.collection_url, self.tarball_name)
+        _, _ = urlretrieve(self.collection_url, self.tarball_name)
 
         tarball = tarfile.open(self.tarball_name)
         tarball.extractall(self.index_dir)

--- a/tests/test_load_topics.py
+++ b/tests/test_load_topics.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import unittest
 

--- a/tests/test_nnsearch.py
+++ b/tests/test_nnsearch.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import os
 import shutil
@@ -20,8 +22,7 @@ from random import randint
 from typing import List
 from urllib.request import urlretrieve
 
-from pyserini.pyclass import JSimpleNearestNeighborSearcherResult
-from pyserini import search
+from pyserini.search import SimpleNearestNeighborSearcher, JSimpleNearestNeighborSearcherResult
 
 
 class TestSearch(unittest.TestCase):
@@ -39,7 +40,7 @@ class TestSearch(unittest.TestCase):
         vectors_tarball.extractall(self.vectors_dir)
         vectors_tarball.close()
 
-        self.nnsercher = search.SimpleNearestNeighborSearcher(f'{self.vectors_dir}lucene-index-vectors.cacm')
+        self.nnsercher = SimpleNearestNeighborSearcher(f'{self.vectors_dir}lucene-index-vectors.cacm')
 
     def test_nearest_neighbor(self):
         hits = self.nnsercher.search('CACM-0059')

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import os
 import shutil
@@ -20,8 +22,8 @@ from random import randint
 from urllib.request import urlretrieve
 
 from pyserini import search
-from pyserini.search import querybuilder
 from pyserini.analysis import get_lucene_analyzer
+from pyserini.search import querybuilder
 
 
 class TestQueryBuilding(unittest.TestCase):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import os
 import shutil
@@ -20,8 +22,7 @@ from random import randint
 from typing import List, Dict
 from urllib.request import urlretrieve
 
-from pyserini.pyclass import JSimpleSearcherResult
-from pyserini import search
+from pyserini.search import Document, SimpleSearcher, JSimpleSearcherResult
 
 
 class TestSearch(unittest.TestCase):
@@ -38,7 +39,7 @@ class TestSearch(unittest.TestCase):
         tarball.extractall(self.index_dir)
         tarball.close()
 
-        self.searcher = search.SimpleSearcher(f'{self.index_dir}lucene-index.cacm')
+        self.searcher = SimpleSearcher(f'{self.index_dir}lucene-index.cacm')
 
     def test_basic(self):
         self.assertTrue(self.searcher.get_similarity().toString().startswith('BM25'))
@@ -198,7 +199,7 @@ class TestSearch(unittest.TestCase):
     def test_doc_int(self):
         # The doc method is overloaded: if input is int, it's assumed to be a Lucene internal docid.
         doc = self.searcher.doc(1)
-        self.assertTrue(isinstance(doc, search.Document))
+        self.assertTrue(isinstance(doc, Document))
 
         # These are all equivalent ways to get the docid.
         self.assertEqual('CACM-0002', doc.id())
@@ -221,7 +222,7 @@ class TestSearch(unittest.TestCase):
     def test_doc_str(self):
         # The doc method is overloaded: if input is str, it's assumed to be an external collection docid.
         doc = self.searcher.doc('CACM-0002')
-        self.assertTrue(isinstance(doc, search.Document))
+        self.assertTrue(isinstance(doc, Document))
 
         # These are all equivalent ways to get the docid.
         self.assertEqual(doc.lucene_document().getField('id').stringValue(), 'CACM-0002')


### PR DESCRIPTION
Previously, all the wrappers around Java classes were centralized in `pyclass`, which made imports a mess. Now, moved the wraps into separate subpackages, where they belong.