### PR TITLE
Fix dindex bug

### DIFF
--- a/pyserini/dindex/__main__.py
+++ b/pyserini/dindex/__main__.py
@@ -30,7 +30,7 @@ def init_encoder(encoder, device):
     elif 'tct_colbert' in encoder:
         return TctColBertDocumentEncoder(encoder, device=device)
     elif 'ance' in encoder:
-        return AnceDocumentEncoder(encoder)
+        return AnceDocumentEncoder(encoder, device=device)
     elif 'sentence-transformers' in encoder:
         return AutoDocumentEncoder(encoder, device=device, pooling='mean', l2_norm=True)
     else:

--- a/pyserini/dindex/__main__.py
+++ b/pyserini/dindex/__main__.py
@@ -86,15 +86,17 @@ if __name__ == '__main__':
     shard_size = int(total_len / args.shard_num)
     start_idx = args.shard_id * shard_size
     end_idx = min(start_idx + shard_size, total_len)
+    if args.shard_id == args.shard_num - 1:
+        end_idx = total_len
 
     with open(os.path.join(args.index, 'docid'), 'w') as id_file:
         for idx in tqdm(range(start_idx, end_idx)):
             id_file.write(f'{ids[idx]}\n')
 
     for idx in tqdm(range(start_idx, end_idx, args.batch)):
-        text_batch = texts[idx: idx+min(args.batch, end_idx)]
+        text_batch = texts[idx: idx + args.batch]
         if len(titles) != 0:
-            title_batch = titles[idx: idx+min(args.batch, end_idx)]
+            title_batch = titles[idx: idx+args.batch]
             embeddings = model.encode(text_batch, title_batch)
         else:
             embeddings = model.encode(text_batch)

--- a/pyserini/dindex/__main__.py
+++ b/pyserini/dindex/__main__.py
@@ -94,9 +94,9 @@ if __name__ == '__main__':
             id_file.write(f'{ids[idx]}\n')
 
     for idx in tqdm(range(start_idx, end_idx, args.batch)):
-        text_batch = texts[idx: idx + args.batch]
+        text_batch = texts[idx: min(idx + args.batch, end_idx)]
         if len(titles) != 0:
-            title_batch = titles[idx: idx+args.batch]
+            title_batch = titles[idx: min(idx + args.batch, end_idx)]
             embeddings = model.encode(text_batch, title_batch)
         else:
             embeddings = model.encode(text_batch)

--- a/pyserini/dindex/_base.py
+++ b/pyserini/dindex/_base.py
@@ -58,11 +58,10 @@ class DprDocumentEncoder(DocumentEncoder):
         self.model.to(self.device)
         self.tokenizer = DPRContextEncoderTokenizer.from_pretrained(tokenizer_name or model_name)
 
-    def encode(self, texts, titles):
+    def encode(self, texts):
         max_length = 256  # hardcode for now
         inputs = self.tokenizer(
-            titles,
-            text_pair=texts,
+            texts,
             max_length=max_length,
             padding='longest',
             truncation=True,

--- a/pyserini/dindex/_base.py
+++ b/pyserini/dindex/_base.py
@@ -58,10 +58,11 @@ class DprDocumentEncoder(DocumentEncoder):
         self.model.to(self.device)
         self.tokenizer = DPRContextEncoderTokenizer.from_pretrained(tokenizer_name or model_name)
 
-    def encode(self, texts):
+    def encode(self, texts, titles):
         max_length = 256  # hardcode for now
         inputs = self.tokenizer(
-            texts,
+            titles,
+            text_pair=texts,
             max_length=max_length,
             padding='longest',
             truncation=True,


### PR DESCRIPTION
the `title-delimiter` only works for DprEncoder for now, since wiki passages have titles.
the input collection has '\n' to split title and passage
```
{"id": "doc1", "contents": "title1\ncontents of doc one."}
```

the MSMARCO passages don't have titles, so we don't need add  `title-delimiter` for ANCE encoder (we manually handle this for now).
input can just be:
```
{"id": "doc1", "contents": "contents of doc one."}
```

