### PR TITLE
update bm25Vectorizer

### DIFF
--- a/pyserini/vectorizer/_base.py
+++ b/pyserini/vectorizer/_base.py
@@ -16,7 +16,7 @@
 
 import math
 from typing import List
-from sklearn import preprocessing
+from sklearn.preprocessing import normalize
 
 from scipy.sparse import csr_matrix
 
@@ -132,7 +132,7 @@ class TfidfVectorizer(Vectorizer):
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
 
         if norm:
-            return preprocessing.normalize(vectors, norm=norm)
+            return normalize(vectors, norm=norm)
         return vectors
 
 
@@ -190,5 +190,5 @@ class BM25Vectorizer(Vectorizer):
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
 
         if norm:
-            return preprocessing.normalize(vectors, norm=norm)
+            return normalize(vectors, norm=norm)
         return vectors

--- a/pyserini/vectorizer/_base.py
+++ b/pyserini/vectorizer/_base.py
@@ -24,6 +24,7 @@ from pyserini import index, search
 from pyserini.analysis import Analyzer, get_lucene_analyzer
 from tqdm import tqdm
 
+
 class Vectorizer:
     """Base class for vectorizer implemented on top of Pyserini.
 
@@ -134,9 +135,9 @@ class BM25Vectorizer(Vectorizer):
 
     def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
         super().__init__(lucene_index_path, min_df, verbose)
-        self.idf_ = {}
-        for term in self.index_reader.terms():
-            self.idf_[term.term] = math.log(self.num_docs / term.df)
+        # self.idf_ = {}
+        # for term in self.index_reader.terms():
+        #     self.idf_[term.term] = math.log(self.num_docs-term.df + 0.5 / (term.df+0.5))
 
     def get_vectors(self, docids: List[str]):
         """Get the BM25 vectors given a list of docids
@@ -172,16 +173,16 @@ class BM25Vectorizer(Vectorizer):
                 matrix_data.append(bm25_weight)
 
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
-        return normalize(vectors, norm='l2')
+        return vectors  # normalize(vectors, norm='l2')
 
     def get_query_vector(self, query: str):
         matrix_row, matrix_col, matrix_data = [], [], []
         tokens = self.analyzer.analyze(query)
         for term in tokens:
             if term in self.vocabulary_:
-                bm25_weight = self.idf_[term]
+                # bm25_weight = self.idf_[term]
                 matrix_row.append(0)
                 matrix_col.append(self.term_to_index[term])
-                matrix_data.append(bm25_weight)
+                matrix_data.append(1)  # bm25_weight)
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(1, self.vocabulary_size))
-        return normalize(vectors, norm='l2')
+        return vectors  # normalize(vectors, norm='l2')

--- a/pyserini/vectorizer/_base.py
+++ b/pyserini/vectorizer/_base.py
@@ -135,9 +135,6 @@ class BM25Vectorizer(Vectorizer):
 
     def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
         super().__init__(lucene_index_path, min_df, verbose)
-        # self.idf_ = {}
-        # for term in self.index_reader.terms():
-        #     self.idf_[term.term] = math.log(self.num_docs-term.df + 0.5 / (term.df+0.5))
 
     def get_vectors(self, docids: List[str]):
         """Get the BM25 vectors given a list of docids
@@ -180,9 +177,8 @@ class BM25Vectorizer(Vectorizer):
         tokens = self.analyzer.analyze(query)
         for term in tokens:
             if term in self.vocabulary_:
-                # bm25_weight = self.idf_[term]
                 matrix_row.append(0)
                 matrix_col.append(self.term_to_index[term])
-                matrix_data.append(1)  # bm25_weight)
+                matrix_data.append(1)
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(1, self.vocabulary_size))
         return vectors  # normalize(vectors, norm='l2')

--- a/pyserini/vectorizer/_base.py
+++ b/pyserini/vectorizer/_base.py
@@ -16,6 +16,7 @@
 
 import math
 from typing import List
+from sklearn import preprocessing
 
 from scipy.sparse import csr_matrix
 
@@ -94,18 +95,20 @@ class TfidfVectorizer(Vectorizer):
         for term in self.index_reader.terms():
             self.idf_[term.term] = math.log(self.num_docs / term.df)
 
-    def get_vectors(self, docids: List[str]):
+    def get_vectors(self, docids: List[str], normalize: bool = True):
         """Get the tf-idf vectors given a list of docids
 
         Parameters
         ----------
