### PR TITLE
Fixing issues where Pyserini failed to produce metrices with TREC evaluation tool on MS MAROC passgae retrieval

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -104,7 +104,7 @@ For that we first need to convert the run file into TREC format:
 $ python tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
    --input runs/run.msmarco-passage.bm25tuned.txt --output runs/run.msmarco-passage.bm25tuned.trec
 $ python tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \
-   --input tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt --output tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.trec
+   --input tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt --output collections/msmarco-passage/qrels.dev.small.trec
 ```
 
 

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -103,13 +103,16 @@ For that we first need to convert the run file into TREC format:
 ```bash
 $ python tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
    --input runs/run.msmarco-passage.bm25tuned.txt --output runs/run.msmarco-passage.bm25tuned.trec
+$ python tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \
+   --input tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt --output tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.trec
 ```
+
 
 And then run the `trec_eval` tool:
 
 ```bash
 $ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
-   collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.bm25tuned.trec
+   tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.trec runs/run.msmarco-passage.bm25tuned.trec
 map                   	all	0.1957
 recall_1000           	all	0.8573
 ```

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -112,7 +112,7 @@ And then run the `trec_eval` tool:
 
 ```bash
 $ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
-   tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.trec runs/run.msmarco-passage.bm25tuned.trec
+   collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.bm25tuned.trec
 map                   	all	0.1957
 recall_1000           	all	0.8573
 ```


### PR DESCRIPTION
It seems that the file changes from `runs/msmarco-passage/qrels.dev.small.tsv` to `tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt`. Therefore, the trec file name need to be changed to `tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.trec` when running the `trec_eval` tool

In addition, the documentation seems to be missing the step running `convert_msmarco_to_trec_qrels.py`, which exists in the previous version.

I think the previous version of the documentation should be able to replicate the results. However, to accommodate the current naming of the files, I update the script accordingly and I am able to replicate the same result as mentioned in the documentation.
![Capture3](https://user-images.githubusercontent.com/28650735/105568865-c9b3ec00-5d0a-11eb-892e-7d6ee8ed0d57.PNG)
