### PR TITLE
Change WapoGenerator to WashingtonPostGenerator

### DIFF
--- a/pyserini/index/_base.py
+++ b/pyserini/index/_base.py
@@ -55,7 +55,7 @@ class JGenerators(Enum):
     AclAnthologyGenerator = autoclass('io.anserini.index.generator.AclAnthologyGenerator')
     DefaultLuceneDocumentGenerator = autoclass('io.anserini.index.generator.DefaultLuceneDocumentGenerator')
     TweetGenerator = autoclass('io.anserini.index.generator.TweetGenerator')
-    WapoGenerator = autoclass('io.anserini.index.generator.WashingtonPostGenerator')
+    WashingtonPostGenerator = autoclass('io.anserini.index.generator.WashingtonPostGenerator')
 
 
 class Generator:


### PR DESCRIPTION
This PR changes the name WapoGenerator to WashingtonPostGenerator to be consistent with Anserini names.

Fix #406