### PR TITLE
Tokenizer test cases for 9 African Languages

### DIFF
--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -286,6 +286,294 @@ class TestTokenization(unittest.TestCase):
         # adversarial
         tokens = tokenizer.tokenize('প্রতিকূল')
         self.assertEqual(['প্রতি', '##ক', '##ূ', '##ল'], tokens)
+    
+    def test_bert_base_multilingual_am(self):
+        """
+        amharic
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('የሽፋኑ ርዕሰ ጉዳይ የሞቱ ሰዎች ይነሳሉ')
+        self.assertEqual(['[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]'], tokens)
+
+        tokens = tokenizer.tokenize('የሽፋኑ')
+        self.assertEqual(['[UNK]'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('የሽፋኑ ርዕሰ ጉዳይ የሞቱ ሰዎች ይነሳሉ')
+        self.assertEqual(['[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]'], tokens)
+
+        tokens = tokenizer.tokenize('የሽፋኑ')
+        self.assertEqual(['[UNK]'], tokens)
+    
+    def test_xlmr_base_multilingual_am(self):
+        """
+        amharic
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('የሽፋኑ ርዕሰ ጉዳይ የሞቱ ሰዎች ይነሳሉ')
+        self.assertEqual(['▁የ', 'ሽ', 'ፋ', 'ኑ', '▁ርዕሰ', '▁ጉዳይ', '▁የ', 'ሞቱ', '▁ሰዎች', '▁ይ', 'ነሳ', 'ሉ'], tokens)
+
+        tokens = tokenizer.tokenize('የሽፋኑ')
+        self.assertEqual(['▁የ', 'ሽ', 'ፋ', 'ኑ'], tokens)
+    
+    def test_bert_base_multilingual_ha(self):
+        """
+        hausa
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('Ya san kungiyar, ya san komai game da kungiyar')
+        self.assertEqual(['ya', 'san', 'kung', '##iya', '##r', ',', 'ya', 'san', 'koma', '##i', 'game', 'da', 'kung', '##iya', '##r'], tokens)
+
+        tokens = tokenizer.tokenize('kungiyar')
+        self.assertEqual(['kung', '##iya', '##r'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('Ya san kungiyar, ya san komai game da kungiyar')
+        self.assertEqual(['Ya', 'san', 'kung', '##iya', '##r', ',', 'ya', 'san', 'koma', '##i', 'game', 'da', 'kung', '##iya', '##r'], tokens)
+
+        tokens = tokenizer.tokenize('kungiyar')
+        self.assertEqual(['kung', '##iya', '##r'], tokens)
+    
+    def test_xlmr_base_multilingual_ha(self):
+        """
+        hausa
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('Ya san kungiyar, ya san komai game da kungiyar')
+        self.assertEqual(['▁Ya', '▁san', '▁kungiyar', ',', '▁ya', '▁san', '▁koma', 'i', '▁game', '▁da', '▁kungiyar'], tokens)
+
+        tokens = tokenizer.tokenize('kungiyar')
+        self.assertEqual(['▁kungiyar'], tokens)
+
+    def test_bert_base_multilingual_ig(self):
+        """
+        igbo
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('Oke Ọñụ Adaa Dịka Lọọlọ Ezenneka gbàrà Ahọ Otu Narị')
+        self.assertEqual(['ok', '##e', 'onu', 'ada', '##a', 'dik', '##a', 'lo', '##olo', 'ezen', '##nek', '##a', 'gba', '##ra', 'ah', '##o', 'ot', '##u', 'nar', '##i'], tokens)
+
+        tokens = tokenizer.tokenize('Ezenneka')
+        self.assertEqual(['ezen', '##nek', '##a'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('Oke Ọñụ Adaa Dịka Lọọlọ Ezenneka gbàrà Ahọ Otu Narị')
+        self.assertEqual(['Ok', '##e', 'Ọ', '##ñ', '##ụ', 'Ada', '##a', 'D', '##ị', '##ka', 'L', '##ọ', '##ọ', '##l', '##ọ', 'Ezen', '##nek', '##a', 'g', '##bà', '##rà', 'Ah', '##ọ', 'O', '##tu', 'Na', '##r', '##ị'], tokens)
+
+        tokens = tokenizer.tokenize('Ezenneka')
+        self.assertEqual(['Ezen', '##nek', '##a'], tokens)
+    
+    def test_xlmr_base_multilingual_ig(self):
+        """
+        igbo
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('Oke Ọñụ Adaa Dịka Lọọlọ Ezenneka gbàrà Ahọ Otu Narị')
+        self.assertEqual(['▁O', 'ke', '▁', 'Ọ', 'ñ', 'ụ', '▁Ada', 'a', '▁D', 'ị', 'ka', '▁L', 'ọ', 'ọ', 'l', 'ọ', '▁Ezen', 'nek', 'a', '▁', 'gb', 'à', 'rà', '▁Ah', 'ọ', '▁O', 'tu', '▁Nar', 'ị'], tokens)
+
+        tokens = tokenizer.tokenize('Ezenneka')
+        self.assertEqual(['▁Ezen', 'nek', 'a'], tokens)
+
+    def test_bert_base_multilingual_om(self):
+        """
+        Afaan Oromoo
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('Ani obbolaa keessan, Abdii Baalee Oromiyaatii')
+        self.assertEqual(['ani', 'ob', '##bola', '##a', 'ke', '##essa', '##n', ',', 'abd', '##ii', 'ba', '##ale', '##e', 'oro', '##mi', '##ya', '##atii'], tokens)
+
+        tokens = tokenizer.tokenize('Oromiyaatii')
+        self.assertEqual(['oro', '##mi', '##ya', '##atii'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('Ani obbolaa keessan, Abdii Baalee Oromiyaatii')
+        self.assertEqual(['Ani', 'ob', '##bola', '##a', 'ke', '##essa', '##n', ',', 'Abd', '##ii', 'Ba', '##ale', '##e', 'Oro', '##mi', '##ya', '##ati', '##i'], tokens)
+
+        tokens = tokenizer.tokenize('Oromiyaatii')
+        self.assertEqual(['Oro', '##mi', '##ya', '##ati', '##i'], tokens)
+    
+    def test_xlmr_base_multilingual_om(self):
+        """
+        Afaan Oromoo
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('Ani obbolaa keessan, Abdii Baalee Oromiyaatii')
+        self.assertEqual(['▁Ani', '▁ob', 'bola', 'a', '▁keessa', 'n', ',', '▁Ab', 'dii', '▁Ba', 'ale', 'e', '▁Oromiyaa', 'tii'], tokens)
+
+        tokens = tokenizer.tokenize('Oromiyaatii')
+        self.assertEqual(['▁Oromiyaa', 'tii'], tokens)
+
+    def test_bert_base_multilingual_pcm(self):
+        """
+        Nigerian Pidgin
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('Crude oil dey kill pickin for Nigeria?')
+        self.assertEqual(['cru', '##de', 'oil', 'de', '##y', 'kill', 'pick', '##in', 'for', 'nigeria', '?'], tokens)
+
+        tokens = tokenizer.tokenize('wahala')
+        self.assertEqual(['wah', '##ala'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('Crude oil dey kill pickin for Nigeria?')
+        self.assertEqual(['C', '##rude', 'oil', 'de', '##y', 'kill', 'pick', '##in', 'for', 'Nigeria', '?'], tokens)
+
+        tokens = tokenizer.tokenize('wahala')
+        self.assertEqual(['wa', '##hala'], tokens)
+    
+    def test_xlmr_base_multilingual_pcm(self):
+        """
+        Nigerian Pidgin
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('Crude oil dey kill pickin for Nigeria?')
+        self.assertEqual(['▁Cru', 'de', '▁oil', '▁de', 'y', '▁kill', '▁pick', 'in', '▁for', '▁Nigeria', '?'], tokens)
+
+        tokens = tokenizer.tokenize('wahala')
+        self.assertEqual(['▁wa', 'hala'], tokens)
+
+    def test_bert_base_multilingual_so(self):
+        """
+        Somali
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('Rabbigu wuxuu amar ku bixiyey in la dumiyo qalcadaha Kancaan.')
+        self.assertEqual(['rabbi', '##gu', 'wu', '##xu', '##u', 'amar', 'ku', 'bi', '##xi', '##ye', '##y', 'in', 'la', 'dum', '##iy', '##o', 'qal', '##cada', '##ha', 'kan', '##ca', '##an', '.'], tokens)
+
+        tokens = tokenizer.tokenize('bixiyey')
+        self.assertEqual(['bi', '##xi', '##ye', '##y'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('Rabbigu wuxuu amar ku bixiyey in la dumiyo qalcadaha Kancaan.')
+        self.assertEqual(['Rabbi', '##gu', 'w', '##ux', '##uu', 'amar', 'ku', 'bi', '##xi', '##ye', '##y', 'in', 'la', 'dum', '##iyo', 'q', '##al', '##cada', '##ha', 'Kan', '##ca', '##an', '.'], tokens)
+
+        tokens = tokenizer.tokenize('bixiyey')
+        self.assertEqual(['bi', '##xi', '##ye', '##y'], tokens)
+    
+    def test_xlmr_base_multilingual_so(self):
+        """
+        Somali
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('Rabbigu wuxuu amar ku bixiyey in la dumiyo qalcadaha Kancaan.')
+        self.assertEqual(['▁Rabbi', 'gu', '▁wuxuu', '▁amar', '▁ku', '▁bixi', 'yey', '▁in', '▁la', '▁dum', 'iyo', '▁qal', 'cada', 'ha', '▁Kan', 'ca', 'an', '.'], tokens)
+
+        tokens = tokenizer.tokenize('bixiyey')
+        self.assertEqual(['▁bixi', 'yey'], tokens)
+
+    def test_bert_base_multilingual_sw(self):
+        """
+        Swahili
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('Huduma ya upasuaji mkubwa na mdogo')
+        self.assertEqual(['hu', '##dum', '##a', 'ya', 'up', '##asu', '##aji', 'mk', '##ubwa', 'na', 'md', '##ogo'], tokens)
+
+        tokens = tokenizer.tokenize('upasuaji')
+        self.assertEqual(['up', '##asu', '##aji'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('Huduma ya upasuaji mkubwa na mdogo')
+        self.assertEqual(['Hu', '##dum', '##a', 'ya', 'up', '##asu', '##aji', 'mk', '##ub', '##wa', 'na', 'm', '##dogo'], tokens)
+
+        tokens = tokenizer.tokenize('upasuaji')
+        self.assertEqual(['up', '##asu', '##aji'], tokens)
+    
+    def test_xlmr_base_multilingual_sw(self):
+        """
+        Swahili
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('Huduma ya upasuaji mkubwa na mdogo')
+        self.assertEqual(['▁Huduma', '▁ya', '▁up', 'asu', 'aji', '▁mkubwa', '▁na', '▁mdogo'], tokens)
+
+        tokens = tokenizer.tokenize('upasuaji')
+        self.assertEqual(['▁up', 'asu', 'aji'], tokens)
+
+    def test_bert_base_multilingual_ti(self):
+        """
+        Tigrinya
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('ስርዓተ ቀብሪ ኢንጂነር ስመኘው በቀለ ትማሊ ተፈፂሙ')
+        self.assertEqual(['[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]'], tokens)
+
+        tokens = tokenizer.tokenize('ኢንጂነር')
+        self.assertEqual(['[UNK]'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('ስርዓተ ቀብሪ ኢንጂነር ስመኘው በቀለ ትማሊ ተፈፂሙ')
+        self.assertEqual(['[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]', '[UNK]'], tokens)
+
+        tokens = tokenizer.tokenize('ኢንጂነር')
+        self.assertEqual(['[UNK]'], tokens)
+    
+    def test_xlmr_base_multilingual_ti(self):
+        """
+        Tigrinya
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('ስርዓተ ቀብሪ ኢንጂነር ስመኘው በቀለ ትማሊ ተፈፂሙ')
+        self.assertEqual(['▁ስር', 'ዓ', 'ተ', '▁ቀ', 'ብሪ', '▁ኢን', 'ጂ', 'ነ', 'ር', '▁ስ', 'መ', 'ኘ', 'ው', '▁በቀለ', '▁ት', 'ማ', 'ሊ', '▁ተፈ', 'ፂ', 'ሙ'], tokens)
+
+        tokens = tokenizer.tokenize('ኢንጂነር')
+        self.assertEqual(['▁ኢን', 'ጂ', 'ነ', 'ር'], tokens)
+
+    def test_bert_base_multilingual_yo(self):
+        """
+        Yoruba
+        """
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-uncased')
+
+        tokens = tokenizer.tokenize('Orúkọ ọmọbinrin rẹ̀ àgbà ni Merabu, ti èyí àbúrò ni Mikali.')
+        self.assertEqual(['oru', '##ko', 'omo', '##bin', '##rin', 're', 'ag', '##ba', 'ni', 'mera', '##bu', ',', 'ti', 'e', '##yi', 'abu', '##ro', 'ni', 'mika', '##li', '.'], tokens)
+
+        tokens = tokenizer.tokenize('ọmọbinrin')
+        self.assertEqual(['omo', '##bin', '##rin'], tokens)
+
+        tokenizer = BertTokenizer.from_pretrained('bert-base-multilingual-cased')
+
+        tokens = tokenizer.tokenize('Orúkọ ọmọbinrin rẹ̀ àgbà ni Merabu, ti èyí àbúrò ni Mikali.')
+        self.assertEqual(['Or', '##ú', '##k', '##ọ', 'ọ', '##m', '##ọ', '##bin', '##rin', 'r', '##ẹ̀', 'à', '##g', '##bà', 'ni', 'Mer', '##abu', ',', 'ti', 'è', '##y', '##í', 'à', '##b', '##úr', '##ò', 'ni', 'Mika', '##li', '.'], tokens)
+
+        tokens = tokenizer.tokenize('ọmọbinrin')
+        self.assertEqual(['ọ', '##m', '##ọ', '##bin', '##rin'], tokens)
+    
+    def test_xlmr_base_multilingual_yo(self):
+        """
+        Yoruba
+        """
+        tokenizer = AutoTokenizer.from_pretrained('xlm-roberta-base')
+
+        tokens = tokenizer.tokenize('Orúkọ ọmọbinrin rẹ̀ àgbà ni Merabu, ti èyí àbúrò ni Mikali.')
+        self.assertEqual(['▁O', 'rú', 'k', 'ọ', '▁', 'ọ', 'm', 'ọ', 'bin', 'rin', '▁r', 'ẹ', '̀', '▁à', 'gb', 'à', '▁ni', '▁Mera', 'bu', ',', '▁ti', '▁è', 'y', 'í', '▁à', 'bú', 'rò', '▁ni', '▁Mi', 'kali', '.'], tokens)
+
+        tokens = tokenizer.tokenize('ọmọbinrin')
+        self.assertEqual(['▁', 'ọ', 'm', 'ọ', 'bin', 'rin'], tokens)
 
     def test_doc2query(self):
         tokenizer = T5Tokenizer.from_pretrained('castorini/doc2query-t5-base-msmarco')


### PR DESCRIPTION
Added mBERT and XLM-R tokenizer test cases for the following African languages:

1. Amharic
2. Afaan Oromooo
3. Hausa
4. Igbo
5. Nigerian Pidgin
6. Somali
7. Swahili
8. Tigrinya
9. Yoruba

Fixes #578 @