### PR TITLE
Increased tolerance for dense test case

### DIFF
--- a/integrations/dense/test_tct_colbert.py
+++ b/integrations/dense/test_tct_colbert.py
@@ -51,7 +51,7 @@ class TestSearchIntegration(unittest.TestCase):
         score = parse_score(stdout, "MRR @10")
         self.assertEqual(status, 0)
         # We get a small difference in scores on macOS vs. Linux, better way to check:
-        self.assertAlmostEqual(score, 0.3350, delta=0.0001)
+        self.assertAlmostEqual(score, 0.3350, delta=0.0002)
 
     def test_msmarco_passage_tct_colbert_hnsw_otf(self):
         output_file = 'test_run.msmarco-passage.tct_colbert.hnsw-otf.tsv'


### PR DESCRIPTION
Otherwise, we get the following error:

```
======================================================================
FAIL: test_msmarco_passage_tct_colbert_bf_otf (test_tct_colbert.TestSearchIntegration)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/store/scratch/jimmylin/pyserini/integrations/dense/test_tct_colbert.py", line 54, in test_msmarco_passage_tct_colbert_bf_otf
    self.assertAlmostEqual(score, 0.3350, delta=0.0001)
AssertionError: 0.3349 != 0.335 within 0.0001 delta

----------------------------------------------------------------------
```

This is running on `orca`.