### PR TITLE
Cleaner way to test TCT-ColBERT wrt OS differences

### DIFF
--- a/integrations/test_tct_colbert_encoded.py
+++ b/integrations/test_tct_colbert_encoded.py
@@ -49,11 +49,8 @@ class TestSearchIntegration(unittest.TestCase):
         score = parse_score(stdout, "MRR @10")
         self.assertEqual(status, 0)
         self.assertEqual(stderr, '')
-        # We get a small difference in scores on macOS (vs. Linux):
-        if platform.system() == 'Darwin':
-            self.assertAlmostEqual(score, 0.3349, places=4)
-        else:
-            self.assertAlmostEqual(score, 0.3350, places=4)
+        # We get a small difference in scores on macOS vs. Linux, better way to check:
+        self.assertAlmostEqual(score, 0.3350, delta=0.0001)
 
     def test_msmarco_passage_tct_colbert_hnsw(self):
         output_file = 'test_run.msmarco-passage.tct_colbert.hnsw.tsv'

--- a/integrations/test_tct_colbert_otf.py
+++ b/integrations/test_tct_colbert_otf.py
@@ -50,11 +50,8 @@ class TestSearchIntegration(unittest.TestCase):
         score = parse_score(stdout, "MRR @10")
         self.assertEqual(status, 0)
         self.assertEqual(stderr, '')
-        # We get a small difference in scores on macOS (vs. Linux):
-        if platform.system() == 'Darwin':
-            self.assertAlmostEqual(score, 0.3350, places=4)
-        else:
-            self.assertAlmostEqual(score, 0.3349, places=4)
+        # We get a small difference in scores on macOS vs. Linux, better way to check:
+        self.assertAlmostEqual(score, 0.3350, delta=0.0001)
 
     def test_msmarco_passage_tct_colbert_hnsw_otf(self):
         output_file = 'test_run.msmarco-passage.tct_colbert.hnsw-otf.tsv'


### PR DESCRIPTION
`test_tct_colbert_otf.py` is failing right now due to rounding difference - 0.3349 vs 0.3350 - on a Linux machine. This is a cleaner way to test.