### PR TITLE
TrecRun.remove/keep docs by qrels

### DIFF
--- a/pyserini/trectools/_base.py
+++ b/pyserini/trectools/_base.py
@@ -30,6 +30,56 @@ class RescoreMethod(Enum):
     SCALE = 'scale'
 
 
+class Qrels:
+    """Wrapper class for TREC Qrels.
+
+    Parameters
+    ----------
+    filepath : str
+        File path of a given TREC Qrels.
+    """
+
+    columns = ['topic', 'q0', 'docid', 'relevance_grade']
+
+    def __init__(self, filepath: str = None):
+        self.filepath = filepath
+        self.qrels_data = pd.DataFrame(columns=Qrels.columns)
+
+        if filepath is not None:
+            self.read_run(self.filepath)
+
+    def read_run(self, filepath: str):
+        self.qrels_data = pd.read_csv(filepath, sep='\s+', names=Qrels.columns)
+
+    def get_relevance_grades(self) -> Set[str]:
+        """Return a set with all relevance grades."""
+
+        return set(sorted(self.qrels_data["relevance_grade"].unique()))
+
+    def topics(self) -> Set[str]:
+        """Return a set with all topics."""
+
+        return set(sorted(self.qrels_data["topic"].unique()))
+
+    def get_docids(self, topic, relevance_grades=None) -> List[str]:
+        """"Return a list of docids for a given topic and a list relevance grades.
+
+        Parameters:
+        ----------
+        relevance : List[int]
+            E.g. [0, 1, 2]. If not provided, then all relevance will be returned.
+        topic : int
+        """
+
+        if relevance_grades is None:
+            relevance_grades = self.get_relevance_grades()
+
+        filtered_df = self.qrels_data[self.qrels_data['topic'] == topic]
+        filtered_df = filtered_df[filtered_df['relevance_grade'].isin(relevance_grades)]
+
+        return filtered_df['docid'].tolist()
+
+
 class TrecRun:
     """Wrapper class for a TREC run.
 
@@ -42,11 +92,14 @@ class TrecRun:
     columns = ['topic', 'q0', 'docid', 'rank', 'score', 'tag']
 
     def __init__(self, filepath: str = None):
-        self.run_data = pd.DataFrame(columns=TrecRun.columns)
+        self.reset_data()
         self.filepath = filepath
 
         if filepath is not None:
             self.read_run(self.filepath)
+
+    def reset_data(self):
+        self.run_data = pd.DataFrame(columns=TrecRun.columns)
 
     def read_run(self, filepath: str) -> None:
         self.run_data = pd.read_csv(filepath, sep='\s+', names=TrecRun.columns)
@@ -98,6 +151,71 @@ class TrecRun:
 
     def to_numpy(self) -> np.ndarray:
         return self.run_data.to_numpy(copy=True)
+
+    def remove_by_qrels(self, qrels: Qrels, copy=True):
+        """Given a Qrels object, remove each docid in self if docid is also in the qrels.
+        This operation is performed on each topic separately.
+
+        Parameters:
+        ----------
+        qrels : Qrels
+            Qrels with docids to remove from TrecRun.
+        copy : Bool
+            Return a new TrecRun object if True, else self will be modified and returned.
+        """
+
+        return self._filter_from_qrels(qrels, False, copy=copy)
+
+    def keep_only_qrels(self, qrels: Qrels, copy=True):
+        """Given a Qrels object, keep each docid in self if docid is also in the qrels.
+        This operation is performed on each topic separately.
+        After this operation, judged@x based on the given qrels should be 1.
+
+        Parameters:
+        ----------
+        qrels : Qrels
+            Qrels with docids to keep in TrecRun.
+        copy : Bool
+            Return a new TrecRun object if True, else self will be modified and returned.
+        """
+
+        return self._filter_from_qrels(qrels, True, copy=copy)
+
+    def _filter_from_qrels(self, qrels: Qrels, keep: bool, copy=True):
+        """Private helper function to remove/keep each docid in self if docid is also in the given Qrels object.
+        This operation is performed on each topic separately.
+
+        Parameters:
+        ----------
+        qrels : Qrels
+            Qrels with docids to remove from or keep in TrecRun.
+        copy : Bool
+            If True, only docids in qrels will appear in TrecRun. Else, docids in qrels won't appear in the TrecRun.
+        copy : Bool
+            Return a new TrecRun object if True, else self will be modified and returned.
+        """
+
+        df_list = []
+        for topic in self.topics():
+            if topic not in qrels.topics():
+                continue
+
+            tabu_list = qrels.get_docids(topic)
+            topic_df = self.run_data[self.run_data['topic'] == topic]
+            if keep is True:
+                topic_df = topic_df[topic_df['docid'].isin(tabu_list)]
+            else:
+                topic_df = topic_df[~topic_df['docid'].isin(tabu_list)]
+            df_list.append(topic_df)
+
+        if copy is True:
+            run = TrecRun()
+            run.run_data = run.run_data.append([df for df in df_list], ignore_index=True)
+            return run
+        else:
+            self.reset_data()
+            self.run_data = self.run_data.append([df for df in df_list], ignore_index=True)
+            return self
 
     @staticmethod
     def get_all_topics_from_runs(runs) -> Set[str]:
@@ -192,55 +310,5 @@ class TrecRun:
         """
 
         run = TrecRun()
