### PR TITLE
Add replication record for MS MARCO experiments

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -80,3 +80,5 @@ map                   	all	0.2303
 We see that "out of the box" Anserini is already better!
 
 ## Replication Log
+
++ Results replicated by [@JeffreyCA](https://github.com/JeffreyCA) on 2020-09-14 (commit [`49fd7cb`](https://github.com/castorini/pyserini/commit/49fd7cb8fd802493dc34f5cb33767d2e72e19f13))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -123,3 +123,5 @@ AP captures aspects of both precision and recall in a single metric, and is the 
 On the other hand, recall@1000 provides the upper bound effectiveness of downstream reranking modules (i.e., rerankers are useless if there isn't a relevant document in the results).
 
 ## Replication Log
+
++ Results replicated by [@JeffreyCA](https://github.com/JeffreyCA) on 2020-09-14 (commit [`49fd7cb`](https://github.com/castorini/pyserini/commit/49fd7cb8fd802493dc34f5cb33767d2e72e19f13))


### PR DESCRIPTION
### Enviroment
OS: `Ubuntu 18.04.5 LTS`
Python: `Python 3.6.9`

#### MS MARCO Passage
```bash
(myenv) ubuntu:~/pyserini$ python tools/scripts/msmarco/msmarco_eval.py collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.dev.small.tsv
#####################
MRR @10: 0.18741227770955546
QueriesRanked: 6980
#####################

(myenv) ubuntu:~/pyserini$ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.dev.small.trec
map                   	all	0.1957
recall_1000           	all	0.8573
```

#### MS MARCO Doc
```bash
(myenv) ubuntu:~/pyserini$ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -mrecall.1000 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.dev.bm25.txt
map                   	all	0.2310
recall_1000           	all	0.8856

(myenv) ubuntu:~/pyserini$ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -M 100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/msmarco-docdev-top100
map                   	all	0.2219
(myenv) ubuntu:~/pyserini$ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -M 100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.dev.bm25.txt
map                   	all	0.2303
```
