### PR TITLE
Kilt Reproduction

### DIFF
--- a/docs/experiments-kilt.md
+++ b/docs/experiments-kilt.md
@@ -15,6 +15,9 @@ pip install pyserini
 # Get KILT scripts, input and gold data, and install the package
 git clone https://github.com/facebookresearch/KILT.git
 cd KILT
+
+# go back to an older version
+git reset 2130aafaaee0671bdbd03d781b1fa57ee02650d2
 pip install -r requirements.txt
 pip install .
 mkdir data
@@ -145,3 +148,7 @@ For Recall@100/1000:
 | baseline drqa (tfidf + bigram hashing) | 91.87/96.54 | - | - | - | 84.82/94.16 | 94.12/97.29 | 70.98/84.99 | 62.32/80.57 | 87.04/94.95 | 39.98/56.77 | 91.53/96.47 |
 | anserini (document) | 88.41/95.65 | - | - | - | 83.24/92.36 | 91.83/97.82 | 75.12/87.59 | 59.66/78.59 | 81.21/92.36 | 34.00/53.12 | 69.95/83.58 |
 | anserini (passage) | 91.99/95.79 | - | - | - | 88.03/94.25 | 98.01/99.25 | 75.55/87.08 | 61.52/77.80 | 80.18/91.32 | 32.50/47.85 | 65.96/78.45 |