+        normalize : bool
+            L2 Normalize the sparse matrix
         docids : List[str]
             The piece of text to analyze.
 
         Returns
         -------
         csr_matrix
-            L2 normalized sparse matrix representation of tf-idf vectors
+            Sparse matrix representation of tf-idf vectors
         """
         matrix_row, matrix_col, matrix_data = [], [], []
         num_docs = len(docids)
@@ -127,6 +130,9 @@ class TfidfVectorizer(Vectorizer):
                 matrix_data.append(tfidf)
 
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
+
+        if normalize:
+            return preprocessing.normalize(vectors, norm='l2')
         return vectors
 
 
@@ -146,18 +152,20 @@ class BM25Vectorizer(Vectorizer):
     def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
         super().__init__(lucene_index_path, min_df, verbose)
 
-    def get_vectors(self, docids: List[str]):
+    def get_vectors(self, docids: List[str], normalize: bool = True):
         """Get the BM25 vectors given a list of docids
 
         Parameters
         ----------
+        normalize : bool
+            L2 Normalize the sparse matrix
         docids : List[str]
             The piece of text to analyze.
 
         Returns
         -------
         csr_matrix
-            L2 normalized sparse matrix representation of BM25 vectors
+            Sparse matrix representation of BM25 vectors
         """
         matrix_row, matrix_col, matrix_data = [], [], []
         num_docs = len(docids)
@@ -180,4 +188,7 @@ class BM25Vectorizer(Vectorizer):
                 matrix_data.append(bm25_weight)
 
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
+
+        if normalize:
+            return preprocessing.normalize(vectors, norm='l2')
         return vectors

--- a/pyserini/vectorizer/_base.py
+++ b/pyserini/vectorizer/_base.py
@@ -15,7 +15,7 @@
 #
 
 import math
-from typing import List
+from typing import List, Optional
 from sklearn.preprocessing import normalize
 
 from scipy.sparse import csr_matrix
@@ -95,7 +95,7 @@ class TfidfVectorizer(Vectorizer):
         for term in self.index_reader.terms():
             self.idf_[term.term] = math.log(self.num_docs / term.df)
 
-    def get_vectors(self, docids: List[str], norm: str = 'l2'):
+    def get_vectors(self, docids: List[str], norm: Optional[str] = 'l2'):
         """Get the tf-idf vectors given a list of docids
 
         Parameters
@@ -152,7 +152,7 @@ class BM25Vectorizer(Vectorizer):
     def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
         super().__init__(lucene_index_path, min_df, verbose)
 
-    def get_vectors(self, docids: List[str], norm: str = 'l2'):
+    def get_vectors(self, docids: List[str], norm: Optional[str] = 'l2'):
         """Get the BM25 vectors given a list of docids
 
         Parameters

--- a/pyserini/vectorizer/_base.py
+++ b/pyserini/vectorizer/_base.py
@@ -95,13 +95,13 @@ class TfidfVectorizer(Vectorizer):
         for term in self.index_reader.terms():
             self.idf_[term.term] = math.log(self.num_docs / term.df)
 
-    def get_vectors(self, docids: List[str], normalize: bool = True):
+    def get_vectors(self, docids: List[str], norm: str = 'l2'):
         """Get the tf-idf vectors given a list of docids
 
         Parameters
         ----------
-        normalize : bool
-            L2 Normalize the sparse matrix
+        norm : str
+            Normalize the sparse matrix
         docids : List[str]
             The piece of text to analyze.
 
@@ -131,8 +131,8 @@ class TfidfVectorizer(Vectorizer):
 
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
 
-        if normalize:
-            return preprocessing.normalize(vectors, norm='l2')
+        if norm:
+            return preprocessing.normalize(vectors, norm=norm)
         return vectors
 
 
