### PR TITLE
vsearch based on hnsw (nmslib)

### DIFF
--- a/pyserini/output_writer.py
+++ b/pyserini/output_writer.py
@@ -110,3 +110,7 @@ def get_output_writer(file_path: str, output_format: OutputFormat, *args, **kwar
         OutputFormat.KILT: KiltWriter,
     }
     return mapping[output_format](file_path, *args, **kwargs)
+
+
+def tie_breaker(hits):
+    return sorted(hits, key=lambda x: (-x.score, x.docid))

--- a/pyserini/vsearch/__init__.py
+++ b/pyserini/vsearch/__init__.py
@@ -1,0 +1,19 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from ._vsearcher import SearchResult, SimpleVectorSearcher
+
+__all__ = ['SearchResult', 'SimpleVectorSearcher']

--- a/pyserini/vsearch/__main__.py
+++ b/pyserini/vsearch/__main__.py
@@ -19,7 +19,7 @@ import json
 from tqdm import tqdm
 
 from pyserini.vsearch import SimpleVectorSearcher
-from pyserini.output_writer import get_output_writer, OutputFormat
+from pyserini.output_writer import get_output_writer, OutputFormat, tie_breaker
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Search a nmslib index.')
@@ -81,6 +81,6 @@ if __name__ == '__main__':
                     continue
 
             for topic, hits in results:
-                output_writer.write(topic, hits)
+                output_writer.write(topic, tie_breaker(hits))
 
             results.clear()

--- a/pyserini/vsearch/__main__.py
+++ b/pyserini/vsearch/__main__.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
     parser.add_argument('--output-format', type=str, metavar='format', default=OutputFormat.TREC.value,
                         help=f"Format of output. Available: {[x.value for x in list(OutputFormat)]}")
     parser.add_argument('--output', type=str, metavar='path', required=True, help="Path to output file.")
+    parser.add_argument('--ef', type=int, required=False, default=256, help="hnsw ef_search")
     parser.add_argument('--threads', type=int, metavar='num', required=False, default=1,
                         help="maximum threads to use during search")
     parser.add_argument('--batch-size', type=int, metavar='num', required=False, default=1,
@@ -40,7 +41,7 @@ if __name__ == '__main__':
     parser.add_argument('--dim', type=int, required=True)
     args = parser.parse_args()
 
-    searcher = SimpleVectorSearcher(args.index, is_sparse=args.is_sparse)
+    searcher = SimpleVectorSearcher(args.index, ef_search=args.ef, is_sparse=args.is_sparse)
 
     topics = json.load(open(args.topics))
     topic_ids = [str(t['id']) for t in topics]

--- a/pyserini/vsearch/__main__.py
+++ b/pyserini/vsearch/__main__.py
@@ -1,0 +1,100 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import json
+from scipy.sparse import csr_matrix, vstack
+
+from tqdm import tqdm
+
+from pyserini.vsearch import SimpleVectorSearcher
+from pyserini.output_writer import get_output_writer, OutputFormat
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Search a nmslib index.')
+    parser.add_argument('--index', type=str, metavar='path to index or index name', required=True,
+                        help="Path to nmslib index.")
+    parser.add_argument('--topics', type=str, required=True, help="path to topics")
+    parser.add_argument('--hits', type=int, metavar='num', required=False, default=1000, help="Number of hits.")
+    parser.add_argument('--output-format', type=str, metavar='format', default=OutputFormat.TREC.value,
+                        help=f"Format of output. Available: {[x.value for x in list(OutputFormat)]}")
+    parser.add_argument('--output', type=str, metavar='path', required=True, help="Path to output file.")
+    parser.add_argument('--threads', type=int, metavar='num', required=False, default=1,
+                        help="maximum threads to use during search")
+    parser.add_argument('--batch-size', type=int, metavar='num', required=False, default=1,
+                        help="search batch of queries in parallel")
+    parser.add_argument('--is-sparse', action='store_true', required=False)
+    parser.add_argument('--dim', type=int, required=True)
+    args = parser.parse_args()
+
+    print(args.is_sparse)
+    searcher = SimpleVectorSearcher(args.index, is_sparse=args.is_sparse)
+
+    topics = json.load(open(args.topics))
+    topic_ids = [str(t['id']) for t in topics]
+    topic_vectors = []
+    if args.is_sparse:
+        matrix_row, matrix_col, matrix_data = [], [], []
+        for i, t in enumerate(topics):
+            matrix_row.extend([i]*len(t['vector'][0]))
+            matrix_col.extend(t['vector'][0])
+            matrix_data.extend(t['vector'][1])
+        topic_vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(len(topics), args.dim))
+        print(topic_vectors)
+    else:
+        for i, t in enumerate(topics):
+            topic_vectors.append(t['vector'])
+
+    if not searcher:
+        exit()
+
+    # build output path
+    output_path = args.output
+
+    print(f'Running {args.topics} topics, saving to {output_path}...')
+    tag = 'HNSW'
+
+    # support trec and msmarco format only for now
+    output_writer = get_output_writer(output_path, OutputFormat(args.output_format), max_hits=args.hits, tag=tag)
+
+    with output_writer:
+        batch_topic_vectors = list()
+        batch_topic_ids = list()
+        for index, (topic_id, vec) in enumerate(tqdm(zip(topic_ids, topic_vectors))):
+            if args.batch_size <= 1 and args.threads <= 1:
+                hits = searcher.search(vec, args.hits)
+                results = [(topic_id, hits)]
+            else:
+                batch_topic_ids.append(str(topic_id))
+                batch_topic_vectors.append(vec)
+                if (index + 1) % args.batch_size == 0 or \
+                        index == len(topics) - 1:
+                    if args.is_sparse:
+                        results = searcher.batch_search(
+                            vstack(batch_topic_vectors), batch_topic_ids, args.hits, args.threads)
+                    else:
+                        results = searcher.batch_search(
+                            batch_topic_vectors, batch_topic_ids, args.hits, args.threads)
+                    results = [(id_, results[id_]) for id_ in batch_topic_ids]
+                    batch_topic_ids.clear()
+                    batch_topic_vectors.clear()
+                else:
+                    continue
+
+            for topic, hits in results:
+                output_writer.write(topic, hits)
+
+            results.clear()

