### PR TITLE
Improvements to data downloading, moving away from Dropbox

### DIFF
--- a/integrations/test_simple_fusion_search_integration.py
+++ b/integrations/test_simple_fusion_search_integration.py
@@ -28,16 +28,11 @@ from pyserini.util import download_url, download_and_unpack_index
 
 class TestSearchIntegration(unittest.TestCase):
     def setUp(self):
-        download_and_unpack_index(
-            'https://www.dropbox.com/s/jdsc6wu0vbumpup/lucene-index-cord19-abstract-2020-05-01.tar.gz?dl=1')
+        download_and_unpack_index('https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-abstract-2020-05-01.tar.gz')
+        download_and_unpack_index('https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-full-text-2020-05-01.tar.gz')
+        download_and_unpack_index('https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-paragraph-2020-05-01.tar.gz')
 
-        download_and_unpack_index(
-            'https://www.dropbox.com/s/ouvp7zyqsp9y9gh/lucene-index-cord19-full-text-2020-05-01.tar.gz?dl=1')
-
-        download_and_unpack_index(
-            'https://www.dropbox.com/s/e1118vjuf58ojt4/lucene-index-cord19-paragraph-2020-05-01.tar.gz?dl=1')
-
-        download_url('https://www.dropbox.com/s/wqb0vhxp98g7dxh/anserini.covid-r2.fusion1.txt.gz?dl=1', 'runs')
+        download_url('https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round2/anserini.covid-r2.fusion1.txt.gz', 'runs')
         # from https://stackoverflow.com/questions/31028815/how-to-unzip-gz-file-using-python
         with gzip.open('runs/anserini.covid-r2.fusion1.txt.gz', 'rb') as f_in:
             with open('runs/anserini.covid-r2.fusion1.txt', 'wb') as f_out:

--- a/integrations/test_trec_covid_stored_runs.py
+++ b/integrations/test_trec_covid_stored_runs.py
@@ -26,60 +26,60 @@ from pyserini.util import download_url
 class TestSearchIntegration(unittest.TestCase):
     def setUp(self):
         self.round3_runs = {
-            'https://www.dropbox.com/s/g80cqdxud1l06wq/anserini.covid-r3.abstract.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.abstract.qq.bm25.txt':
                 'd08d85c87e30d6c4abf54799806d282f',
-            'https://www.dropbox.com/s/sjcnxq7h0a3j3xz/anserini.covid-r3.abstract.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.abstract.qdel.bm25.txt':
                 'd552dff90995cd860a5727637f0be4d1',
-            'https://www.dropbox.com/s/4bjx35sgosu0jz0/anserini.covid-r3.full-text.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.full-text.qq.bm25.txt':
                 '6c9f4c09d842b887262ca84d61c61a1f',
-            'https://www.dropbox.com/s/mjt7y1ywae784d0/anserini.covid-r3.full-text.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.full-text.qdel.bm25.txt':
                 'c5f9db7733c72eea78ece2ade44d3d35',
-            'https://www.dropbox.com/s/qwn7jd8vg2chjik/anserini.covid-r3.paragraph.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.paragraph.qq.bm25.txt':
                 '872673b3e12c661748d8899f24d3ba48',
-            'https://www.dropbox.com/s/2928i60fj2i09bt/anserini.covid-r3.paragraph.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.paragraph.qdel.bm25.txt':
                 'c1b966e4c3f387b6810211f339b35852',
-            'https://www.dropbox.com/s/6vk5iohqf81iy8b/anserini.covid-r3.fusion1.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.fusion1.txt':
                 '61cbd73c6e60ba44f18ce967b5b0e5b3',
-            'https://www.dropbox.com/s/n09595t1eqymkks/anserini.covid-r3.fusion2.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.fusion2.txt':
                 'd7eabf3dab840104c88de925e918fdab',
-            'https://www.dropbox.com/s/ypoe9tgwef17rak/anserini.final-r3.fusion1.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.final-r3.fusion1.txt':
                 'c1caf63a9c3b02f0b12e233112fc79a6',
-            'https://www.dropbox.com/s/uvfrssp6nw2v2jl/anserini.final-r3.fusion2.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.final-r3.fusion2.txt':
                 '12679197846ed77306ecb2ca7895b011',
-            'https://www.dropbox.com/s/2wrg7ceaca3n7ac/anserini.final-r3.rf.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.final-r3.rf.txt':
                 '7192a08c5275b59d5ef18395917ff694',
-            'https://www.dropbox.com/s/ilqgky1tti0zvez/anserini.final-r3.fusion1.post-processed.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.final-r3.fusion1.post-processed.txt':
                 'f7c69c9bff381a847af86e5a8daf7526',
-            'https://www.dropbox.com/s/ue3z6xxxca9krkb/anserini.final-r3.fusion2.post-processed.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.final-r3.fusion2.post-processed.txt':
                 '84c5fd2c7de0a0282266033ac4f27c22',
-            'https://www.dropbox.com/s/95vk831wp1ldnpm/anserini.final-r3.rf.post-processed.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.final-r3.rf.post-processed.txt':
                 '3e79099639a9426cb53afe7066239011'
         }
 
         self.round4_runs = {
-            'https://www.dropbox.com/s/mf79huhxfy96g6i/anserini.covid-r4.abstract.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.abstract.qq.bm25.txt':
                 '56ac5a0410e235243ca6e9f0f00eefa1',
-            'https://www.dropbox.com/s/4zau6ejrkvgn9m7/anserini.covid-r4.abstract.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.abstract.qdel.bm25.txt':
                 '115d6d2e308b47ffacbc642175095c74',
-            'https://www.dropbox.com/s/bpdopie6gqffv0w/anserini.covid-r4.full-text.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.full-text.qq.bm25.txt':
                 'af0d10a5344f4007e6781e8d2959eb54',
-            'https://www.dropbox.com/s/rh0uy71ogbpas0v/anserini.covid-r4.full-text.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.full-text.qdel.bm25.txt':
                 '594d469b8f45cf808092a3d8e870eaf5',
-            'https://www.dropbox.com/s/ifkjm8ff8g2aoh1/anserini.covid-r4.paragraph.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.paragraph.qq.bm25.txt':
                 '6f468b7b60aaa05fc215d237b5475aec',
-            'https://www.dropbox.com/s/keuogpx1dzinsgy/anserini.covid-r4.paragraph.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.paragraph.qdel.bm25.txt':
                 'b7b39629c12573ee0bfed8687dacc743',
-            'https://www.dropbox.com/s/zjc0069do0a4gu3/anserini.covid-r4.fusion1.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.fusion1.txt':
                 '8ae9d1fca05bd1d9bfe7b24d1bdbe270',
-            'https://www.dropbox.com/s/qekc9vr3oom777n/anserini.covid-r4.fusion2.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.fusion2.txt':
                 'e1894209c815c96c6ddd4cacb578261a',
-            'https://www.dropbox.com/s/2jx27rh3lknps9q/anserini.covid-r4.abstract.qdel.bm25%2Brm3Rf.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.abstract.qdel.bm25%2Brm3Rf.txt':
                 '9d954f31e2f07e11ff559bcb14ef16af',
-            'https://www.dropbox.com/s/g3giixyusk4tzro/anserini.final-r4.fusion1.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.final-r4.fusion1.txt':
                 'a8ab52e12c151012adbfc8e37d666760',
-            'https://www.dropbox.com/s/z4wbqj9gfos8wln/anserini.final-r4.fusion2.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.final-r4.fusion2.txt':
                 '1500104c928f463f38e76b58b91d4c07',
-            'https://www.dropbox.com/s/28w83b07yzndlbg/anserini.final-r4.rf.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.final-r4.rf.txt':
                 '41d746eb86a99d2f33068ebc195072cd'
         }
 

