### PR TITLE
Release notes for v0.10.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ The previous error was documented in [this notebook](https://github.com/castorin
 
 ## Release History
 
++ v0.10.0.1: December 2, 2020 [[Release Notes](docs/release-notes/release-notes-v0.10.0.1.md)]
 + v0.10.0.0: November 26, 2020 [[Release Notes](docs/release-notes/release-notes-v0.10.0.0.md)]
 + v0.9.4.0: June 26, 2020 [[Release Notes](docs/release-notes/release-notes-v0.9.4.0.md)]
 + v0.9.3.1: June 11, 2020 [[Release Notes](docs/release-notes/release-notes-v0.9.3.1.md)]

--- a/docs/release-notes/release-notes-v0.10.0.1.md
+++ b/docs/release-notes/release-notes-v0.10.0.1.md
@@ -1,0 +1,37 @@
+# Pyserini Release Notes (v0.10.0.1)
+
+**Release date: December 2, 2020**
+
++ Improved support for pre-built indexes: added additional indexes, alternate download URLs, and fixed broken `robust04` download link.
++ Added option to specify number of hits in `pyserini.search`.
+
+## Contributors (This Release)
+
+Sorted by number of commits:
+
++ Jimmy Lin ([lintool](https://github.com/lintool))
+
+## All Contributors
+
+Sorted by number of commits, [according to GitHub](https://github.com/castorini/pyserini/graphs/contributors):
+
++ Jimmy Lin ([lintool](https://github.com/lintool))
++ Johnson Han ([x65han](https://github.com/x65han))
++ Stephanie Hu ([stephaniewhoo](https://github.com/stephaniewhoo))
++ Yuqi Liu ([yuki617](https://github.com/yuki617))
++ Zeynep Akkalyoncu Yilmaz ([zeynepakkalyoncu](https://github.com/zeynepakkalyoncu))
++ Chris Kamphuis ([Chriskamphuis](https://github.com/Chriskamphuis))
++ Xinyu Mavis Liu ([x389liu](https://github.com/x389liu))
++ Pepijn Boers ([PepijnBoers](https://github.com/PepijnBoers))
++ Tommaso Teofili ([tteofili](https://github.com/tteofili))
++ Qing Guo ([qguo96](https://github.com/qguo96))
++ Hang Cui ([HangCui0510](https://github.com/HangCui0510))
++ Marko Arezina ([mrkarezina](https://github.com/mrkarezina))
++ Rodrigo Nogueira ([rodrigonogueira4](https://github.com/rodrigonogueira4))
++ Tim Hatch ([thatch](https://github.com/thatch))
++ Yue Zhang ([nsndimt](https://github.com/nsndimt))
++ Jerry Huang ([jhuang265](https://github.com/jhuang265))
++ Alireza Mirzaeiyan ([amirzaeiyan](https://github.com/amirzaeiyan))
++ Adam Yang ([adamyy](https://github.com/adamyy))
++ Jeffrey Chen ([JeffreyCA](https://github.com/JeffreyCA))
++ Dahlia Chehata ([Dahlia-Chehata](https://github.com/Dahlia-Chehata))


### PR DESCRIPTION
The PyPI version had a broken link for downloading Robust04 index - didn't want to leave it broken.