### PR TITLE
Refactor vectorizer.py into sub-module

### DIFF
--- a/pyserini/vectorizer/__init__.py
+++ b/pyserini/vectorizer/__init__.py
@@ -1,0 +1,19 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from ._base import BM25Vectorizer, TfidfVectorizer
+
+__all__ = ['BM25Vectorizer', 'TfidfVectorizer']

--- a/pyserini/vectorizer/_base.py
+++ b/pyserini/vectorizer/_base.py
@@ -1,3 +1,4 @@
+#
 # Pyserini: Python interface to the Anserini IR toolkit built on Lucene
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 import math
 from typing import List


### PR DESCRIPTION
- Refactor vectorizer.py into sub-module `vectorizer`
- Expose TfidfVectorizer and BM25Vectorizer in the sub-module