### PR TITLE
Pyserini Doc and Passage retrieval replication (Jerry Huang)

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -82,3 +82,5 @@ We see that "out of the box" Anserini is already better!
 ## Replication Log
 
 + Results replicated by [@JeffreyCA](https://github.com/JeffreyCA) on 2020-09-14 (commit [`49fd7cb`](https://github.com/castorini/pyserini/commit/49fd7cb8fd802493dc34f5cb33767d2e72e19f13))
++ Results replicated by [@jhuang265](https://github.com/jhuang265) on 2020-09-14 (commit [`2ed2acc`](https://github.com/castorini/pyserini/commit/2ed2acc62e445e3e887c6cf853ccc0b0b3b57534))
+

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -125,3 +125,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 ## Replication Log
 
 + Results replicated by [@JeffreyCA](https://github.com/JeffreyCA) on 2020-09-14 (commit [`49fd7cb`](https://github.com/castorini/pyserini/commit/49fd7cb8fd802493dc34f5cb33767d2e72e19f13))
++ Results replicated by [@jhuang265](https://github.com/jhuang265) on 2020-09-14 (commit [`2ed2acc`](https://github.com/castorini/pyserini/commit/2ed2acc62e445e3e887c6cf853ccc0b0b3b57534))


### PR DESCRIPTION
Results for both Doc and Passage retrieval are identical:

Passage:
```
❯ python3 tools/scripts/msmarco/msmarco_eval.py \
 collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.dev.small.tsv
#####################
MRR @10: 0.18741227770955546
QueriesRanked: 6980
#####################
❯ python3 tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
 --input runs/run.msmarco-passage.dev.small.tsv \
 --output runs/run.msmarco-passage.dev.small.trec
Done!
❯ python3 tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \
 --input collections/msmarco-passage/qrels.dev.small.tsv \
 --output collections/msmarco-passage/qrels.dev.small.trec
Done!
❯ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
 collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.dev.small.trec
map                   	all	0.1957
recall_1000           	all	0.8573
```

Doc:
```
❯ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -mrecall.1000 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.dev.bm25.txt

map                   	all	0.2310
recall_1000           	all	0.8856
❯ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -M 100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/msmarco-docdev-top100

map                   	all	0.2219
❯ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -M 100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.dev.bm25.txt

map                   	all	0.2303
```

Everything worked fine, however at one point I did get a minor issue with 
```
Exception: No matching jar file found in /Users/jerry/Downloads/pyserini/pyserini/resources/jars
```
I ultimately fixed this by simply copying one of the jar files ```anserini-0.9.5-SNAPSHOT-fatjar.jar``` that was built when replicating the results in the Anserini repo, although I'm not sure whether this was the correct way to go about this issue.