### PR TITLE
specifying cache directory to from_prebuilt_index function

### DIFF
--- a/pyserini/search/_searcher.py
+++ b/pyserini/search/_searcher.py
@@ -51,14 +51,15 @@ class SimpleSearcher:
         self.num_docs = self.object.getTotalNumDocuments()
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str):
+    def from_prebuilt_index(cls, prebuilt_index_name: str, cache_dir: str = None):
         """Build a searcher from a pre-built index; download the index if necessary.
 
         Parameters
         ----------
         prebuilt_index_name : str
             Prebuilt index name.
-
+        cache_dir : str
+            Path to a directory in which a downloaded index should be cached if the standard cache should not be used.
         Returns
         -------
         SimpleSearcher
@@ -66,7 +67,7 @@ class SimpleSearcher:
         """
         print(f'Attempting to initialize pre-built index {prebuilt_index_name}.')
         try:
-            index_dir = download_prebuilt_index(prebuilt_index_name)
+            index_dir = download_prebuilt_index(prebuilt_index_name, cache_dir)
         except ValueError as e:
             print(str(e))
             return None

--- a/pyserini/search/_searcher.py
+++ b/pyserini/search/_searcher.py
@@ -51,15 +51,14 @@ class SimpleSearcher:
         self.num_docs = self.object.getTotalNumDocuments()
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str, cache_dir: str = None):
+    def from_prebuilt_index(cls, prebuilt_index_name: str):
         """Build a searcher from a pre-built index; download the index if necessary.
 
         Parameters
         ----------
         prebuilt_index_name : str
             Prebuilt index name.
-        cache_dir : str
-            Path to a directory in which a downloaded index should be cached if the standard cache should not be used.
+
         Returns
         -------
         SimpleSearcher
@@ -67,7 +66,7 @@ class SimpleSearcher:
         """
         print(f'Attempting to initialize pre-built index {prebuilt_index_name}.')
         try:
-            index_dir = download_prebuilt_index(prebuilt_index_name, cache_dir)
+            index_dir = download_prebuilt_index(prebuilt_index_name)
         except ValueError as e:
             print(str(e))
             return None

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -92,12 +92,15 @@ def get_cache_home():
     return os.path.expanduser(os.path.join(f'~{os.path.sep}.cache', "pyserini"))
 
 
-def download_and_unpack_index(url, index_directory='indexes', force=False, verbose=True, prebuilt=False, md5=None):
+def download_and_unpack_index(url, cache_dir, index_directory='indexes', force=False, verbose=True, prebuilt=False, md5=None):
     index_name = url.split('/')[-1]
     index_name = re.sub('''.tar.gz.*$''', '', index_name)
 
     if prebuilt:
-        index_directory = os.path.join(get_cache_home(), index_directory)
+        if cache_dir is not None:
+            index_directory = os.path.join(cache_dir, index_directory)
+        else:
+            index_directory = os.path.join(get_cache_home(), index_directory)
         index_path = os.path.join(index_directory, f'{index_name}.{md5}')
 
         if not os.path.exists(index_directory):
@@ -174,7 +177,7 @@ def get_dense_indexes_info():
         print(df)
 
 
-def download_prebuilt_index(index_name, force=False, verbose=True, mirror=None):
+def download_prebuilt_index(index_name, cache_dir, force=False, verbose=True, mirror=None):
     if index_name not in INDEX_INFO and index_name not in DINDEX_INFO:
         raise ValueError(f'Unrecognized index name {index_name}')
     if index_name in INDEX_INFO:
@@ -184,7 +187,7 @@ def download_prebuilt_index(index_name, force=False, verbose=True, mirror=None):
     index_md5 = target_index['md5']
     for url in target_index['urls']:
         try:
-            return download_and_unpack_index(url, prebuilt=True, md5=index_md5)
+            return download_and_unpack_index(url, cache_dir, prebuilt=True, md5=index_md5)
         except HTTPError:
             print(f'Unable to download pre-built index at {url}, trying next URL...')
     raise ValueError(f'Unable to download pre-built index at any known URLs.')

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -89,18 +89,17 @@ def download_url(url, save_dir, md5=None, force=False, verbose=True):
 
 
 def get_cache_home():
+    if os.environ["PYSERINI_CACHE"]:
+        return os.environ["PYSERINI_CACHE"]
     return os.path.expanduser(os.path.join(f'~{os.path.sep}.cache', "pyserini"))
 
 
-def download_and_unpack_index(url, cache_dir, index_directory='indexes', force=False, verbose=True, prebuilt=False, md5=None):
+def download_and_unpack_index(url, index_directory='indexes', force=False, verbose=True, prebuilt=False, md5=None):
     index_name = url.split('/')[-1]
     index_name = re.sub('''.tar.gz.*$''', '', index_name)
 
     if prebuilt:
-        if cache_dir is not None:
-            index_directory = os.path.join(cache_dir, index_directory)
-        else:
-            index_directory = os.path.join(get_cache_home(), index_directory)
+        index_directory = os.path.join(get_cache_home(), index_directory)
         index_path = os.path.join(index_directory, f'{index_name}.{md5}')
 
         if not os.path.exists(index_directory):
@@ -177,7 +176,7 @@ def get_dense_indexes_info():
         print(df)
 
 
-def download_prebuilt_index(index_name, cache_dir, force=False, verbose=True, mirror=None):
+def download_prebuilt_index(index_name, force=False, verbose=True, mirror=None):
     if index_name not in INDEX_INFO and index_name not in DINDEX_INFO:
         raise ValueError(f'Unrecognized index name {index_name}')
     if index_name in INDEX_INFO:
@@ -187,7 +186,7 @@ def download_prebuilt_index(index_name, cache_dir, force=False, verbose=True, mi
     index_md5 = target_index['md5']
     for url in target_index['urls']:
         try:
-            return download_and_unpack_index(url, cache_dir, prebuilt=True, md5=index_md5)
+            return download_and_unpack_index(url, prebuilt=True, md5=index_md5)
         except HTTPError:
             print(f'Unable to download pre-built index at {url}, trying next URL...')
     raise ValueError(f'Unable to download pre-built index at any known URLs.')


### PR DESCRIPTION
To solve issue [#414](https://github.com/castorini/pyserini/issues/414), I added cache_dir argument to the function from_prebuilt_index to specify the wanted cache directory. The same keyword has been used in huggingface transformers to specify the directory of cached models.