--- a/pyserini/vsearch/__main__.py
+++ b/pyserini/vsearch/__main__.py
@@ -36,7 +36,6 @@ if __name__ == '__main__':
     parser.add_argument('--batch-size', type=int, metavar='num', required=False, default=1,
                         help="search batch of queries in parallel")
     parser.add_argument('--is-sparse', action='store_true', required=False)
-    parser.add_argument('--dim', type=int, required=True)
     args = parser.parse_args()
 
     searcher = SimpleVectorSearcher(args.index, ef_search=args.ef, is_sparse=args.is_sparse)

--- a/pyserini/vsearch/_vsearcher.py
+++ b/pyserini/vsearch/_vsearcher.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import json
 import os
 from dataclasses import dataclass
 from typing import Dict, List
 
 import nmslib
+import numpy as np
+from scipy.sparse import csr_matrix, vstack
 
 
 @dataclass
@@ -33,8 +35,9 @@ class SimpleVectorSearcher:
 
     def __init__(self, index_dir: str, ef_search: int = 1000, is_sparse=False):
         self.is_sparse = is_sparse
-        self.index, self.docids = self._load_index(index_dir, self.is_sparse)
+        self.index, self.docids, self.token2id, self.metadata = self._load_index(index_dir, self.is_sparse)
         self.index.setQueryTimeParams({'efSearch': ef_search})
+        self.dimension = len(self.token2id) if self.is_sparse else None
 
     def search(self, query, k: int = 10) -> List[SearchResult]:
         """Search the collection.
@@ -51,6 +54,10 @@ class SimpleVectorSearcher:
         List[SearchResult]
             List of search results.
         """
+        if self.is_sparse:
+            query = self._token_dict_to_sparse_vector(query)
+        else:
+            query = np.array([query])
         indexes, scores = self.index.knnQueryBatch(query, k=k, num_threads=1)[0]
         return [SearchResult(self.docids[idx], -score)
                 for score, idx in zip(scores, indexes) if idx != -1]
@@ -61,8 +68,7 @@ class SimpleVectorSearcher:
 
         Parameters
         ----------
-        queries : List[str]
-            List of query texts
+        queries : vectors
         q_ids : List[str]
             List of corresponding query ids.
         k : int
