### PR TITLE
update encoded query info

### DIFF
--- a/docs/experiments-ance.md
+++ b/docs/experiments-ance.md
@@ -13,7 +13,7 @@ You'll need a Pyserini [development installation](https://github.com/castorini/p
 ```bash
 $ python -m pyserini.dsearch --topics msmarco-passage-dev-subset \
                              --index msmarco-passage-ance-bf \
-                             --encoded-queries msmarco-passage-dev-subset-ance \
+                             --encoded-queries ance-msmarco-passage-dev-subset \
                              --batch-size 36 \
                              --threads 12 \
                              --output runs/run.msmarco-passage.ance.bf.tsv \
@@ -83,7 +83,7 @@ recall_100            	all	0.9033
 ```bash
 $ python -m pyserini.dsearch --topics dpr-nq-test \
                              --index wikipedia-ance-multi-bf \
-                             --encoded-queires dpr-nq-dev-ance-multi \
+                             --encoded-queires ance_multi-nq-dev \
                              --output runs/run.ance.nq-test.multi.bf.trec \
                              --batch-size 36 --threads 12
 ```
@@ -110,7 +110,7 @@ Top100	accuracy: 0.8786703601108034
 ```bash
 $ python -m pyserini.dsearch --topics dpr-trivia-test \
                              --index wikipedia-ance-multi-bf \
