### PR TITLE
Add retrievers and models to demo

### DIFF
--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -40,10 +40,8 @@ class MsMarcoDemo(cmd.Cmd):
     def do_help(self, arg):
         print(f'/help    : returns this message')
         print(f'/k [NUM] : sets k (number of hits to return) to [NUM]')
-        print(
-            f'/model [MODEL] : sets encoder to use the model [MODEL] (one of tct, ance)')
-        print(
-            f'/mode [MODE] : sets retriver type to [MODE] (one of sparse, dense, hybrid)')
+        print(f'/model [MODEL] : sets encoder to use the model [MODEL] (one of tct, ance)')
+        print(f'/mode [MODE] : sets retriver type to [MODE] (one of sparse, dense, hybrid)')
 
     def do_k(self, arg):
         print(f'setting k = {int(arg)}')
@@ -54,17 +52,17 @@ class MsMarcoDemo(cmd.Cmd):
             self.searcher = self.ssearcher
         elif arg == "dense":
             if self.dsearcher is None:
-                print(f'specify model through /model before using dense retrieval')
+                print(f'Specify model through /model before using dense retrieval.')
                 return
             self.searcher = self.dsearcher
         elif arg == "hybrid":
             if self.hsearcher is None:
-                print(f'specify model through /model before using hybrid retrieval')
+                print(f'Specify model through /model before using hybrid retrieval.')
                 return
             self.searcher = self.hsearcher
         else:
             print(
-                f'invalid mode {arg}. mode should be one of [sparse, dense, hybrid]')
+                f'Mode "{arg}" is invalid. Mode should be one of [sparse, dense, hybrid].')
             return
         print(f'setting retriver = {arg}')
 
@@ -77,7 +75,7 @@ class MsMarcoDemo(cmd.Cmd):
             index = "msmarco-passage-ance-bf"
         else:
             print(
-                f"Invalid argument {arg}. model should be one of [tct, ance]")
+                f'Model "{arg}" is invalid. Model should be one of [tct, ance].')
             return
 
         self.dsearcher = SimpleDenseSearcher.from_prebuilt_index(

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -64,7 +64,7 @@ class MsMarcoDemo(cmd.Cmd):
             self.searcher = self.hsearcher
         else:
             print(
-                f'invalid mode. mode should be one of [sparse, dense, hybrid]')
+                f'invalid mode {arg}. mode should be one of [sparse, dense, hybrid]')
             return
         print(f'setting retriver = {arg}')
 
@@ -94,15 +94,15 @@ class MsMarcoDemo(cmd.Cmd):
         hits = self.searcher.search(q, self.k)
 
         for i in range(0, len(hits)):
-            contents = ""
+            raw_doc = None
             if isinstance(self.searcher, SimpleSearcher):
-                jsondoc = json.loads(hits[i].raw)
-                contents = jsondoc["contents"]
+                raw_doc = hits[i].raw
             else:
                 doc = self.ssearcher.doc(hits[i].docid)
                 if doc:
-                    jsondoc = json.loads(doc.raw())
-                    contents = jsondoc["contents"]
+                    raw_doc = doc.raw()
+            jsondoc = json.loads(raw_doc)
+            contents = jsondoc["contents"]
             print(f'{i + 1:2} {hits[i].score:.5f} {contents}')
 
 

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -43,13 +43,13 @@ class MsMarcoDemo(cmd.Cmd):
         print(
             f'/model [MODEL] : sets encoder to use the model [MODEL] (one of tct, ance)')
         print(
-            f'/retriever [RETRIEVER] : sets retriver type to [RETRIEVER] (one of sparse, dense, hybrid)')
+            f'/mode [MODE] : sets retriver type to [MODE] (one of sparse, dense, hybrid)')
 
     def do_k(self, arg):
         print(f'setting k = {int(arg)}')
         self.k = int(arg)
 
-    def do_retriever(self, arg):
+    def do_mode(self, arg):
         if arg == "sparse":
             self.searcher = self.ssearcher
         elif arg == "dense":
@@ -64,7 +64,7 @@ class MsMarcoDemo(cmd.Cmd):
             self.searcher = self.hsearcher
         else:
             print(
-                f'invalid retrieval method. retrieval should be one of [sparse, dense, retrieval]')
+                f'invalid mode. mode should be one of [sparse, dense, hybrid]')
             return
         print(f'setting retriver = {arg}')
 

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -102,8 +102,7 @@ class MsMarcoDemo(cmd.Cmd):
                 if doc:
                     raw_doc = doc.raw()
             jsondoc = json.loads(raw_doc)