@@ -152,13 +152,13 @@ class BM25Vectorizer(Vectorizer):
     def __init__(self, lucene_index_path: str, min_df: int = 1, verbose: bool = False):
         super().__init__(lucene_index_path, min_df, verbose)
 
-    def get_vectors(self, docids: List[str], normalize: bool = True):
+    def get_vectors(self, docids: List[str], norm: str = 'l2'):
         """Get the BM25 vectors given a list of docids
 
         Parameters
         ----------
-        normalize : bool
-            L2 Normalize the sparse matrix
+        norm : str
+            Normalize the sparse matrix
         docids : List[str]
             The piece of text to analyze.
 
@@ -189,6 +189,6 @@ class BM25Vectorizer(Vectorizer):
 
         vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(num_docs, self.vocabulary_size))
 
-        if normalize:
-            return preprocessing.normalize(vectors, norm='l2')
+        if norm:
+            return preprocessing.normalize(vectors, norm=norm)
         return vectors

--- a/tests/test_index_reader.py
+++ b/tests/test_index_reader.py
@@ -47,7 +47,7 @@ class TestIndexUtils(unittest.TestCase):
         self.searcher = search.SimpleSearcher(self.index_path)
         self.index_reader = index.IndexReader(self.index_path)
 
-    def test_tfidf_vectorizer(self):
+    def test_tfidf_vectorizer_train(self):
         vectorizer = TfidfVectorizer(self.index_path, min_df=5)
         train_docs = ['CACM-0239', 'CACM-0440', 'CACM-3168', 'CACM-3169']
         train_labels = [1, 1, 0, 0]
@@ -62,7 +62,7 @@ class TestIndexUtils(unittest.TestCase):
         self.assertAlmostEqual(0.51837413, pred[1][0], places=8)
         self.assertAlmostEqual(0.48162587, pred[1][1], places=8)
 
-    def test_bm25_vectorizer(self):
+    def test_bm25_vectorizer_train(self):
         vectorizer = BM25Vectorizer(self.index_path, min_df=5)
         train_docs = ['CACM-0239', 'CACM-0440', 'CACM-3168', 'CACM-3169']
         train_labels = [1, 1, 0, 0]
@@ -76,6 +76,25 @@ class TestIndexUtils(unittest.TestCase):
         self.assertAlmostEqual(0.5370251, pred[0][1], places=8)
         self.assertAlmostEqual(0.48288416, pred[1][0], places=8)
         self.assertAlmostEqual(0.51711584, pred[1][1], places=8)
+
+    def test_tfidf_vectorizer(self):
+        vectorizer = TfidfVectorizer(self.index_path, min_df=5)
+        result = vectorizer.get_vectors(['CACM-0239', 'CACM-0440'], norm=None)
+        self.assertAlmostEqual(result[0, 190], 2.907369334264736, places=8)
+        self.assertAlmostEqual(result[1, 391], 0.07516490235060004, places=8)
+
+    def test_bm25_vectorizer(self):
+        vectorizer = BM25Vectorizer(self.index_path, min_df=5)
+        result = vectorizer.get_vectors(['CACM-0239', 'CACM-0440'], norm=None)
+        self.assertAlmostEqual(result[0, 190], 1.7513844966888428, places=8)
+        self.assertAlmostEqual(result[1, 391], 0.03765463829040527, places=8)
+
+    def test_vectorizer_query(self):
+        vectorizer = BM25Vectorizer(self.index_path, min_df=5)
+        result = vectorizer.get_query_vector('this is a query to test query vector')
+        self.assertEqual(result[0, 2703], 2)
+        self.assertEqual(result[0, 3078], 1)
+        self.assertEqual(result[0, 3204], 1)
 
     def test_terms_count(self):
         # We're going to iterate through the index and make sure we have the correct number of terms.


### PR DESCRIPTION
- fix bug: Each time of initializing, the BM25 Vectorizer gives vocabulary list with different order, which will make results not replicable. Solved by sort the vocabulary list.
- change: remove `normalize`. If we want to normalize, it should be done externally.
- add: `get_query_vector`