### PR TITLE
Updates to TCT-ColBERT dense retrieval replication

### DIFF
--- a/docs/dense-retrieval.md
+++ b/docs/dense-retrieval.md
@@ -1,7 +1,10 @@
 # Dense Retrieval Replication
 
-Please follow the development installation [here](https://github.com/castorini/pyserini#development-installation) to setup `pyserini`
-It's easy to replicate runs on dense retrieval experiments!
+This guide provides replication instructions for the following dense retrieval work:
+
++ Sheng-Chieh Lin, Jheng-Hong Yang, and Jimmy Lin. [Distilling Dense Representations for Ranking using Tightly-Coupled Teachers.](https://arxiv.org/abs/2010.11386) arXiv:2010.11386, October 2020. 
+
+You'll need a Pyserini [development installation](https://github.com/castorini/pyserini#development-installation) to get started.
 
 ## MS MARCO Passage Ranking
 
@@ -16,34 +19,23 @@ $ python -m pyserini.dsearch --topics msmarco_passage_dev_subset \
 
 To evaluate:
 
-Using official MS MARCO evaluation script:
 ```bash
-$ wget https://www.dropbox.com/s/khsplt2fhqwjs0v/qrels.dev.small.tsv -P collections/msmarco-passage/
-$ python tools/scripts/msmarco/msmarco_eval.py qrels.dev.small.tsv runs/run.msmarco-passage.tct_colbert.hnsw.tsv
-```
-```
+$ python tools/scripts/msmarco/msmarco_eval.py tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt \
+   runs/run.msmarco-passage.tct_colbert.hnsw.tsv
 #####################
 MRR @10: 0.33395142584254184
 QueriesRanked: 6980
 #####################
 ```
-We can also use the official TREC evaluation tool, trec_eval, to compute other metrics than MRR@10. 
+
+We can also use the official TREC evaluation tool `trec_eval` to compute other metrics than MRR@10.
 For that we first need to convert runs and qrels files to the TREC format:
-```
-python tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
-       --input runs/run.msmarco-passage.tct_colbert.hnsw.tsv \
-       --output runs/run.msmarco-passage.tct_colbert.hnsw.trec
+
+```bash
+$ python tools/scripts/msmarco/convert_msmarco_to_trec_run.py --input runs/run.msmarco-passage.tct_colbert.hnsw.tsv --output runs/run.msmarco-passage.tct_colbert.hnsw.trec
                                                             
-python tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \
-       --input collections/msmarco-passage/qrels.dev.small.tsv \
-       --output collections/msmarco-passage/qrels.dev.small.trec
-```
-And run the trec_eval tool:
-```
-tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
- collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.tct_colbert.hnsw.trec
-```
-```
+$ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
+   collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.tct_colbert.hnsw.trec
 map                     all     0.3407
 recall_1000             all     0.9618
 ```
@@ -61,36 +53,25 @@ $ python -m pyserini.dsearch --topics msmarco_passage_dev_subset \
 
 To evaluate:
 
-Using official MS MARCO evaluation script:
 ```bash
-$ wget https://www.dropbox.com/s/khsplt2fhqwjs0v/qrels.dev.small.tsv -P collections/msmarco-passage/
-$ python tools/scripts/msmarco/msmarco_eval.py collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.tct_colbert.bf.tsv
-```
-```
+$ python tools/scripts/msmarco/msmarco_eval.py tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt \
+   runs/run.msmarco-passage.tct_colbert.bf.tsv
 #####################
 MRR @10: 0.3344603629417369
 QueriesRanked: 6980
 #####################
 ```
 
-We can also use the official TREC evaluation tool, trec_eval, to compute other metrics than MRR@10. 
+We can also use the official TREC evaluation tool `trec_eval` to compute other metrics than MRR@10. 
 For that we first need to convert runs and qrels files to the TREC format:
-```
-python tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
-       --input runs/run.msmarco-passage.tct_colbert.bf.tsv \
-       --output runs/run.msmarco-passage.tct_colbert.bf.trec
-                                                            
-python tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \
-       --input collections/msmarco-passage/qrels.dev.small.tsv \
-       --output collections/msmarco-passage/qrels.dev.small.trec
-```
-And run the trec_eval tool:
-```
-tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
- collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.tct_colbert.bf.trec
-```
 
-```
+```bash
+$ python tools/scripts/msmarco/convert_msmarco_to_trec_run.py --input runs/run.msmarco-passage.tct_colbert.bf.tsv --output runs/run.msmarco-passage.tct_colbert.bf.trec
+
+$ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
+    collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.tct_colbert.bf.trec
 map                   	all	0.3412
 recall_1000           	all	0.9637
 ```
+
+You'll notice that hnsw index leads to a small loss in effectiveness.

--- a/pyserini/dsearch/__main__.py
+++ b/pyserini/dsearch/__main__.py
@@ -23,6 +23,10 @@ from tqdm import tqdm
 from pyserini.dsearch import QueryEncoder, SimpleDenseSearcher
 from pyserini.search import get_topics
 
+# Fixes this error: "OMP: Error #15: Initializing libomp.a, but found libomp.dylib already initialized."
+# https://stackoverflow.com/questions/53014306/error-15-initializing-libiomp5-dylib-but-found-libiomp5-dylib-already-initial
+os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
+
 parser = argparse.ArgumentParser(description='Search a Faiss index.')
 parser.add_argument('--index', type=str, metavar='path to index or index name', required=True,
                     help="Path to Faiss index or name of prebuilt index.")


### PR DESCRIPTION
Minor tweaks to get replication working on my Mac.

Primarily for @MXueguang to CR, but need @rodrigonogueira4 or @ronakice for +1 once @MXueguang is happy.

HNSW, efficiency:

```
trial 1: 6980/6980 [05:16<00:00, 22.08it/s]
trial 2: 6980/6980 [05:02<00:00, 23.04it/s]
```

What Xueguang got:

```
#####################
MRR @10: 0.33395142584254184
QueriesRanked: 6980
#####################
```

What I got:

```
#####################
MRR @10: 0.33394187474416553
QueriesRanked: 6980
#####################
```

Small differences in scores.

Brute force, efficiency:

```
trial 1: 582/582 [28:28<00:00,  2.93s/it]
trial 2: 582/582 [27:20<00:00,  2.82s/it]
```

What Xueguang got:

```
#####################
MRR @10: 0.3344603629417369
QueriesRanked: 6980
#####################
```

What I got:

```
#####################
MRR @10: 0.3343958930276968
QueriesRanked: 6980
#####################
```

Small differences in scores.

Not sure what's causing the issue.... perhaps related to https://github.com/castorini/pyserini/issues/257 ?