-                             --encoded-queries dpr-trivia-test-multi \
+                             --encoded-queries dpr_multi-trivia-test \
                              --output runs/run.ance.trivia-test.multi.bf.trec \
                              --batch-size 36 --threads 12
 ```

--- a/pyserini/dsearch/__main__.py
+++ b/pyserini/dsearch/__main__.py
@@ -46,14 +46,14 @@ def define_dsearch_args(parser):
 
 def init_query_encoder(encoder, topics_name, encoded_queries, device):
     encoded_queries_map = {
-        'msmarco-passage-dev-subset': 'msmarco-passage-dev-subset-tct_colbert',
-        'dpr-nq-dev': 'dpr-nq-dev-multi',
-        'dpr-nq-test': 'dpr-nq-test-multi',
-        'dpr-trivia-dev': 'dpr-trivia-dev-multi',
-        'dpr-trivia-test': 'dpr-trivia-test-multi',
-        'dpr-wq-test': 'dpr-wq-test-multi',
-        'dpr-squad-test': 'dpr-squad-test-multi',
-        'dpr-curated-test': 'dpr-curated-test-multi'
+        'msmarco-passage-dev-subset': 'tct_colbert-msmarco-passage-dev-subset',
+        'dpr-nq-dev': 'dpr_multi-nq-dev',
+        'dpr-nq-test': 'dpr_multi-nq-test',
+        'dpr-trivia-dev': 'dpr_multi-trivia-dev',
+        'dpr-trivia-test': 'dpr_multi-trivia-test',
+        'dpr-wq-test': 'dpr_multi-wq-test',
+        'dpr-squad-test': 'dpr_multi-squad-test',
+        'dpr-curated-test': 'dpr_multi-curated-test'
     }
     if encoder:
         if 'dpr' in encoder:

--- a/pyserini/encoded_query_info.py
+++ b/pyserini/encoded_query_info.py
@@ -1,5 +1,5 @@
 QUERY_INFO = {
-    "msmarco-passage-dev-subset-tct_colbert": {
+    "tct_colbert-msmarco-passage-dev-subset": {
         "description": "MS MARCO passage dev set queries encoded by TCT-ColBERT",
         "urls": [
             "https://www.dropbox.com/s/vdfjmvayn8bobop/query-embedding-tct_colbert-msmarco-passage-dev-subset-20210404-727692.tar.gz?dl=1",
@@ -9,7 +9,7 @@ QUERY_INFO = {
         "total_queries": 6980,
         "downloaded": False
     },
-    "msmarco-passage-dev-subset-ance": {
+    "ance-msmarco-passage-dev-subset": {
         "description": "MS MARCO passage dev set queries encoded by ANCE",
         "urls": [
             "https://www.dropbox.com/s/eh7enn1hc0cvf7u/query-embedding-ance-msmarco-passage-dev-subset-20210404-727692.tar.gz?dl=1",
@@ -19,7 +19,7 @@ QUERY_INFO = {
         "total_queries": 6980,
         "downloaded": False
     },
-    "msmarco-doc-dev-tct_colbert": {
+    "tct_colbert-msmarco-doc-dev": {
         "description": "MS MARCO Document dev set queries encoded by TCT-ColBERT zero-shot",
         "urls": [
             "https://www.dropbox.com/s/kzgbhvb9qvkf78m/query-embedding-tct_colbert-msmarco-doc-dev-20210404-727692.tar.gz?dl=1",
@@ -29,7 +29,7 @@ QUERY_INFO = {
         "total_queries": 6980,
         "downloaded": False
     },
-    "msmarco-doc-dev-ance_maxp": {
+    "ance_maxp-msmarco-doc-dev": {
         "description": "MS MARCO Document dev set queries encoded by ANCE maxp",
         "urls": [
             "https://www.dropbox.com/s/u4tu08vpj0w3dl4/query-embedding-ance_maxp-msmarco-doc-dev-20210404-727692.tar.gz?dl=1",
@@ -39,7 +39,7 @@ QUERY_INFO = {
         "total_queries": 6980,
         "downloaded": False
     },
-    "msmarco-passage-dev-subset-sbert": {
+    "sbert-msmarco-passage-dev-subset": {
         "description": "MS MARCO passage dev set queries encoded by SBERT",
         "urls": [
             "https://www.dropbox.com/s/7tg1byavfcjy66u/query-embedding-sbert-msmarco-passage-dev-subset-20210404-727692.tar.gz?dl=1",
@@ -49,7 +49,7 @@ QUERY_INFO = {
         "total_queries": 6980,
         "downloaded": False
     },
-    "msmarco-passage-dev-subset-distilbert_kd": {
+    "distilbert_kd-msmarco-passage-dev-subset": {
         "description": "MS MARCO passage dev set queries encoded by SBERT",
         "urls": [
             "https://www.dropbox.com/s/annm4pw3xfht8xn/query-embedding-distilbert_kd-msmarco-passage-dev-subset.tar.gz?dl=1",
@@ -59,7 +59,7 @@ QUERY_INFO = {
         "total_queries": 6980,
         "downloaded": False
     },
-    "dpr-nq-dev-multi": {
+    "dpr_multi-nq-dev": {
         "description": "Natural Question dev set questions encoded by DPR question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/33ks0ekwsvm6lk0/query-embedding-dpr_multi-nq-dev-20210404-727692.tar.gz?dl=1",
@@ -69,7 +69,7 @@ QUERY_INFO = {
         "total_queries": 8757,
         "downloaded": False
     },
-    "dpr-nq-test-multi": {
+    "dpr_multi-nq-test": {
         "description": "Natural Question test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/2p5k63yhfooicqe/query-embedding-dpr_multi-nq-test-20210404-727692.tar.gz?dl=1",
@@ -79,7 +79,7 @@ QUERY_INFO = {
         "total_queries": 3610,
         "downloaded": False
     },
-    "dpr-nq-dev-ance-multi": {
+    "ance_multi-nq-dev": {
         "description": "Natural Question dev set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/l2apd5505iu03ul/query-embedding-ance_multi-nq-dev-20210404-727692.tar.gz?dl=1",
@@ -89,7 +89,7 @@ QUERY_INFO = {
         "total_queries": 8757,
         "downloaded": False
     },
-    "dpr-nq-test-ance-multi": {
+    "ance_multi-nq-test": {
         "description": "Natural Question test set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/i09ej3c5zj7s0zj/query-embedding-ance_multi-nq-test-20210404-727692.tar.gz?dl=1",
@@ -99,7 +99,7 @@ QUERY_INFO = {
         "total_queries": 3610,
         "downloaded": False
     },
-    "dpr-trivia-dev-multi": {
+    "dpr_multi-trivia-dev": {
         "description": "TriviaQA dev set questions encoded by DPR question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/pdis1zhtojfc6zu/query-embedding-dpr_multi-trivia-dev-20210404-727692.tar.gz?dl=1",
@@ -109,7 +109,7 @@ QUERY_INFO = {
         "total_queries": 8837,
         "downloaded": False
     },
-    "dpr-trivia-test-multi": {
+    "dpr_multi-trivia-test": {
         "description": "TriviaQA test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/nip4b8aqawq78xz/query-embedding-dpr_multi-trivia-test-20210404-727692.tar.gz?dl=1",
@@ -119,7 +119,7 @@ QUERY_INFO = {
         "total_queries": 11313,
         "downloaded": False
     },
-    "dpr-trivia-dev-ance-multi": {
+    "ance_multi-trivia-dev": {
         "description": "TriviaQA dev set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/ihql2r00nn89qlg/query-embedding-ance_multi-trivia-dev-20210404-727692.tar.gz?dl=1",
@@ -129,7 +129,7 @@ QUERY_INFO = {
         "total_queries": 8837,
         "downloaded": False
     },
-    "dpr-trivia-test-ance-multi": {
+    "ance_multi-trivia-test": {
         "description": "TriviaQA test set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/nbur4u2kjveir82/query-embedding-ance_multi-trivia-test-20210404-727692.tar.gz?dl=1",
@@ -139,7 +139,7 @@ QUERY_INFO = {
         "total_queries": 11313,
         "downloaded": False
     },
-    "dpr-wq-test-multi": {
+    "dpr_multi-wq-test": {
         "description": "Web Questions test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/fkiqg4inpyqg54o/query-embedding-dpr_multi-wq-test-20210404-727692.tar.gz?dl=1",
@@ -149,7 +149,7 @@ QUERY_INFO = {
         "total_queries": 2032,
         "downloaded": False
     },
-    "dpr-squad-test-multi": {
+    "dpr_multi-squad-test": {
         "description": "SQUAD dev set questions encoded by DPR question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/gqlnmum83cijgxm/query-embedding-dpr_multi-squad-test-20210404-727692.tar.gz?dl=1",
@@ -159,7 +159,7 @@ QUERY_INFO = {
         "total_queries": 10570,
         "downloaded": False
     },
-    "dpr-curated-test-multi": {
+    "dpr_multi-curated-test": {
         "description": "CuratedTREC test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
             "https://www.dropbox.com/s/2pt3eviuygx107y/query-embedding-dpr_multi-curated-test-20210404-727692.tar.gz?dl=1",

--- a/pyserini/encoded_query_info.py
+++ b/pyserini/encoded_query_info.py
@@ -2,130 +2,170 @@ QUERY_INFO = {
     "msmarco-passage-dev-subset-tct_colbert": {
         "description": "MS MARCO passage dev set queries encoded by TCT-ColBERT",
         "urls": [
-            "https://www.dropbox.com/s/g7sci7n15mekbut/query-embedding-msmarco-passage-dev-subset-20210115-cd5034.tar.gz?dl=1",
+            "https://www.dropbox.com/s/vdfjmvayn8bobop/query-embedding-tct_colbert-msmarco-passage-dev-subset-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "0e448fda77344e7b892e861f416a8870",
-        "size (bytes)": 20075071,
+        "md5": "31b6d2a83c9f7a2d0d2ce982d5449da1",
+        "size (bytes)": 20077831,
         "total_queries": 6980,
         "downloaded": False
     },
     "msmarco-passage-dev-subset-ance": {
         "description": "MS MARCO passage dev set queries encoded by ANCE",
         "urls": [
-            "https://www.dropbox.com/s/30nz5uuoke777ik/query-embedding-msmarco-dev-subset-ance-20210312-646582.tar.gz?dl=1",
+            "https://www.dropbox.com/s/eh7enn1hc0cvf7u/query-embedding-ance-msmarco-passage-dev-subset-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "e94acb8b04a8ca91f90ca40ec3095e6d",
-        "size (bytes)": 19960589,
+        "md5": "14588c19be7df7479e724ebbee6d93af",
+        "size (bytes)": 19964196,
+        "total_queries": 6980,
+        "downloaded": False
+    },
+    "msmarco-doc-dev-tct_colbert": {
+        "description": "MS MARCO Document dev set queries encoded by TCT-ColBERT zero-shot",
+        "urls": [
+            "https://www.dropbox.com/s/kzgbhvb9qvkf78m/query-embedding-tct_colbert-msmarco-doc-dev-20210404-727692.tar.gz?dl=1",
+        ],
+        "md5": "a1c2195ae0d66d3e3acacef9eb49a510",
+        "size (bytes)": 14939500,
+        "total_queries": 6980,
+        "downloaded": False
+    },
+    "msmarco-doc-dev-ance_maxp": {
+        "description": "MS MARCO Document dev set queries encoded by ANCE maxp",
+        "urls": [
+            "https://www.dropbox.com/s/u4tu08vpj0w3dl4/query-embedding-ance_maxp-msmarco-doc-dev-20210404-727692.tar.gz?dl=1",
+        ],
+        "md5": "4c2b9aff50b92161c955a4018d014943",
+        "size (bytes)": 14853556,
+        "total_queries": 6980,
+        "downloaded": False
+    },
+    "msmarco-passage-dev-subset-sbert": {
+        "description": "MS MARCO passage dev set queries encoded by SBERT",
+        "urls": [
+            "https://www.dropbox.com/s/7tg1byavfcjy66u/query-embedding-sbert-msmarco-passage-dev-subset-20210404-727692.tar.gz?dl=1",
+        ],
+        "md5": "edfac9e18258aa37839d21dda033f184",
+        "size (bytes)": 20057735,
+        "total_queries": 6980,
+        "downloaded": False
+    },
+    "msmarco-passage-dev-subset-distilbert_kd": {
+        "description": "MS MARCO passage dev set queries encoded by SBERT",
+        "urls": [
+            "https://www.dropbox.com/s/annm4pw3xfht8xn/query-embedding-distilbert_kd-msmarco-passage-dev-subset.tar.gz?dl=1",
+        ],
+        "md5": "a4c4d6a2428741399893b39324e120fd",
+        "size (bytes)": 20012135,
         "total_queries": 6980,
         "downloaded": False
     },
     "dpr-nq-dev-multi": {
         "description": "Natural Question dev set questions encoded by DPR question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/jr25kv1aub6qn36/query-embedding-dpr-nq-dev-multi-20210129-3a276c.tar.gz?dl=1",
+            "https://www.dropbox.com/s/33ks0ekwsvm6lk0/query-embedding-dpr_multi-nq-dev-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "33b6bf5c5abb35aafa3e5d3f16cb96da",
-        "size (bytes)": 25121360,
+        "md5": "0265ade8390ea2c0df6c0b610b270b95",
+        "size (bytes)": 25128295,
         "total_queries": 8757,
         "downloaded": False
     },
     "dpr-nq-test-multi": {
         "description": "Natural Question test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/sclw33ljzzajiji/query-embedding-dpr-nq-test-multi-20210129-3a276c.tar.gz?dl=1",
+            "https://www.dropbox.com/s/2p5k63yhfooicqe/query-embedding-dpr_multi-nq-test-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "3b25331c4cef93e0bc1cc5997919ce6e",
-        "size (bytes)": 10359974,
+        "md5": "41753d4d35f61fd10724b71eb6eb3259",
+        "size (bytes)": 10364610,
         "total_queries": 3610,
         "downloaded": False
     },
     "dpr-nq-dev-ance-multi": {
         "description": "Natural Question dev set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/vcfekv3mwr0t75c/query-embedding-dpr-nq-dev-ance-multi-20210312-646582.tar.gz?dl=1",
+            "https://www.dropbox.com/s/l2apd5505iu03ul/query-embedding-ance_multi-nq-dev-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "f5daa7029d13a6d66fc7685e3ec3ab9e",
-        "size (bytes)": 25153811,
+        "md5": "db54c870ef60022474d4f6aa36ab71a0",
+        "size (bytes)": 25162822,
         "total_queries": 8757,
         "downloaded": False
     },
     "dpr-nq-test-ance-multi": {
         "description": "Natural Question test set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/efxohlcdj3vj4ui/query-embedding-dpr-nq-test-ance-multi-20210312-646582.tar.gz?dl=1",
+            "https://www.dropbox.com/s/i09ej3c5zj7s0zj/query-embedding-ance_multi-nq-test-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "f73135775ff56ee5025ee4ea22356ba9",
-        "size (bytes)": 10373469,
+        "md5": "c8788d86549261dc723b828046b4fbbf",
+        "size (bytes)": 10379027,
         "total_queries": 3610,
         "downloaded": False
     },
     "dpr-trivia-dev-multi": {
         "description": "TriviaQA dev set questions encoded by DPR question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/qpx8x3vk0xapyjj/query-embedding-dpr-trivia-dev-multi-20210129-3a276c.tar.gz?dl=1",
+            "https://www.dropbox.com/s/pdis1zhtojfc6zu/query-embedding-dpr_multi-trivia-dev-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "91a59a6430206861ed63837e37799f9e",
-        "size (bytes)": 25504217,
+        "md5": "3a6a49b9ae88d2ad8fbd77be428ab7d6",
+        "size (bytes)": 25516865,
         "total_queries": 8837,
         "downloaded": False
     },
     "dpr-trivia-test-multi": {
         "description": "TriviaQA test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/00c3mvxhznh7rk6/query-embedding-dpr-trivia-test-multi-20210129-3a276c.tar.gz?dl=1",
+            "https://www.dropbox.com/s/nip4b8aqawq78xz/query-embedding-dpr_multi-trivia-test-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "36c2b5d9af83b04c8237abe84167942c",
-        "size (bytes)": 32644066,
+        "md5": "144c848ee406d2fdfdea168071d559bb",
+        "size (bytes)": 32663752,
         "total_queries": 11313,
         "downloaded": False
     },
     "dpr-trivia-dev-ance-multi": {
         "description": "TriviaQA dev set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/k7rlj9r5l2bhldj/query-embedding-dpr-trivia-dev-ance-multi-20210312-646582.tar.gz?dl=1",
+            "https://www.dropbox.com/s/ihql2r00nn89qlg/query-embedding-ance_multi-trivia-dev-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "68ee8bd2a6306b48bcabdf623a96ded9",
-        "size (bytes)": 25544142,
+        "md5": "e4a280905f3dc30761f2d9ed13353733",
+        "size (bytes)": 25559727,
         "total_queries": 8837,
         "downloaded": False
     },
     "dpr-trivia-test-ance-multi": {
         "description": "TriviaQA test set questions encoded by ANCE question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/299y2oaq04cnzz1/query-embedding-dpr-trivia-test-ance-multi-20210312-646582.tar.gz?dl=1",
+            "https://www.dropbox.com/s/nbur4u2kjveir82/query-embedding-ance_multi-trivia-test-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "a5bbe2dced6da53f9b87acd55310084d",
-        "size (bytes)": 32693817,
+        "md5": "ceea6ac9d84047f50c26c18533f6daad",
+        "size (bytes)": 32717721,
         "total_queries": 11313,
         "downloaded": False
     },
     "dpr-wq-test-multi": {
         "description": "Web Questions test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/x4zhqjv8h0nnj3g/query-embedding-dpr-wq-test-multi-20210129-3a276c.tar.gz?dl=1",
+            "https://www.dropbox.com/s/fkiqg4inpyqg54o/query-embedding-dpr_multi-wq-test-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "61e4cdbf381bc10313d6d10665e35570",
-        "size (bytes)": 5824579,
+        "md5": "4a3b5e88fd80823627b6f1743c8fbb96",
+        "size (bytes)": 5826640,
         "total_queries": 2032,
         "downloaded": False
     },
     "dpr-squad-test-multi": {
         "description": "SQUAD dev set questions encoded by DPR question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/kdjvnfa33gdaskj/query-embedding-dpr-squad-test-multi-20210129-3a276c.tar.gz?dl=1",
+            "https://www.dropbox.com/s/gqlnmum83cijgxm/query-embedding-dpr_multi-squad-test-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "1aa4a5fbca5b21f7c12296d9889d4e4d",
-        "size (bytes)": 30245472,
+        "md5": "83d5da45c1e5cf5c03c76af59cf27802",
+        "size (bytes)": 30326384,
         "total_queries": 10570,
         "downloaded": False
     },
     "dpr-curated-test-multi": {
         "description": "CuratedTREC test set questions encoded by DPR question encoder trained on multiset",
         "urls": [
-            "https://www.dropbox.com/s/swg1ypxqxpk9zmy/query-embedding-dpr-curated-test-multi-20210129-3a276c.tar.gz?dl=1",
+            "https://www.dropbox.com/s/2pt3eviuygx107y/query-embedding-dpr_multi-curated-test-20210404-727692.tar.gz?dl=1",
         ],
-        "md5": "9f6471877e2a8b823a61b2e55e4e9ac7",
-        "size (bytes)": 1994406,
+        "md5": "2dfd1bc4db407ab832d7bae13e93b022",
+        "size (bytes)": 1995260,
         "total_queries": 694,
         "downloaded": False
     }


### PR DESCRIPTION
re https://github.com/castorini/pyserini/issues/445 and https://github.com/castorini/pyserini/issues/396.

now all the experiments have both otf and encoded queries.
I'll update doc in a separate PR