### PR TITLE
Replicated MS MARCO passage/document ranking results with Pyserini

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -133,3 +133,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results replicated by [@jrzhang12](https://github.com/jrzhang12) on 2021-01-03 (commit [`7caedfc`](https://github.com/castorini/pyserini/commit/7caedfc150f916de302297406c45dead27b475ba))
 + Results replicated by [@HEC2018](https://github.com/HEC2018) on 2021-01-04 (commit [`46a6d47`](https://github.com/castorini/pyserini/commit/46a6d472267a559152495d004c2a12f8e95e53f0))
 + Results replicated by [@KaiSun314](https://github.com/KaiSun314) on 2021-01-08 (commit [`aeec31f`](https://github.com/castorini/pyserini/commit/aeec31fbe17d39ecf3081597b4832f5af57ea549))
++ Results replicated by [@yemiliey](https://github.com/yemiliey) on 2021-01-18 (commit [`98f3236`](https://github.com/castorini/pyserini/commit/98f323659c8a0a5d8ef26bb3f6768458a34e3eb9))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -129,3 +129,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results replicated by [@jrzhang12](https://github.com/jrzhang12) on 2021-01-03 (commit [`7caedfc`](https://github.com/castorini/pyserini/commit/7caedfc150f916de302297406c45dead27b475ba))
 + Results replicated by [@HEC2018](https://github.com/HEC2018) on 2021-01-04 (commit [`46a6d47`](https://github.com/castorini/pyserini/commit/46a6d472267a559152495d004c2a12f8e95e53f0))
 + Results replicated by [@KaiSun314](https://github.com/KaiSun314) on 2021-01-08 (commit [`aeec31f`](https://github.com/castorini/pyserini/commit/aeec31fbe17d39ecf3081597b4832f5af57ea549))
++ Results replicated by [@yemiliey](https://github.com/yemiliey) on 2021-01-18 (commit [`98f3236`](https://github.com/castorini/pyserini/commit/98f323659c8a0a5d8ef26bb3f6768458a34e3eb9))


### PR DESCRIPTION
# Environment
- Google Colab (Python3 Google Compute Engine Backend)
- Python 3.6

**Replicated results are exactly the same as the given results**

# Passage Replication Results

> Given Results

![Screenshot from 2021-01-17 04-24-16](https://user-images.githubusercontent.com/35389425/104979929-71f84680-59d3-11eb-81af-4c2236216617.png)

>My Results

![Screenshot from 2021-01-17 04-24-28](https://user-images.githubusercontent.com/35389425/104979967-89cfca80-59d3-11eb-91f3-4660e1a9df11.png)

# Document Replication Results
>Given Results

![Screenshot from 2021-01-17 03-59-12](https://user-images.githubusercontent.com/35389425/104979801-23e34300-59d3-11eb-8fbe-1e7e837f28da.png)

>My Results

![Screenshot from 2021-01-17 03-58-57](https://user-images.githubusercontent.com/35389425/104979301-f3e77000-59d1-11eb-9136-1b2bf224b27d.png)