-        run.run_data = run.run_data.append([run.run_data for run in runs])
+        run.run_data = run.run_data.append([run.run_data for run in runs], ignore_index=True)
         return run
-
-
-class Qrels:
-    """Wrapper class for TREC qrels.
-
-    Parameters
-    ----------
-    filepath : str
-        File path of a given TREC Qrels.
-    """
-
-    columns = ['topic', 'q0', 'docid', 'relevance_grade']
-
-    def __init__(self, filepath: str = None):
-        self.filepath = filepath
-        self.qrels_data = pd.DataFrame(columns=Qrels.columns)
-
-        if filepath is not None:
-            self.read_run(self.filepath)
-
-    def read_run(self, filepath: str):
-        self.qrels_data = pd.read_csv(filepath, sep='\s+', names=Qrels.columns)
-
-    def get_relevance_grades(self) -> Set[str]:
-        """Return a set with all relevance grades."""
-
-        return set(sorted(self.qrels_data["relevance_grade"].unique()))
-
-    def topics(self) -> Set[str]:
-        """Return a set with all topics."""
-
-        return set(sorted(self.qrels_data["topic"].unique()))
-
-    def get_docids(self, topic, relevance_grades=None) -> List[str]:
-        """"Return a list of docids for a given topic and a list relevance grades.
-
-        Parameters:
-        ----------
-        relevance : List[int]
-            E.g. [0, 1, 2]. If not provided, then all relevance will be returned.
-        topic : int
-        """
-
-        if relevance_grades is None:
-            relevance_grades = self.get_relevance_grades()
-
-        filtered_df = self.qrels_data[self.qrels_data['topic'] == topic]
-        filtered_df = filtered_df[filtered_df['relevance_grade'].isin(relevance_grades)]
-
-        return filtered_df['docid'].tolist()

--- a/pyserini/trectools/_base.py
+++ b/pyserini/trectools/_base.py
@@ -152,22 +152,22 @@ class TrecRun:
     def to_numpy(self) -> np.ndarray:
         return self.run_data.to_numpy(copy=True)
 
-    def remove_by_qrels(self, qrels: Qrels, copy=True):
-        """Given a Qrels object, remove each docid in self if docid is also in the qrels.
+    def discard_qrels(self, qrels: Qrels, clone=True):
+        """Discard each docid in self if docid is also in the given qrels.
         This operation is performed on each topic separately.
 
         Parameters:
         ----------
         qrels : Qrels
             Qrels with docids to remove from TrecRun.
-        copy : Bool
+        clone : Bool
             Return a new TrecRun object if True, else self will be modified and returned.
         """
 
-        return self._filter_from_qrels(qrels, False, copy=copy)
+        return self._filter_from_qrels(qrels, False, clone=clone)
 
-    def keep_only_qrels(self, qrels: Qrels, copy=True):
-        """Given a Qrels object, keep each docid in self if docid is also in the qrels.
+    def retain_qrels(self, qrels: Qrels, clone=True):
+        """Retain each docid in self if docid is also in the given qrels.
         This operation is performed on each topic separately.
         After this operation, judged@x based on the given qrels should be 1.
 
@@ -175,13 +175,13 @@ class TrecRun:
         ----------
         qrels : Qrels
             Qrels with docids to keep in TrecRun.
-        copy : Bool
+        clone : Bool
             Return a new TrecRun object if True, else self will be modified and returned.
         """
 
