### PR TITLE
Update TCT ColBERT repro log

### DIFF
--- a/docs/experiments-ance.md
+++ b/docs/experiments-ance.md
@@ -144,4 +144,4 @@ Top100	accuracy: 0.8522
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-25 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
 + Results reproduced by [@jingtaozhan](https://github.com/jingtaozhan) on 2021-05-15 (commit [`53d8d3c`](https://github.com/castorini/pyserini/commit/53d8d3cbb78c88a23ce132a42b0396caad7d2e0f))
-+ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-17 (commit [`c6c394`](https://github.com/castorini/pyserini/commit/c6c39450ca16045bcb32494053c0c16fc52c0fcb))
++ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-17 (PyPi [`0.12.0`](https://pypi.org/project/pyserini/0.12.0/))

--- a/docs/experiments-ance.md
+++ b/docs/experiments-ance.md
@@ -144,3 +144,4 @@ Top100	accuracy: 0.8522
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-25 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
 + Results reproduced by [@jingtaozhan](https://github.com/jingtaozhan) on 2021-05-15 (commit [`53d8d3c`](https://github.com/castorini/pyserini/commit/53d8d3cbb78c88a23ce132a42b0396caad7d2e0f))
++ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-17 (commit [`c6c394`](https://github.com/castorini/pyserini/commit/c6c39450ca16045bcb32494053c0c16fc52c0fcb))

--- a/docs/experiments-tct_colbert.md
+++ b/docs/experiments-tct_colbert.md
@@ -279,4 +279,4 @@ recall_100            	all	0.9081
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-02-12 (commit [`52a1e7`](https://github.com/castorini/pyserini/commit/52a1e7f241b7b833a3ec1d739e629c08417a324c))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-25 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
 + Results reproduced by [@jingtaozhan](https://github.com/jingtaozhan) on 2021-05-15 (commit [`53d8d3c`](https://github.com/castorini/pyserini/commit/53d8d3cbb78c88a23ce132a42b0396caad7d2e0f))
-+ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-15 (commit [`c6c394`](https://github.com/castorini/pyserini/commit/c6c39450ca16045bcb32494053c0c16fc52c0fcb))
++ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-17 (commit [`c6c394`](https://github.com/castorini/pyserini/commit/c6c39450ca16045bcb32494053c0c16fc52c0fcb))

--- a/docs/experiments-tct_colbert.md
+++ b/docs/experiments-tct_colbert.md
@@ -278,4 +278,4 @@ recall_100            	all	0.9081
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-02-12 (commit [`52a1e7`](https://github.com/castorini/pyserini/commit/52a1e7f241b7b833a3ec1d739e629c08417a324c))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-25 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
-+ Results reproduced by [@jingtaozhan](https://github.com/jingtaozhan) on 2021-05-15 (commit [`53d8d3c`](https://github.com/castorini/pyserini/commit/53d8d3cbb78c88a23ce132a42b0396caad7d2e0f))
++ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-15 (commit [`c6c394`](https://github.com/castorini/pyserini/commit/c6c39450ca16045bcb32494053c0c16fc52c0fcb))

--- a/docs/experiments-tct_colbert.md
+++ b/docs/experiments-tct_colbert.md
@@ -278,4 +278,5 @@ recall_100            	all	0.9081
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-02-12 (commit [`52a1e7`](https://github.com/castorini/pyserini/commit/52a1e7f241b7b833a3ec1d739e629c08417a324c))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-25 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
++ Results reproduced by [@jingtaozhan](https://github.com/jingtaozhan) on 2021-05-15 (commit [`53d8d3c`](https://github.com/castorini/pyserini/commit/53d8d3cbb78c88a23ce132a42b0396caad7d2e0f))
 + Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-15 (commit [`c6c394`](https://github.com/castorini/pyserini/commit/c6c39450ca16045bcb32494053c0c16fc52c0fcb))

--- a/docs/experiments-tct_colbert.md
+++ b/docs/experiments-tct_colbert.md
@@ -279,4 +279,4 @@ recall_100            	all	0.9081
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-02-12 (commit [`52a1e7`](https://github.com/castorini/pyserini/commit/52a1e7f241b7b833a3ec1d739e629c08417a324c))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-25 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
 + Results reproduced by [@jingtaozhan](https://github.com/jingtaozhan) on 2021-05-15 (commit [`53d8d3c`](https://github.com/castorini/pyserini/commit/53d8d3cbb78c88a23ce132a42b0396caad7d2e0f))
-+ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-17 (commit [`c6c394`](https://github.com/castorini/pyserini/commit/c6c39450ca16045bcb32494053c0c16fc52c0fcb))
++ Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-17 (PyPi [`0.12.0`](https://pypi.org/project/pyserini/0.12.0/))


### PR DESCRIPTION
Notes: Used Pyserini (0.12.0) via Pip. Only examined passages; CPU running over pre-built indexes; reproduced both brute force and HNSW runs.

Package version info:
```
faiss-cpu==1.7.0
torch==1.7.1
transformers==4.0.0
```