+
+## Reproduction Log[*](reproducibility.md)
+
++ Results reproduced by [@ArthurChen189](https://github.com/ArthurChen189) on 2021-05-03 (commit [`6d48609`](https://github.com/castorini/pyserini/commit/6d486094137a26c8a0a57652a06ab4d42d5bce32))

--- a/scripts/kilt/anserini_retriever.py
+++ b/scripts/kilt/anserini_retriever.py
@@ -81,7 +81,7 @@ def _get_predictions_thread(arguments):
         except jnius.JavaException as e:
             if logger:
                 logger.warning("{query} jnius.JavaException: {}".format(query_element, e))
-            if 'maxClauseError' in str(e):
+            if 'maxClauseCount' in str(e):
                 query = " ".join(query.split()[:950])
                 hits = ranker.search(query, k=topk)
                 doc_ids, doc_scores = parse_hits(hits)


### PR DESCRIPTION
OS: Ubuntu 21.04 

Replication results:

> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/fever-dev-kilt.jsonl KILT/data/fever-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.3821230234721237),
>                 ('precision@1', 0.36202604366143243),
>                 ('precision@100', 0.009222520107239729),
>                 ('recall@100', 0.8840571103329627),
>                 ('success_rate@100', 0.8933358866334737),
>                 ('precision@1000', 0.0010051704327843417),
>                 ('recall@1000', 0.9564598493552918),
>                 ('success_rate@1000', 0.962562236690923)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/aidayago2-dev-kilt.jsonl KILT/data/aidayago2-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.034280936454849496),
>                 ('precision@1', 0.034280936454849496),
>                 ('precision@100', 0.0025020903010033006),
>                 ('recall@100', 0.25020903010033446),
>                 ('success_rate@100', 0.25020903010033446),
>                 ('precision@1000', 0.0004546404682273979),
>                 ('recall@1000', 0.45464046822742477),
>                 ('success_rate@1000', 0.45464046822742477)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/wned-dev-kilt.jsonl KILT/data/wned-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.0008833922261484099),
>                 ('precision@1', 0.0008833922261484099),
>                 ('precision@100', 0.0027149587750294017),
>                 ('recall@100', 0.2714958775029446),
>                 ('success_rate@100', 0.2714958775029446),
>                 ('precision@1000', 0.0005029446407538052),
>                 ('recall@1000', 0.502944640753828),
>                 ('success_rate@1000', 0.502944640753828)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/cweb-dev-kilt.jsonl KILT/data/cweb-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.02714770494731202),
>                 ('precision@1', 0.02714770494731202),
>                 ('precision@100', 0.0019146276120735517),
>                 ('recall@100', 0.19146276120735845),
>                 ('success_rate@100', 0.19146276120735845),
>                 ('precision@1000', 0.0003498839078406671),
>                 ('recall@1000', 0.34988390784068585),
>                 ('success_rate@1000', 0.34988390784068585)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/trex-dev-kilt.jsonl KILT/data/trex-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.4464),
>                 ('precision@1', 0.4464),
>                 ('precision@100', 0.009409999999999854),
>                 ('recall@100', 0.8326261089271926),
>                 ('success_rate@100', 0.849),
>                 ('precision@1000', 0.0010938000000000245),
>                 ('recall@1000', 0.9237630383015674),
>                 ('success_rate@1000', 0.9334)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/structured_zeroshot-dev-kilt.jsonl KILT/data/structured_zeroshot-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.5008055853920516),
>                 ('precision@1', 0.5008055853920516),
>                 ('precision@100', 0.00918367346938823),
>                 ('recall@100', 0.9183673469387755),
>                 ('success_rate@100', 0.9183673469387755),
>                 ('precision@1000', 0.00097824919441453),
>                 ('recall@1000', 0.978249194414608),
>                 ('success_rate@1000', 0.978249194414608)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/nq-dev-kilt.jsonl KILT/data/nq-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.299259781459288),
>                 ('precision@1', 0.299259781459288),
>                 ('precision@100', 0.01136411702502681),
>                 ('recall@100', 0.7512336975678534),
>                 ('success_rate@100', 0.8579485371871696),
>                 ('precision@1000', 0.0013722241804722548),
>                 ('recall@1000', 0.8758900246739517),
>                 ('success_rate@1000', 0.9460697920338386)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/hotpotqa-dev-kilt.jsonl KILT/data/hotpotqa-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.3836607142857143),
>                 ('precision@1', 0.11017857142857143),
>                 ('precision@100', 0.005966071428571772),
>                 ('recall@100', 0.5966071428571429),
>                 ('success_rate@100', 0.5966071428571429),
>                 ('precision@1000', 0.0007860714285713937),
>                 ('recall@1000', 0.7860714285714285),
>                 ('success_rate@1000', 0.7860714285714285)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/triviaqa-dev-kilt.jsonl KILT/data/triviaqa-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.3676058966225042),
>                 ('precision@1', 0.3676058966225042),
>                 ('precision@100', 0.01310319089382357),
>                 ('recall@100', 0.812061280035716),
>                 ('success_rate@100', 0.8977421160664303),
>                 ('precision@1000', 0.0015278969957081751),
>                 ('recall@1000', 0.9235869343072186),
>                 ('success_rate@1000', 0.960813584623997)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/eli5-dev-kilt.jsonl KILT/data/eli5-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.07166556071665561),
>                 ('precision@1', 0.07166556071665561),
>                 ('precision@100', 0.004631718646317124),
>                 ('recall@100', 0.34002433090024314),
>                 ('success_rate@100', 0.41274054412740546),
>                 ('precision@1000', 0.0007498341074983341),
>                 ('recall@1000', 0.5311877903118778),
>                 ('success_rate@1000', 0.6177836761778368)])
> + python KILT/kilt/eval_retrieval.py pyserini/runs/kilt_document/wow-dev-kilt.jsonl KILT/data/wow-dev-kilt.jsonl --ks 1,100,1000
> OrderedDict([   ('Rprec', 0.22269457161543493),
>                 ('precision@1', 0.22269457161543493),
>                 ('precision@100', 0.0069947678221061295),
>                 ('recall@100', 0.6994767822105952),
>                 ('success_rate@100', 0.6994767822105952),
>                 ('precision@1000', 0.0008358404185741758),
>                 ('recall@1000', 0.8358404185742315),
>                 ('success_rate@1000', 0.8358404185742315)])