-        return self._filter_from_qrels(qrels, True, copy=copy)
+        return self._filter_from_qrels(qrels, True, clone=clone)
 
-    def _filter_from_qrels(self, qrels: Qrels, keep: bool, copy=True):
+    def _filter_from_qrels(self, qrels: Qrels, keep: bool, clone=True):
         """Private helper function to remove/keep each docid in self if docid is also in the given Qrels object.
         This operation is performed on each topic separately.
 
@@ -189,9 +189,7 @@ class TrecRun:
         ----------
         qrels : Qrels
             Qrels with docids to remove from or keep in TrecRun.
-        copy : Bool
-            If True, only docids in qrels will appear in TrecRun. Else, docids in qrels won't appear in the TrecRun.
-        copy : Bool
+        clone : Bool
             Return a new TrecRun object if True, else self will be modified and returned.
         """
 
@@ -200,15 +198,15 @@ class TrecRun:
             if topic not in qrels.topics():
                 continue
 
-            tabu_list = qrels.get_docids(topic)
+            qrels_docids = qrels.get_docids(topic)
             topic_df = self.run_data[self.run_data['topic'] == topic]
             if keep is True:
-                topic_df = topic_df[topic_df['docid'].isin(tabu_list)]
+                topic_df = topic_df[topic_df['docid'].isin(qrels_docids)]
             else:
-                topic_df = topic_df[~topic_df['docid'].isin(tabu_list)]
+                topic_df = topic_df[~topic_df['docid'].isin(qrels_docids)]
             df_list.append(topic_df)
 
-        if copy is True:
+        if clone is True:
             run = TrecRun()
             run.run_data = run.run_data.append([df for df in df_list], ignore_index=True)
             return run

--- a/tests/resources/simple_trec_run_filter.txt
+++ b/tests/resources/simple_trec_run_filter.txt
@@ -1,0 +1,6 @@
+1 Q0 010vptx3 1 2.4 reciprocal_rank_fusion_k=60
+1 Q0 whati123 3 1.3 reciprocal_rank_fusion_k=60
+2 Q0 02f0opkr 1 4.1 reciprocal_rank_fusion_k=60
+2 Q0 sbnugd2g 2 3.3 reciprocal_rank_fusion_k=60
+3 Q0 hanxiao2 1 123 reciprocal_rank_fusion_k=60
+4 Q0 athjtu2j 1 561 reciprocal_rank_fusion_k=60

--- a/tests/resources/simple_trec_run_keep_verify.txt
+++ b/tests/resources/simple_trec_run_keep_verify.txt
@@ -1,0 +1,3 @@
+1 Q0 010vptx3 1 2.4 reciprocal_rank_fusion_k=60
+2 Q0 sbnugd2g 2 3.3 reciprocal_rank_fusion_k=60
+4 Q0 athjtu2j 1 561.0 reciprocal_rank_fusion_k=60

--- a/tests/resources/simple_trec_run_remove_verify.txt
+++ b/tests/resources/simple_trec_run_remove_verify.txt
@@ -1,0 +1,3 @@
+1 Q0 whati123 3 1.3 reciprocal_rank_fusion_k=60
+2 Q0 02f0opkr 1 4.1 reciprocal_rank_fusion_k=60
+3 Q0 hanxiao2 1 123.0 reciprocal_rank_fusion_k=60

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -16,22 +16,12 @@
 
 import filecmp
 import os
-from pyserini.trectools import TrecRun, Qrels
 import unittest
 
 
 class TestSearch(unittest.TestCase):
     def setUp(self):
         self.output_path = 'output_test_fusion.txt'
-
-    def test_trec_run_read(self):
-        input_path = 'tests/resources/simple_trec_run_read.txt'
-        verify_path = 'tests/resources/simple_trec_run_read_verify.txt'
-
-        run = TrecRun(filepath=input_path)
-        run.save_to_txt(self.output_path)
-        self.assertTrue(filecmp.cmp(verify_path, self.output_path))
-        os.remove(self.output_path)
 
     def test_reciprocal_rank_fusion_simple(self):
         input_paths = ['tests/resources/simple_trec_run_fusion_1.txt', 'tests/resources/simple_trec_run_fusion_2.txt']
