### PR TITLE
Add support for output in MS MARCO in pyserini.search

### DIFF
--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -73,7 +73,6 @@ if topics == {}:
 # get re-ranker
 use_prcl = args.prcl and len(args.prcl) > 0 and args.alpha > 0
 if use_prcl is True:
-    print("reranker is added")
     ranker = PseudoRelevanceClassifierReranker(
         searcher.index_dir, args.vectorizer, args.prcl, r=args.r, n=args.n, alpha=args.alpha)
 

--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -21,7 +21,7 @@ from pyserini.search.reranker import ClassifierType, PseudoRelevanceClassifierRe
 from tqdm import tqdm
 
 parser = argparse.ArgumentParser(description='Search a Lucene index.')
-parser.add_argument('--index', type=str, metavar='path to index', required=True, help="Path to Lucene index or prebuilt index's name.")
+parser.add_argument('--index', type=str, metavar='path to index or index name', required=True, help="Path to Lucene index or prebuilt index's name.")
 parser.add_argument('--topics', type=str, metavar='topic_name', required=True,
                     help="Name of topics. Available: robust04, robust05, core17, core18.")
 parser.add_argument('--output', type=str, metavar='path', help="Path to output file.")
@@ -43,11 +43,13 @@ args = parser.parse_args()
 topics = get_topics(args.topics)
 
 if os.path.exists(args.index):
+    # create searcher from index directory
     searcher = SimpleSearcher(args.index)
 else:
+    # create searcher from prebuilt index name
     searcher = SimpleSearcher.from_prebuilt_index(args.index)
-    if searcher == None:
-        exit()
+if searcher == None:
+    exit()
 
 search_rankers = []
 

--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -61,6 +61,8 @@ else:
     search_rankers.append('bm25')
     if args.msmarco:
         # setting k1=0.82 and b=0.68 for ms-marco passage
+        # tuned parameters from grid search of parameter values
+        # link to BM25 tuning: https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-passage.md#bm25-tuning
         searcher.set_bm25(0.82, 0.68)
 
 if args.rm3:

--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -46,6 +46,9 @@ if os.path.exists(args.index):
     searcher = SimpleSearcher(args.index)
 else:
     searcher = SimpleSearcher.from_prebuilt_index(args.index)
+    if searcher == None:
+        exit()
+
 search_rankers = []
 
 if args.qld:

--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -113,7 +113,7 @@ with open(output_path, 'w') as target_file:
         if args.msmarco:
             writer = csv.writer(target_file, delimiter='\t', lineterminator='\n')
             for i, doc_id in enumerate(doc_ids):
-                writer.writerow([topic, doc_id, i+1])
+                writer.writerow([topic, doc_id, i + 1])
         else:
             tag = output_path[:-4] if args.output is None else 'Anserini'
             for i, (doc_id, score) in enumerate(zip(doc_ids, scores)):

--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -16,7 +16,6 @@
 
 import argparse
 import os
-import csv
 from pyserini.search import get_topics, SimpleSearcher
 from pyserini.search.reranker import ClassifierType, PseudoRelevanceClassifierReranker
 from tqdm import tqdm
@@ -60,6 +59,9 @@ if args.qld:
     searcher.set_qld()
 else:
     search_rankers.append('bm25')
+    if args.msmarco:
+        # setting k1=0.82 and b=0.68 for ms-marco passage
+        searcher.set_bm25(0.82, 0.68)
 
 if args.rm3:
     search_rankers.append('rm3')
@@ -111,9 +113,8 @@ with open(output_path, 'w') as target_file:
             scores, doc_ids = ranker.rerank(doc_ids, scores)
 
         if args.msmarco:
-            writer = csv.writer(target_file, delimiter='\t', lineterminator='\n')
             for i, doc_id in enumerate(doc_ids):
-                writer.writerow([topic, doc_id, i + 1])
+                target_file.write('{}\t{}\t{}\n'.format(topic, doc_id, i + 1))
         else:
             tag = output_path[:-4] if args.output is None else 'Anserini'
             for i, (doc_id, score) in enumerate(zip(doc_ids, scores)):

--- a/pyserini/search/__main__.py
+++ b/pyserini/search/__main__.py
@@ -111,7 +111,7 @@ with open(output_path, 'w') as target_file:
             scores, doc_ids = ranker.rerank(doc_ids, scores)
 
         if args.msmarco:
-            writer = csv.writer(target_file, delimiter='\t')
+            writer = csv.writer(target_file, delimiter='\t', lineterminator='\n')
             for i, doc_id in enumerate(doc_ids):
                 writer.writerow([topic, doc_id, i+1])
         else:

--- a/pyserini/search/_searcher.py
+++ b/pyserini/search/_searcher.py
@@ -46,6 +46,7 @@ class SimpleSearcher:
     """
 
     def __init__(self, index_dir: str):
+        self.index_dir = index_dir
         self.object = JSimpleSearcher(JString(index_dir))
         self.num_docs = self.object.getTotalNumDocuments()
 


### PR DESCRIPTION
Add support for output in MS MARCO in pyserini.search

Example:
```
python -m pyserini.search --topics msmarco_passage_dev_subset \
--index ms-marco-passage \
--output runs/run.msmarco-passage.dev.bm25.tsv \
--bm25 --msmarco
```

This is the head of output file:
```
2       1001873 1
2       1782337 2
2       4339075 3
2       4339068 4
2       7496507 5
2       7496506 6
2       6920058 7
2       6285817 8
2       4339072 9
2       7496505 10
```