-            contents = jsondoc["contents"]
-            print(f'{i + 1:2} {hits[i].score:.5f} {contents}')
+            print(f'{i + 1:2} {hits[i].score:.5f} {jsondoc["contents"]}')
 
 
 if __name__ == '__main__':

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -101,7 +101,8 @@ class MsMarcoDemo(cmd.Cmd):
             else:
                 doc = self.ssearcher.doc(hits[i].docid)
                 if doc:
-                    contents = doc.contents()
+                    jsondoc = json.loads(doc.raw())
+                    contents = jsondoc["contents"]
             print(f'{i + 1:2} {hits[i].score:.5f} {contents}')
 
 

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -62,6 +62,10 @@ class MsMarcoDemo(cmd.Cmd):
                 print(f'specify model through /model before using hybrid retrieval')
                 return
             self.searcher = self.hsearcher
+        else:
+            print(
+                f'invalid retrieval method. retrievel should be one of [sparse, dense, retrieval]')
+            return
         print(f'setting retriver = {arg}')
 
     def do_model(self, arg):
@@ -72,7 +76,8 @@ class MsMarcoDemo(cmd.Cmd):
             encoder = AnceQueryEncoder("castorini/ance-msmarco-passage")
             index = "msmarco-passage-ance-bf"
         else:
-            print(f"Invalid argument {arg}. model should be one [tct, ance]")
+            print(
+                f"Invalid argument {arg}. model should be one of [tct, ance]")
             return
 
         self.dsearcher = SimpleDenseSearcher.from_prebuilt_index(

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -60,7 +60,7 @@ class MsMarcoDemo(cmd.Cmd):
 
     def do_model(self, arg):
         if arg == "tct":
-            encoder = TctColBertQueryEncoder("astorini/tct_colbert-msmarco")
+            encoder = TctColBertQueryEncoder("castorini/tct_colbert-msmarco")
             index = "msmarco-passage-tct_colbert-hnsw"
         elif arg == "ance":
             encoder = AnceQueryEncoder("castorini/ance-msmarco-passage")

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -64,7 +64,7 @@ class MsMarcoDemo(cmd.Cmd):
             self.searcher = self.hsearcher
         else:
             print(
-                f'invalid retrieval method. retrievel should be one of [sparse, dense, retrieval]')
+                f'invalid retrieval method. retrieval should be one of [sparse, dense, retrieval]')
             return
         print(f'setting retriver = {arg}')
 

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -56,6 +56,7 @@ class MsMarcoDemo(cmd.Cmd):
             self.searcher = self.dsearcher
         elif arg == "hybrid":
             self.searcher = self.hsearcher
+        print(f'setting retriver = {arg}')
 
     def do_model(self, arg):
         if arg == "tct":
@@ -73,6 +74,7 @@ class MsMarcoDemo(cmd.Cmd):
             encoder
         )
         self.hsearcher = HybridSearcher(self.dsearcher, self.ssearcher)
+        print(f'setting model = {arg}')
 
     def do_EOF(self, line):
         return True

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -94,8 +94,15 @@ class MsMarcoDemo(cmd.Cmd):
         hits = self.searcher.search(q, self.k)
 
         for i in range(0, len(hits)):
-            jsondoc = json.loads(hits[i].raw)
-            print(f'{i + 1:2} {hits[i].score:.5f} {jsondoc["contents"]}')
+            contents = ""
+            if isinstance(self.searcher, SimpleSearcher):
+                jsondoc = json.loads(hits[i].raw)
+                contents = jsondoc["contents"]
+            else:
+                doc = self.ssearcher.doc(hits[i].docid)
+                if doc:
+                    contents = doc.contents()
+            print(f'{i + 1:2} {hits[i].score:.5f} {contents}')
 
 
 if __name__ == '__main__':

--- a/pyserini/demo/msmarco.py
+++ b/pyserini/demo/msmarco.py
@@ -53,8 +53,14 @@ class MsMarcoDemo(cmd.Cmd):
         if arg == "sparse":
             self.searcher = self.ssearcher
         elif arg == "dense":
+            if self.dsearcher is None:
+                print(f'specify model through /model before using dense retrieval')
+                return
             self.searcher = self.dsearcher
         elif arg == "hybrid":
+            if self.hsearcher is None:
+                print(f'specify model through /model before using hybrid retrieval')
+                return
             self.searcher = self.hsearcher
         print(f'setting retriver = {arg}')
 


### PR DESCRIPTION
Solves https://github.com/castorini/pyserini/issues/548 (interactive retrieval demo). 

This PR adds support for `dense` and `hybrid` retrievers to the interactive demo through the `/mode` command. 
For these retrievers, this PR adds support for 2 encoder models, `tct` and `ance`.

Also, with `tct`, there are 2 possible indices: (1) HNSW index i.e. and (2) brute-force index i.e. msmarco-passage-tct_colbert-bf. I used (1) in this PR.