@@ -80,12 +70,6 @@ class TestSearch(unittest.TestCase):
         self.assertTrue(filecmp.cmp(verify_path, self.output_path))
         os.remove(self.output_path)
         os.system('rm anserini.covid-r2.*')
-
-    def test_simple_qrels(self):
-        qrels = Qrels('tools/topics-and-qrels/qrels.covid-round1.txt')
-        self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[1, 2])), 101)
-        self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[2])), 56)
-        self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[1])), 45)
 
 
 if __name__ == '__main__':

--- a/tests/test_trectools.py
+++ b/tests/test_trectools.py
@@ -39,19 +39,19 @@ class TestTrecTools(unittest.TestCase):
         self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[2])), 56)
         self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[1])), 45)
 
-    def test_remove_by_qrels(self):
+    def test_discard_qrels(self):
         run = TrecRun('tests/resources/simple_trec_run_filter.txt')
         qrels = Qrels('tools/topics-and-qrels/qrels.covid-round1.txt')
 
-        run.remove_by_qrels(qrels, copy=False).save_to_txt(output_path=self.output_path)
+        run.discard_qrels(qrels, clone=False).save_to_txt(output_path=self.output_path)
         self.assertTrue(filecmp.cmp('tests/resources/simple_trec_run_remove_verify.txt', self.output_path))
         os.remove(self.output_path)
 
-    def test_keep_only_qrels(self):
+    def test_retain_qrels(self):
         run = TrecRun('tests/resources/simple_trec_run_filter.txt')
         qrels = Qrels('tools/topics-and-qrels/qrels.covid-round1.txt')
 
-        run.keep_only_qrels(qrels, copy=True).save_to_txt(output_path=self.output_path)
+        run.retain_qrels(qrels, clone=True).save_to_txt(output_path=self.output_path)
         self.assertTrue(filecmp.cmp('tests/resources/simple_trec_run_keep_verify.txt', self.output_path))
         os.remove(self.output_path)
 

--- a/tests/test_trectools.py
+++ b/tests/test_trectools.py
@@ -1,0 +1,60 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import filecmp
+import os
+from pyserini.trectools import TrecRun, Qrels
+import unittest
+
+
+class TestTrecTools(unittest.TestCase):
+    def setUp(self):
+        self.output_path = 'output_test_trectools.txt'
+
+    def test_trec_run_read(self):
+        input_path = 'tests/resources/simple_trec_run_read.txt'
+        verify_path = 'tests/resources/simple_trec_run_read_verify.txt'
+
+        run = TrecRun(filepath=input_path)
+        run.save_to_txt(self.output_path)
+        self.assertTrue(filecmp.cmp(verify_path, self.output_path))
+        os.remove(self.output_path)
+
+    def test_simple_qrels(self):
+        qrels = Qrels('tools/topics-and-qrels/qrels.covid-round1.txt')
+        self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[1, 2])), 101)
+        self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[2])), 56)
+        self.assertEqual(len(qrels.get_docids(topic=1, relevance_grades=[1])), 45)
+
+    def test_remove_by_qrels(self):
+        run = TrecRun('tests/resources/simple_trec_run_filter.txt')
+        qrels = Qrels('tools/topics-and-qrels/qrels.covid-round1.txt')
+
+        run.remove_by_qrels(qrels, copy=False).save_to_txt(output_path=self.output_path)
+        self.assertTrue(filecmp.cmp('tests/resources/simple_trec_run_remove_verify.txt', self.output_path))
+        os.remove(self.output_path)
+
+    def test_keep_only_qrels(self):
+        run = TrecRun('tests/resources/simple_trec_run_filter.txt')
+        qrels = Qrels('tools/topics-and-qrels/qrels.covid-round1.txt')
+
+        run.keep_only_qrels(qrels, copy=True).save_to_txt(output_path=self.output_path)
+        self.assertTrue(filecmp.cmp('tests/resources/simple_trec_run_keep_verify.txt', self.output_path))
+        os.remove(self.output_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Add two functions to TrecRun

- keep docs by qrels so that we get 100% judged
- remove docs by qrels so e.g. we don't want rnd1 docs when submitting round 2