--- a/integrations/test_verify_rrf.py
+++ b/integrations/test_verify_rrf.py
@@ -32,29 +32,29 @@ from pyserini.util import download_url
 class TestSearchIntegration(unittest.TestCase):
     def setUp(self):
         self.runs = {
-            'https://www.dropbox.com/s/g80cqdxud1l06wq/anserini.covid-r3.abstract.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.abstract.qq.bm25.txt':
                 'd08d85c87e30d6c4abf54799806d282f',
-            'https://www.dropbox.com/s/sjcnxq7h0a3j3xz/anserini.covid-r3.abstract.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.abstract.qdel.bm25.txt':
                 'd552dff90995cd860a5727637f0be4d1',
-            'https://www.dropbox.com/s/4bjx35sgosu0jz0/anserini.covid-r3.full-text.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.full-text.qq.bm25.txt':
                 '6c9f4c09d842b887262ca84d61c61a1f',
-            'https://www.dropbox.com/s/mjt7y1ywae784d0/anserini.covid-r3.full-text.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.full-text.qdel.bm25.txt':
                 'c5f9db7733c72eea78ece2ade44d3d35',
-            'https://www.dropbox.com/s/qwn7jd8vg2chjik/anserini.covid-r3.paragraph.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.paragraph.qq.bm25.txt':
                 '872673b3e12c661748d8899f24d3ba48',
-            'https://www.dropbox.com/s/2928i60fj2i09bt/anserini.covid-r3.paragraph.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round3/anserini.covid-r3.paragraph.qdel.bm25.txt':
                 'c1b966e4c3f387b6810211f339b35852',
-            'https://www.dropbox.com/s/mf79huhxfy96g6i/anserini.covid-r4.abstract.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.abstract.qq.bm25.txt':
                 '56ac5a0410e235243ca6e9f0f00eefa1',
-            'https://www.dropbox.com/s/4zau6ejrkvgn9m7/anserini.covid-r4.abstract.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.abstract.qdel.bm25.txt':
                 '115d6d2e308b47ffacbc642175095c74',
-            'https://www.dropbox.com/s/bpdopie6gqffv0w/anserini.covid-r4.full-text.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.full-text.qq.bm25.txt':
                 'af0d10a5344f4007e6781e8d2959eb54',
-            'https://www.dropbox.com/s/rh0uy71ogbpas0v/anserini.covid-r4.full-text.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.full-text.qdel.bm25.txt':
                 '594d469b8f45cf808092a3d8e870eaf5',
-            'https://www.dropbox.com/s/ifkjm8ff8g2aoh1/anserini.covid-r4.paragraph.qq.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.paragraph.qq.bm25.txt':
                 '6f468b7b60aaa05fc215d237b5475aec',
-            'https://www.dropbox.com/s/keuogpx1dzinsgy/anserini.covid-r4.paragraph.qdel.bm25.txt?dl=1':
+            'https://git.uwaterloo.ca/jimmylin/covidex-trec-covid-runs/raw/master/round4/anserini.covid-r4.paragraph.qdel.bm25.txt':
                 'b7b39629c12573ee0bfed8687dacc743',
         }
 

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -395,6 +395,7 @@ INDEX_INFO = {
 DINDEX_INFO = {
     "msmarco-passage-tct_colbert-hnsw": {
         "description": "MS MARCO passage corpus encoded by TCT-ColBERT and indexed as HNSW index",
+        "filename": "dindex-msmarco-passage-tct_colbert-hnsw-20210112-be7119.tar.gz",
         "urls": [
             "https://www.dropbox.com/s/xrsjn38lk3axfdd/dindex-msmarco-passage-tct_colbert-hnsw-20210112-be7119.tar.gz?dl=1",
         ],
@@ -405,7 +406,9 @@ DINDEX_INFO = {
     },
     "msmarco-passage-tct_colbert-bf": {
         "description": "MS MARCO passage corpus encoded by TCT-ColBERT and indexed as brute force index",
+        "filename": "dindex-msmarco-passage-tct_colbert-bf-20210112-be7119.tar.gz",
         "urls": [
+            "https://vault.cs.uwaterloo.ca/s/7qDCqLep547Gc2Z/download",
             "https://www.dropbox.com/s/sgmugleqwwirx3n/dindex-msmarco-passage-tct_colbert-bf-20210112-be7119.tar.gz?dl=1",
         ],
         "md5": "7312e0e7acec2a686e994902ca064fc5",
@@ -415,6 +418,7 @@ DINDEX_INFO = {
     },
     "msmarco-doc-tct_colbert-bf": {
         "description": "MS MARCO document corpus encoded by TCT-ColBERT and indexed as brute force index",
+        "filename": "dindex-msmarco-doc-tct_colbert-bf-20210112-be7119.tar.gz",
         "urls": [
             "https://www.dropbox.com/s/jse0j82l4ouqdna/dindex-msmarco-doc-tct_colbert-bf-20210112-be7119.tar.gz?dl=1",
         ],
@@ -425,6 +429,7 @@ DINDEX_INFO = {
     },
     "wikipedia-dpr-multi-bf": {
         "description": "Wikipedia corpus encoded by DPR doc encoder trained on multiset, indexed as brute force index",
+        "filename": "dindex-wikipedia-dpr_multi-bf-20200127-f403c3.tar.gz",
         "urls": [
             "https://www.dropbox.com/s/9g4e2ps73lf4ysl/dindex-wikipedia-dpr_multi-bf-20200127-f403c3.tar.gz?dl=1",
         ],
@@ -435,6 +440,7 @@ DINDEX_INFO = {
     },
     "msmarco-passage-ance-bf": {
         "description": "MS MARCO passage corpus encoded by ANCE msmarco passage encoder and indexed as brute force index",
+        "filename": "dindex-msmarco-passage-ance-bf-20210224-060cef.tar.gz",
         "urls": [
             "https://www.dropbox.com/s/ahpxwtgh56o6j2f/dindex-msmarco-passage-ance-bf-20210224-060cef.tar.gz?dl=1",
         ],
@@ -445,6 +451,7 @@ DINDEX_INFO = {
     },
     "wikipedia-ance-multi-bf": {
         "description": "Wikipedia corpus encoded by ANCE-multi doc encoder and indexed as brute force index",
+        "filename": "dindex-wikipedia-ance_multi-bf-20210224-060cef.tar.gz",
         "urls": [
             "https://www.dropbox.com/s/j89z1vnhe12cva4/dindex-wikipedia-ance_multi-bf-20210224-060cef.tar.gz?dl=1",
         ],
@@ -455,6 +462,7 @@ DINDEX_INFO = {
     },
     "msmarco-doc-ance-maxp-bf": {
         "description": "MS MARCO document corpus encoded by ANCE maxp encoder and indexed as brute force index",
+        "filename": "dindex-msmarco-doc-ance_maxp-bf-20210304-b2a1b0.tar.gz",
         "urls": [
             "https://www.dropbox.com/s/bddpw1nwcka7pdf/dindex-msmarco-doc-ance_maxp-bf-20210304-b2a1b0.tar.gz?dl=1",
         ],

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -1,9 +1,10 @@
 INDEX_INFO = {
     "robust04": {
         "description": "TREC Disks 4 & 5 (minus Congressional Records), used in the TREC 2004 Robust Track",
+        "filename": "index-robust04-20191213.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/s91388puqbxh176/index-robust04-20191213.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-robust04-20191213.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-robust04-20191213.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/eqFacNeSGc4pLLH/download"
         ],
         "md5": "15f3d001489c97849a010b0a4734d018",
         "size compressed (bytes)": 1821814915,
@@ -13,9 +14,10 @@ INDEX_INFO = {
     },
     "msmarco-passage": {
         "description": "MS MARCO passage corpus",
+        "filename": "index-msmarco-passage-20201117-f87c94.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/tiptih5qcjy4sp8/index-msmarco-passage-20201117-f87c94.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-passage-20201117-f87c94.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-passage-20201117-f87c94.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/QQsZMFG8MpF4P8M/download"
         ],
         "md5": "1efad4f1ae6a77e235042eff4be1612d",
         "size compressed (bytes)": 2218470796,
@@ -26,9 +28,10 @@ INDEX_INFO = {
     },
     "msmarco-passage-slim": {
         "description": "MS MARCO passage corpus (slim version, no documents)",
+        "filename": "index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/3hsc8ul9zv1txhr/index-msmarco-passage-slim-20201202-ab6e28.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-passage-slim-20201202-ab6e28.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/Kx6K9NJFmwnaAP8/download"
         ],
         "md5": "5e11da4cebd2e8dda2e73c589ffb0b4c",
         "size compressed (bytes)": 513566686,
@@ -39,9 +42,10 @@ INDEX_INFO = {
     },
     "msmarco-passage-expanded": {
         "description": "MS MARCO passage corpus (+ docTTTTTquery expansion)",
+        "filename": "index-msmarco-passage-expanded-20201121-e127fb.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/rxa52pvqox8ow3o/index-msmarco-passage-expanded-20201121-e127fb.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-passage-expanded-20201121-e127fb.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-passage-expanded-20201121-e127fb.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/pm7cisJtRxiAMHd/download"
         ],
         "md5": "e5762e9e065b6fe5000f9c18da778565",
         "size compressed (bytes)": 816438546,
@@ -52,9 +56,10 @@ INDEX_INFO = {
     },
     "msmarco-doc": {
         "description": "MS MARCO document corpus",
+        "filename": "index-msmarco-doc-20201117-f87c94.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/uwzc3rlkccpt6eb/index-msmarco-doc-20201117-f87c94.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-20201117-f87c94.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-20201117-f87c94.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/5NC7A2wAL7opJKH/download"
         ],
         "md5": "ac747860e7a37aed37cc30ed3990f273",
         "size compressed (bytes)": 13642330935,
@@ -65,9 +70,10 @@ INDEX_INFO = {
     },
     "msmarco-doc-slim": {
         "description": "MS MARCO document corpus (slim version, no documents)",
+        "filename": "index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/v40ajir6v398iek/index-msmarco-doc-slim-20201202-ab6e28.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-slim-20201202-ab6e28.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/BMZ6oYBoEPgTFqs/download"
         ],
         "md5": "c56e752f7992bf6149761097641d515a",
         "size compressed (bytes)": 1874471867,
@@ -78,9 +84,10 @@ INDEX_INFO = {
     },
     "msmarco-doc-per-passage": {
         "description": "MS MARCO document corpus, segmented into passages",
+        "filename": "index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/69ieyumdx3rb3tu/index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/q6sAxE6q57q2TBo/download"
         ],
         "md5": "797367406a7542b649cefa6b41cf4c33",
         "size compressed (bytes)": 11602951258,
@@ -91,9 +98,10 @@ INDEX_INFO = {
     },
     "msmarco-doc-per-passage-slim": {
         "description": "MS MARCO document corpus, segmented into passages (slim version, no documents)",
+        "filename": "index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/uic4ijgv2u3xcat/index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/mKTjbTKMwWF9kY3/download"
         ],
         "md5": "77c2409943a8c9faffabf57cb6adca69",
         "size compressed (bytes)": 2834865200,
@@ -104,9 +112,10 @@ INDEX_INFO = {
     },
     "msmarco-doc-expanded-per-doc": {
         "description": "MS MARCO document corpus, with per-doc docTTTTTquery expansion",
+        "filename": "index-msmarco-doc-expanded-per-doc-20201126-1b4d0a.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/u4yagsgf3lo3gk4/index-msmarco-doc-expanded-per-doc-20201126-1b4d0a.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-expanded-per-doc-20201126-1b4d0a.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-expanded-per-doc-20201126-1b4d0a.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/3BQz6ZAXAxtfne8/download"
         ],
         "md5": "f7056191842ab77a01829cff68004782",
         "size compressed (bytes)": 1978837253,
@@ -117,9 +126,10 @@ INDEX_INFO = {
     },
     "msmarco-doc-expanded-per-passage": {
         "description": "MS MARCO document corpus, with per-passage docTTTTTquery expansion",
+        "filename": "index-msmarco-doc-expanded-per-passage-20201126-1b4d0a.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/t3z7p5o6kfe931s/index-msmarco-doc-expanded-per-passage-20201126-1b4d0a.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-expanded-per-passage-20201126-1b4d0a.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-msmarco-doc-expanded-per-passage-20201126-1b4d0a.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/eZLbPWcnB7LzKnQ/download"
         ],
         "md5": "54ea30c64515edf3c3741291b785be53",
         "size compressed (bytes)": 3069280946,
@@ -130,9 +140,10 @@ INDEX_INFO = {
     },
     "enwiki-paragraphs": {
         "description": "English Wikipedia (for BERTserini)",
+        "filename": "lucene-index.enwiki-20180701-paragraphs.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/b7qqaos9ot3atlp/lucene-index.enwiki-20180701-paragraphs.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/lucene-index.enwiki-20180701-paragraphs.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/lucene-index.enwiki-20180701-paragraphs.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/WHKMSCbwQfDXyHt/download"
         ],
         "md5": "77d1cd530579905dad2ee3c2bda1b73d",
         "size compressed (bytes)": 17725958785,
@@ -143,9 +154,10 @@ INDEX_INFO = {
     },
     "zhwiki-paragraphs": {
         "description": "Chinese Wikipedia (for BERTserini)",
+        "filename": "lucene-index.zhwiki-20181201-paragraphs.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/6zn16mombt0wirs/lucene-index.zhwiki-20181201-paragraphs.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/lucene-index.zhwiki-20181201-paragraphs.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/lucene-index.zhwiki-20181201-paragraphs.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/6kEjQZaRYtnb8A6/download"
         ],
         "md5": "c005af4036296972831288c894918a92",
         "size compressed (bytes)": 3284531213,
@@ -157,8 +169,8 @@ INDEX_INFO = {
     "trec-covid-r5-abstract": {
         "description": "TREC-COVID Round 5: abstract index",
         "urls": [
-            "https://www.dropbox.com/s/9hfowxi7zenuaay/lucene-index-cord19-abstract-2020-07-16.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-07-16/lucene-index-cord19-abstract-2020-07-16.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-07-16/lucene-index-cord19-abstract-2020-07-16.tar.gz",
+            "https://www.dropbox.com/s/9hfowxi7zenuaay/lucene-index-cord19-abstract-2020-07-16.tar.gz?dl=1"
         ],
         "md5": "c883571ccc78b4c2ce05b41eb07f5405",
         "size compressed (bytes)": 2796524,
@@ -170,8 +182,8 @@ INDEX_INFO = {
     "trec-covid-r5-full-text": {
         "description": "TREC-COVID Round 5: full-text index",
         "urls": [
-            "https://www.dropbox.com/s/dyd9sggrqo44d0n/lucene-index-cord19-full-text-2020-07-16.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-07-16/lucene-index-cord19-full-text-2020-07-16.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-07-16/lucene-index-cord19-full-text-2020-07-16.tar.gz",
+            "https://www.dropbox.com/s/dyd9sggrqo44d0n/lucene-index-cord19-full-text-2020-07-16.tar.gz?dl=1"
         ],
         "md5": "23cfad89b4c206d66125f5736f60248f",
         "size compressed (bytes)": 5351744,
@@ -183,8 +195,8 @@ INDEX_INFO = {
     "trec-covid-r5-paragraph": {
         "description": "TREC-COVID Round 5: paragraph index",
         "urls": [
-            "https://www.dropbox.com/s/jdfbrnohtkrvds5/lucene-index-cord19-paragraph-2020-07-16.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-07-16/lucene-index-cord19-paragraph-2020-07-16.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-07-16/lucene-index-cord19-paragraph-2020-07-16.tar.gz",
+            "https://www.dropbox.com/s/jdfbrnohtkrvds5/lucene-index-cord19-paragraph-2020-07-16.tar.gz?dl=1"
         ],
         "md5": "c2c6ac832f8a1fcb767d2356d2b1e1df",
         "size compressed (bytes)": 11352968,
@@ -196,8 +208,8 @@ INDEX_INFO = {
     "trec-covid-r4-abstract": {
         "description": "TREC-COVID Round 4: abstract index",
         "urls": [
-            "https://www.dropbox.com/s/x8wbuy0atgnajfd/lucene-index-cord19-abstract-2020-06-19.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-06-19/lucene-index-cord19-abstract-2020-06-19.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-06-19/lucene-index-cord19-abstract-2020-06-19.tar.gz",
+            "https://www.dropbox.com/s/x8wbuy0atgnajfd/lucene-index-cord19-abstract-2020-06-19.tar.gz?dl=1"
         ],
         "md5": "029bd55daba8800fbae2be9e5fcd7b33",
         "size compressed (bytes)": 2584264,
@@ -209,8 +221,8 @@ INDEX_INFO = {
     "trec-covid-r4-full-text": {
         "description": "TREC-COVID Round 4: full-text index",
         "urls": [
-            "https://www.dropbox.com/s/tf469r70r8aigu2/lucene-index-cord19-full-text-2020-06-19.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-06-19/lucene-index-cord19-full-text-2020-06-19.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-06-19/lucene-index-cord19-full-text-2020-06-19.tar.gz",
+            "https://www.dropbox.com/s/tf469r70r8aigu2/lucene-index-cord19-full-text-2020-06-19.tar.gz?dl=1"
         ],
         "md5": "3d0eb12094a24cff9bcacd1f17c3ea1c",
         "size compressed (bytes)": 4983900,
@@ -222,8 +234,8 @@ INDEX_INFO = {
     "trec-covid-r4-paragraph": {
         "description": "TREC-COVID Round 4: paragraph index",
         "urls": [
-            "https://www.dropbox.com/s/fr3v69vhryevwp9/lucene-index-cord19-paragraph-2020-06-19.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-06-19/lucene-index-cord19-paragraph-2020-06-19.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-06-19/lucene-index-cord19-paragraph-2020-06-19.tar.gz",
+            "https://www.dropbox.com/s/fr3v69vhryevwp9/lucene-index-cord19-paragraph-2020-06-19.tar.gz?dl=1"
         ],
         "md5": "5cd8cd6998177bed7a3e0057ef8b3595",
         "size compressed (bytes)": 10382704,
@@ -235,8 +247,8 @@ INDEX_INFO = {
     "trec-covid-r3-abstract": {
         "description": "TREC-COVID Round 3: abstract index",
         "urls": [
-            "https://www.dropbox.com/s/7bbz6pm4rduqvx3/lucene-index-cord19-abstract-2020-05-19.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-19/lucene-index-cord19-abstract-2020-05-19.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-19/lucene-index-cord19-abstract-2020-05-19.tar.gz",
+            "https://www.dropbox.com/s/7bbz6pm4rduqvx3/lucene-index-cord19-abstract-2020-05-19.tar.gz?dl=1"
         ],
         "md5": "37bb97d0c41d650ba8e135fd75ae8fd8",
         "size compressed (bytes)": 2190328,
@@ -248,8 +260,8 @@ INDEX_INFO = {
     "trec-covid-r3-full-text": {
         "description": "TREC-COVID Round 3: full-text index",
         "urls": [
-            "https://www.dropbox.com/s/bxhldgks1rxz4ly/lucene-index-cord19-full-text-2020-05-19.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-19/lucene-index-cord19-full-text-2020-05-19.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-19/lucene-index-cord19-full-text-2020-05-19.tar.gz",
+            "https://www.dropbox.com/s/bxhldgks1rxz4ly/lucene-index-cord19-full-text-2020-05-19.tar.gz?dl=1"
         ],
         "md5": "f5711915a66cd2b511e0fb8d03e4c325",
         "size compressed (bytes)": 4233300,
@@ -261,8 +273,8 @@ INDEX_INFO = {
     "trec-covid-r3-paragraph": {
         "description": "TREC-COVID Round 3: paragraph index",
         "urls": [
-            "https://www.dropbox.com/s/2ewjchln0ihm6hh/lucene-index-cord19-paragraph-2020-05-19.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-19/lucene-index-cord19-paragraph-2020-05-19.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-19/lucene-index-cord19-paragraph-2020-05-19.tar.gz",
+            "https://www.dropbox.com/s/2ewjchln0ihm6hh/lucene-index-cord19-paragraph-2020-05-19.tar.gz?dl=1"
         ],
         "md5": "012ab1f804382b2275c433a74d7d31f2",
         "size compressed (bytes)": 9053524,
@@ -274,8 +286,8 @@ INDEX_INFO = {
     "trec-covid-r2-abstract": {
         "description": "TREC-COVID Round 2: abstract index",
         "urls": [
-            "https://www.dropbox.com/s/jdsc6wu0vbumpup/lucene-index-cord19-abstract-2020-05-01.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-01/lucene-index-cord19-abstract-2020-05-01.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-01/lucene-index-cord19-abstract-2020-05-01.tar.gz",
+            "https://www.dropbox.com/s/jdsc6wu0vbumpup/lucene-index-cord19-abstract-2020-05-01.tar.gz?dl=1"
         ],
         "md5": "a06e71a98a68d31148cb0e97e70a2ee1",
         "size compressed (bytes)": 1575804,
@@ -287,8 +299,8 @@ INDEX_INFO = {
     "trec-covid-r2-full-text": {
         "description": "TREC-COVID Round 2: full-text index",
         "urls": [
-            "https://www.dropbox.com/s/ouvp7zyqsp9y9gh/lucene-index-cord19-full-text-2020-05-01.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-01/lucene-index-cord19-full-text-2020-05-01.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-01/lucene-index-cord19-full-text-2020-05-01.tar.gz",
+            "https://www.dropbox.com/s/ouvp7zyqsp9y9gh/lucene-index-cord19-full-text-2020-05-01.tar.gz?dl=1"
         ],
         "md5": "e7eca1b976cdf2cd80e908c9ac2263cb",
         "size compressed (bytes)": 3088540,
@@ -300,8 +312,8 @@ INDEX_INFO = {
     "trec-covid-r2-paragraph": {
         "description": "TREC-COVID Round 2: paragraph index",
         "urls": [
-            "https://www.dropbox.com/s/e1118vjuf58ojt4/lucene-index-cord19-paragraph-2020-05-01.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-01/lucene-index-cord19-paragraph-2020-05-01.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-05-01/lucene-index-cord19-paragraph-2020-05-01.tar.gz",
+            "https://www.dropbox.com/s/e1118vjuf58ojt4/lucene-index-cord19-paragraph-2020-05-01.tar.gz?dl=1"
         ],
         "md5": "8f9321757a03985ac1c1952b2fff2c7d",
         "size compressed (bytes)": 6881696,
@@ -313,8 +325,8 @@ INDEX_INFO = {
     "trec-covid-r1-abstract": {
         "description": "TREC-COVID Round 1: abstract index",
         "urls": [
-            "https://www.dropbox.com/s/iebape2yfgkzkt1/lucene-index-covid-2020-04-10.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-04-10/lucene-index-covid-2020-04-10.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-04-10/lucene-index-covid-2020-04-10.tar.gz",
+            "https://www.dropbox.com/s/iebape2yfgkzkt1/lucene-index-covid-2020-04-10.tar.gz?dl=1"
         ],
         "md5": "ec239d56498c0e7b74e3b41e1ce5d42a",
         "size compressed (bytes)": 1621440,
@@ -326,8 +338,8 @@ INDEX_INFO = {
     "trec-covid-r1-full-text": {
         "description": "TREC-COVID Round 1: full-text index",
         "urls": [
-            "https://www.dropbox.com/s/pfouskfoxb471e6/lucene-index-covid-full-text-2020-04-10.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-04-10/lucene-index-covid-full-text-2020-04-10.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-04-10/lucene-index-covid-full-text-2020-04-10.tar.gz",
+            "https://www.dropbox.com/s/pfouskfoxb471e6/lucene-index-covid-full-text-2020-04-10.tar.gz?dl=1"
         ],
         "md5": "401a6f5583b0f05340c73fbbeb3279c8",
         "size compressed (bytes)": 4471820,
@@ -339,8 +351,8 @@ INDEX_INFO = {
     "trec-covid-r1-paragraph": {
         "description": "TREC-COVID Round 1: paragraph index",
         "urls": [
-            "https://www.dropbox.com/s/yr0bj5pxu2k89n0/lucene-index-covid-paragraph-2020-04-10.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-04-10/lucene-index-covid-paragraph-2020-04-10.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/-/raw/master/2020-04-10/lucene-index-covid-paragraph-2020-04-10.tar.gz",
+            "https://www.dropbox.com/s/yr0bj5pxu2k89n0/lucene-index-covid-paragraph-2020-04-10.tar.gz?dl=1"
         ],
         "md5": "8b87a2c55bc0a15b87f11e796860216a",
         "size compressed (bytes)": 5994192,
@@ -351,9 +363,10 @@ INDEX_INFO = {
     },
     "cast2019": {
         "description": "TREC 2019 CaST",
+        "filename": "index-cast2019.tar.gz",
         "urls": [
-            "https://www.dropbox.com/s/ba89k4xyn0srbk0/index-cast2019.tar.gz?dl=1",
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-cast2019.tar.gz"
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-cast2019.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/56LcDcRPopdQc4d/download"
         ],
         "md5": "36e604d7f5a4e08ade54e446be2f6345",
         "size compressed (bytes)": 21266884884,
@@ -364,10 +377,11 @@ INDEX_INFO = {
     },
     "wikipedia-dpr": {
         "description": "Wikipedia (DPR 100 word splits) Anserini index",
+        "filename": "index-wikipedia-dpr-20210120-d1b9e6.tar.gz",
         "urls": [
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-wikipedia-dpr-20210120-d1b9e6.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/t6tDJmpoxPw9tH8/download",
             "https://www.dropbox.com/s/spohu55l6608ho2/index-wikipedia-dpr-20210120-d1b9e6.tar.gz?dl=1",  # Xueguang
-            "https://www.dropbox.com/s/v0545smnlrmxm72/index-wikipedia-dpr-20210120-d1b9e6.tar.gz?dl=1",  # Jimmy
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-wikipedia-dpr-20210120-d1b9e6.tar.gz"
         ],
         "md5": "c28f3a56b2dfcef25bf3bf755c264d04",
         "size compressed (bytes)": 9177942656,
@@ -378,10 +392,11 @@ INDEX_INFO = {
     },
     "wikipedia-dpr-slim": {
         "description": "Wikipedia (DPR 100 word splits) Anserini index, without raw texts stored",
+        "filename": "index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz",
         "urls": [
+            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/Gk2sfTyJCyaTrYH/download",
             "https://www.dropbox.com/s/r2xpo3e0pecibir/index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz?dl=1",  # Xueguang
-            "https://www.dropbox.com/s/jx29yftvn2qnm4d/index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz?dl=1",  # Jimmy
-            "https://git.uwaterloo.ca/jimmylin/anserini-indexes/raw/master/index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz"
         ],
         "md5": "7d40604a824b5df37a1ae9d25ea38071",
         "size compressed (bytes)": 1810342390,
@@ -442,6 +457,7 @@ DINDEX_INFO = {
         "description": "MS MARCO passage corpus encoded by ANCE msmarco passage encoder and indexed as brute force index",
         "filename": "dindex-msmarco-passage-ance-bf-20210224-060cef.tar.gz",
         "urls": [
+            "https://vault.cs.uwaterloo.ca/s/Drx9wEF29wEsnXm/download",
             "https://www.dropbox.com/s/ahpxwtgh56o6j2f/dindex-msmarco-passage-ance-bf-20210224-060cef.tar.gz?dl=1",
         ],
         "md5": "f6332edb8f06ba796850388cf975b414",

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -58,12 +58,12 @@ def compute_md5(file, block_size=2**20):
 
 
 def download_url(url, save_dir, local_filename=None, md5=None, force=False, verbose=True):
-    # If caller does not specify local filename, figure it out from the download URL
+    # If caller does not specify local filename, figure it out from the download URL:
     if not local_filename:
         filename = url.split('/')[-1]
         filename = re.sub('\\?dl=1$', '', filename)  # Remove the Dropbox 'force download' parameter
     else:
-        # Otherwise, use the specified local_filename
+        # Otherwise, use the specified local_filename:
         filename = local_filename
 
     destination_path = os.path.join(save_dir, filename)
@@ -100,8 +100,13 @@ def get_cache_home():
 
 def download_and_unpack_index(url, index_directory='indexes', local_filename=False,
                               force=False, verbose=True, prebuilt=False, md5=None):
-    index_name = url.split('/')[-1]
-    index_name = re.sub('''.tar.gz.*$''', '', index_name)
+    # If caller does not specify local filename, figure it out from the download URL:
+    if not local_filename:
+        index_name = url.split('/')[-1]
+        index_name = re.sub('''.tar.gz.*$''', '', index_name)
+    else:
+        # Otherwise, use the specified local_filename:
+        index_name = local_filename
 
     if prebuilt:
         index_directory = os.path.join(get_cache_home(), index_directory)

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -18,11 +18,10 @@ import hashlib
 import re
 import os
 import shutil
-import socket
 import tarfile
 from tqdm import tqdm
 from urllib.request import urlretrieve
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 import pandas as pd
 from pyserini.prebuilt_index_info import INDEX_INFO, DINDEX_INFO
 from pyserini.encoded_query_info import QUERY_INFO
@@ -200,7 +199,7 @@ def download_prebuilt_index(index_name, force=False, verbose=True, mirror=None):
         local_filename = target_index['filename'] if 'filename' in target_index else None
         try:
             return download_and_unpack_index(url, local_filename=local_filename, prebuilt=True, md5=index_md5)
-        except (HTTPError, socket.gaierror) as e:
+        except (HTTPError, URLError) as e:
             print(f'Unable to download pre-built index at {url}, trying next URL...')
     raise ValueError(f'Unable to download pre-built index at any known URLs.')
 
@@ -212,7 +211,7 @@ def download_encoded_queries(query_name, force=False, verbose=True, mirror=None)
     for url in QUERY_INFO[query_name]['urls']:
         try:
             return download_and_unpack_index(url, index_directory='queries', prebuilt=True, md5=query_md5)
-        except HTTPError:
+        except (HTTPError, URLError) as e:
             print(f'Unable to download encoded query at {url}, trying next URL...')
     raise ValueError(f'Unable to download encoded query at any known URLs.')
 

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -18,6 +18,7 @@ import hashlib
 import re
 import os
 import shutil
+import socket
 import tarfile
 from tqdm import tqdm
 from urllib.request import urlretrieve
@@ -199,7 +200,7 @@ def download_prebuilt_index(index_name, force=False, verbose=True, mirror=None):
         local_filename = target_index['filename'] if 'filename' in target_index else None
         try:
             return download_and_unpack_index(url, local_filename=local_filename, prebuilt=True, md5=index_md5)
-        except HTTPError:
+        except (HTTPError, socket.gaierror) as e:
             print(f'Unable to download pre-built index at {url}, trying next URL...')
     raise ValueError(f'Unable to download pre-built index at any known URLs.')
 

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -103,10 +103,11 @@ def download_and_unpack_index(url, index_directory='indexes', local_filename=Fal
     # If caller does not specify local filename, figure it out from the download URL:
     if not local_filename:
         index_name = url.split('/')[-1]
-        index_name = re.sub('''.tar.gz.*$''', '', index_name)
     else:
         # Otherwise, use the specified local_filename:
         index_name = local_filename
+    # Remove the suffix:
+    index_name = re.sub('''.tar.gz.*$''', '', index_name)
 
     if prebuilt:
         index_directory = os.path.join(get_cache_home(), index_directory)


### PR DESCRIPTION
Apparently, Dropbox has a download bandwidth limit, which I tripped, causing a (temporary) ban. Moving away from Dropbox for "stable" links to avoid this in the future.

Added functionality to specify name of local filename when downloading.