@@ -76,6 +82,11 @@ class SimpleVectorSearcher:
             Dictionary holding the search results, with the query ids as keys and the corresponding lists of search
             results as the values.
         """
+        if self.is_sparse:
+            queries = [self._token_dict_to_sparse_vector(query) for query in queries]
+            queries = vstack(queries)
+        else:
+            queries = np.array(queries)
         I, D = zip(*self.index.knnQueryBatch(queries, k=k, num_threads=threads))
         return {key: [SearchResult(self.docids[idx], -score)
                       for score, idx in zip(distances, indexes) if idx != -1]
@@ -86,13 +97,42 @@ class SimpleVectorSearcher:
             index = nmslib.init(method='hnsw', space='negdotprod_sparse', data_type=nmslib.DataType.SPARSE_VECTOR)
         else:
             index = nmslib.init(method='hnsw', space='negdotprod', data_type=nmslib.DataType.DENSE_VECTOR)
-        index_path = os.path.join(index_dir, 'sparse_index.bin')
+        index_path = os.path.join(index_dir, 'index.bin')
         docid_path = os.path.join(index_dir, 'docid')
+        tokens_path = os.path.join(index_dir, 'tokens')
+        metadata_path = os.path.join(index_dir, 'meta')
         index.loadIndex(index_path, load_data=True)
         docids = self._load_docids(docid_path)
-        return index, docids
+        token2id = self._load_tokens(tokens_path)
+        metadata = self._load_metadata(metadata_path)
+        return index, docids, token2id, metadata
+
+    def _token_dict_to_sparse_vector(self, token_dict):
+        matrix_row, matrix_col, matrix_data = [], [], []
+        tokens = token_dict.keys()
+        col = [self.token2id[tok] for tok in tokens]
+        data = token_dict.values()
+        matrix_row.extend([0] * len(token_dict))
+        matrix_col.extend(col)
+        matrix_data.extend(data)
+        vector = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(1, self.dimension))
+        return vector
 
     @staticmethod
     def _load_docids(docid_path: str) -> List[str]:
         docids = [line.rstrip() for line in open(docid_path, 'r').readlines()]
         return docids
+
+    @staticmethod
+    def _load_tokens(tokens_path: str):
+        if not os.path.exists(tokens_path):
+            return None
+        tokens = [line.rstrip() for line in open(tokens_path, 'r').readlines()]
+        return dict(zip(tokens, range(len(tokens))))
+
+    @staticmethod
+    def _load_metadata(metadata_path):
+        if not os.path.exists(metadata_path):
+            return None
+        meta = json.load(metadata_path)
+        return meta

--- a/pyserini/vsearch/_vsearcher.py
+++ b/pyserini/vsearch/_vsearcher.py
@@ -134,5 +134,5 @@ class SimpleVectorSearcher:
     def _load_metadata(metadata_path):
         if not os.path.exists(metadata_path):
             return None
-        meta = json.load(metadata_path)
+        meta = json.load(open(metadata_path))
         return meta

--- a/pyserini/vsearch/_vsearcher.py
+++ b/pyserini/vsearch/_vsearcher.py
@@ -66,10 +66,8 @@ class SimpleVectorSearcher:
                 for key, distances, indexes in zip(q_ids, D, I)}
 
     def _load_index(self, index_dir: str, is_sparse: bool):
-        print(is_sparse)
         if is_sparse:
             index = nmslib.init(method='hnsw', space='negdotprod_sparse', data_type=nmslib.DataType.SPARSE_VECTOR)
-            print("AAA")
         else:
             index = nmslib.init(method='hnsw', space='negdotprod', data_type=nmslib.DataType.DENSE_VECTOR)
         index_path = os.path.join(index_dir, 'sparse_index.bin')

--- a/pyserini/vsearch/_vsearcher.py
+++ b/pyserini/vsearch/_vsearcher.py
@@ -110,9 +110,13 @@ class SimpleVectorSearcher:
     def _token_dict_to_sparse_vector(self, token_dict):
         matrix_row, matrix_col, matrix_data = [], [], []
         tokens = token_dict.keys()
-        col = [self.token2id[tok] for tok in tokens]
-        data = token_dict.values()
-        matrix_row.extend([0] * len(token_dict))
+        col = []
+        data = []
+        for tok in tokens:
+            if tok in self.token2id:
+                col.append(self.token2id[tok])
+                data.append(token_dict[tok])
+        matrix_row.extend([0] * len(col))
         matrix_col.extend(col)
         matrix_data.extend(data)
         vector = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(1, self.dimension))

--- a/pyserini/vsearch/_vsearcher.py
+++ b/pyserini/vsearch/_vsearcher.py
@@ -1,3 +1,19 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 from dataclasses import dataclass
 from typing import Dict, List

--- a/pyserini/vsearch/_vsearcher.py
+++ b/pyserini/vsearch/_vsearcher.py
@@ -1,0 +1,84 @@
+import os
+from dataclasses import dataclass
+from typing import Dict, List
+
+import nmslib
+
+
+@dataclass
+class SearchResult:
+    docid: str
+    score: float
+
+
+class SimpleVectorSearcher:
+    """Simple Searcher for vector representation
+    """
+
+    def __init__(self, index_dir: str, ef_search: int = 1000, is_sparse=False):
+        self.is_sparse = is_sparse
+        self.index, self.docids = self._load_index(index_dir, self.is_sparse)
+        self.index.setQueryTimeParams({'efSearch': ef_search})
+
+    def search(self, query, k: int = 10) -> List[SearchResult]:
+        """Search the collection.
+
+        Parameters
+        ----------
+        query : query vector
+        k : int
+            Number of hits to return.
+        threads : int
+            Maximum number of threads to use for intra-query search.
+        Returns
+        -------
+        List[SearchResult]
+            List of search results.
+        """
+        indexes, scores = self.index.knnQueryBatch(query, k=k, num_threads=1)[0]
+        return [SearchResult(self.docids[idx], -score)
+                for score, idx in zip(scores, indexes) if idx != -1]
+
+    def batch_search(self, queries, q_ids: List[str], k: int = 10, threads: int = 1) \
+            -> Dict[str, List[SearchResult]]:
+        """
+
+        Parameters
+        ----------
+        queries : List[str]
+            List of query texts
+        q_ids : List[str]
+            List of corresponding query ids.
+        k : int
+            Number of hits to return.
+        threads : int
+            Maximum number of threads to use.
+
+        Returns
+        -------
+        Dict[str, List[SearchResult]]
+            Dictionary holding the search results, with the query ids as keys and the corresponding lists of search
+            results as the values.
+        """
+        I, D = zip(*self.index.knnQueryBatch(queries, k=k, num_threads=threads))
+        return {key: [SearchResult(self.docids[idx], -score)
+                      for score, idx in zip(distances, indexes) if idx != -1]
+                for key, distances, indexes in zip(q_ids, D, I)}
+
+    def _load_index(self, index_dir: str, is_sparse: bool):
+        print(is_sparse)
+        if is_sparse:
+            index = nmslib.init(method='hnsw', space='negdotprod_sparse', data_type=nmslib.DataType.SPARSE_VECTOR)
+            print("AAA")
+        else:
+            index = nmslib.init(method='hnsw', space='negdotprod', data_type=nmslib.DataType.DENSE_VECTOR)
+        index_path = os.path.join(index_dir, 'sparse_index.bin')
+        docid_path = os.path.join(index_dir, 'docid')
+        index.loadIndex(index_path, load_data=True)
+        docids = self._load_docids(docid_path)
+        return index, docids
+
+    @staticmethod
+    def _load_docids(docid_path: str) -> List[str]:
+        docids = [line.rstrip() for line in open(docid_path, 'r').readlines()]
+        return docids

--- a/pyserini/vsearch/index.py
+++ b/pyserini/vsearch/index.py
@@ -32,7 +32,6 @@ if __name__ == '__main__':
     parser.add_argument('--M', type=int, help='M for hnsw', required=False, default=64)
     parser.add_argument('--ef', type=int, help='ef for hnsw', required=False, default=256)
     parser.add_argument('--threads', type=int, help='threads for hnsw', required=False, default=12)
-    parser.add_argument('--dim', type=int, help='dimension of passage embeddings', required=False, default=768)
     parser.add_argument('--is-sparse', action='store_true', required=False)
     parser.add_argument('--tokens', type=str, help='path to token list', required=False)
     args = parser.parse_args()
@@ -75,7 +74,7 @@ if __name__ == '__main__':
             matrix_row.extend([i] * len(weight_dict))
             matrix_col.extend(col)
             matrix_data.extend(data)
-        vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(len(corpus), args.dim))
+        vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(len(corpus), len(token2id)))
     else:
         for i, d in enumerate(tqdm(corpus)):
             vectors.append(d['vector'])

--- a/pyserini/vsearch/index.py
+++ b/pyserini/vsearch/index.py
@@ -1,0 +1,71 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import json
+import os
+import time
+
+import nmslib
+from scipy.sparse import csr_matrix
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--corpus', type=str, help='path to corpus with vectors', required=True)
+    parser.add_argument('--hnsw-index', type=str, help='path to hnsw index', required=True)
+    parser.add_argument('--M', type=int, help='M for hnsw', required=False, default=64)
+    parser.add_argument('--ef', type=int, help='ef for hnsw', required=False, default=256)
+    parser.add_argument('--threads', type=int, help='threads for hnsw', required=False, default=12)
+    parser.add_argument('--dim', type=int, help='dimension of passage embeddings', required=False, default=768)
+    parser.add_argument('--is-sparse', action='store_true', required=False)
+    args = parser.parse_args()
+
+    corpus = json.load(open(args.corpus, 'r'))
+    if not os.path.exists(args.hnsw_index):
+        os.mkdir(args.hnsw_index)
+
+    with open(os.path.join(args.hnsw_index, 'sparse_index.bin'), 'w') as f:
+        for d in corpus:
+            docid = str(d['id'])
+        f.write(f'{docid}\n')
+
+    vectors = []
+    if args.is_sparse:
+        matrix_row, matrix_col, matrix_data = [], [], []
+        for i, d in enumerate(corpus):
+            matrix_row.extend([i] * len(d['vector'][0]))
+            matrix_col.extend(d['vector'][0])
+            matrix_data.extend(d['vector'][1])
+        topic_vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(len(corpus), args.dim))
+    else:
+        for i, d in enumerate(corpus):
+            vectors.append(d['vector'])
+
+    M = args.M
+    efC = args.ef
+    num_threads = args.threads
+    index_time_params = {'M': M, 'indexThreadQty': num_threads, 'efConstruction': efC, 'post': 0}
+    if args.is_sparse:
+        index = nmslib.init(method='hnsw', space='negdotprod_sparse', data_type=nmslib.DataType.SPARSE_VECTOR)
+    else:
+        index = nmslib.init(method='hnsw', space='negdotprod', data_type=nmslib.DataType.DENSE_VECTOR)
+    index.addDataPointBatch(vectors)
+    start = time.time()
+    index.createIndex(index_time_params, print_progress=True)
+    end = time.time()
+    print('Index-time parameters', index_time_params)
+    print('Indexing time = %f' % (end - start))
+    index.saveIndex(os.path.join(args.hnsw_index, 'sparse_index.bin'), save_data=True)

--- a/pyserini/vsearch/index.py
+++ b/pyserini/vsearch/index.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     with open(os.path.join(args.hnsw_index, 'docid'), 'w') as f:
         for d in corpus:
             docid = str(d['id'])
-        f.write(f'{docid}\n')
+            f.write(f'{docid}\n')
 
     vectors = []
     if args.is_sparse:

--- a/pyserini/vsearch/index.py
+++ b/pyserini/vsearch/index.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     token2id = {}
     if args.is_sparse:
         with open(args.tokens) as tok_f:
-            for idx, line in tok_f:
+            for idx, line in enumerate(tok_f):
                 tok = line.rstrip()
                 token2id[tok] = idx
 

--- a/pyserini/vsearch/index.py
+++ b/pyserini/vsearch/index.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
     vectors = []
     if args.is_sparse:
         matrix_row, matrix_col, matrix_data = [], [], []
-        for i, d in enumerate(corpus):
+        for i, d in enumerate(tqdm(corpus)):
             weight_dict = d['vector']
             tokens = weight_dict.keys()
             col = [token2id[tok] for tok in tokens]
@@ -75,9 +75,9 @@ if __name__ == '__main__':
             matrix_row.extend([i] * len(weight_dict))
             matrix_col.extend(col)
             matrix_data.extend(data)
-        topic_vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(len(corpus), args.dim))
+        vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(len(corpus), args.dim))
     else:
-        for i, d in enumerate(corpus):
+        for i, d in enumerate(tqdm(corpus)):
             vectors.append(d['vector'])
 
     M = args.M

--- a/scripts/deepimpact/brute-force.py
+++ b/scripts/deepimpact/brute-force.py
@@ -1,0 +1,99 @@
+import argparse
+import json
+import os
+
+from scipy.sparse import csr_matrix
+from tqdm import tqdm
+import numpy as np
+from multiprocessing import Pool, Manager
+
+
+def token_dict_to_sparse_vector(token_dict, token2id):
+    matrix_row, matrix_col, matrix_data = [], [], []
+    tokens = token_dict.keys()
+    col = []
+    data = []
+    for tok in tokens:
+        if tok in token2id:
+            col.append(token2id[tok])
+            data.append(token_dict[tok])
+    matrix_row.extend([0] * len(col))
+    matrix_col.extend(col)
+    matrix_data.extend(data)
+    vector = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(1, len(token2id)))
+    return vector
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--corpus', type=str, help='path to corpus with vectors', required=True)
+parser.add_argument('--topics', type=str, help='path to topics with vectors', required=True)
+parser.add_argument('--tokens', type=str, help='path to token list', required=True)
+parser.add_argument('--run', type=str, help='path to run file', required=True)
+parser.add_argument('--threads', type=int, help='threads for hnsw', required=False, default=12)
+
+args = parser.parse_args()
+
+token2id = {}
+with open(args.tokens) as tok_f:
+    for idx, line in enumerate(tok_f):
+        tok = line.rstrip()
+        token2id[tok] = idx
+
+corpus = []
+for file in sorted(os.listdir(args.corpus)):
+    file = os.path.join(args.corpus, file)
+    if file.endswith('json') or file.endswith('jsonl'):
+        print(f'Loading {file}')
+        with open(file, 'r') as f:
+            for idx, line in enumerate(tqdm(f.readlines())):
+                info = json.loads(line)
+                corpus.append(info)
+
+ids = []
+vectors = []
+matrix_row, matrix_col, matrix_data = [], [], []
+for i, d in enumerate(tqdm(corpus)):
+    weight_dict = d['vector']
+    tokens = weight_dict.keys()
+    col = [token2id[tok] for tok in tokens]
+    data = weight_dict.values()
+    matrix_row.extend([i] * len(weight_dict))
+    matrix_col.extend(col)
+    matrix_data.extend(data)
+    ids.append(d['id'])
+vectors = csr_matrix((matrix_data, (matrix_row, matrix_col)), shape=(len(corpus), len(token2id)))
+
+topic_ids = []
+topic_vectors = []
+with open(args.topics) as topic_f:
+    for line in topic_f:
+        info = json.loads(line)
+        topic_ids.append(info['id'])
+        topic_vectors.append(token_dict_to_sparse_vector(info['vector'], token2id))
+
+vectors_T = vectors.T
+
+manager = Manager()
+results = manager.dict()
+
+
+def run_search(idx):
+    global results
+    qid = topic_ids[idx]
+    t_vec = topic_vectors[idx]
+    scores = np.array(t_vec.dot(vectors_T).todense())[0]
+    top_idx = sorted(range(len(scores)), key=lambda x: scores[x], reverse=True)[:1000]
+    result = [(ids[x], scores[x]) for x in top_idx]
+    results[qid] = result
+
+
+with Pool(args.threads) as p:
+    for _ in tqdm(p.imap_unordered(run_search, list(range(len(topic_ids)))), total=len(topic_ids)):
+        pass
+
+with open(args.run, 'w') as f:
+    for qid in results:
+        for idx, item in enumerate(results[qid]):
+            did = item[0]
+            score = item[1]
+            f.write(f'{qid} Q0 {did} {idx+1} {score} bf\n')


### PR DESCRIPTION
current process to replicate numbers in ICTIR paper:
1. download bm25 hnsw index
```
wget https://www.dropbox.com/s/3i5vjhy4snj0yd8/bm25_hnsw_40_2500.tar.gz
tar -xvf /bm25_hnsw_40_2500.tar.gz
```
2. download msmarco-passage-dev-subset bm25 vectors:
```
wget https://www.dropbox.com/s/gkgeocv2ktfapl6/msmarco-passage-dev-subset-bm25-vectors.json
```
3. run vsearch
```
python -m pyserini.vsearch --index sparse_bm25_indexes/40_2500/ --topics msmarco-passage-dev-subset-bm25-vectors.json --output bm25_ann.run --is-sparse --dim 202514 --batch-size 36 --threads 12
```

Notes:
- we will need a module `/pyserini/vindex` to generate (1)
- (2) currently has following format
```
[
    {
        "id": 1102330,
        "topic": "why do people grind teeth in sleep",
        "vector": [
            [71919,  92561, 144918, 169850, 179980, 196713],
            [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
        ]
...
```