### PR TITLE
Reproduced BM25 baselines for MS MARCO Passage and Document Ranking

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -143,4 +143,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results reproduced by [@andrewyguo](https://github.com/andrewyguo) on 2021-04-30 (commit [`ecfed61`](https://github.com/castorini/pyserini/commit/ecfed61bfba065aa958848cff96ba9f22609aeb1))
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d))
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
-+ Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`5f341b2`](https://github.com/castorini/pyserini/commit/5f341b28b1e408feaa17979c54e9c85f97df981c))
++ Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`f614111`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -143,3 +143,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results reproduced by [@andrewyguo](https://github.com/andrewyguo) on 2021-04-30 (commit [`ecfed61`](https://github.com/castorini/pyserini/commit/ecfed61bfba065aa958848cff96ba9f22609aeb1))
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d))
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
++ Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`5f341b2`](https://github.com/castorini/pyserini/commit/5f341b28b1e408feaa17979c54e9c85f97df981c))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -142,3 +142,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results reproduced by [@andrewyguo](https://github.com/andrewyguo) on 2021-04-30 (commit [`ecfed61`](https://github.com/castorini/pyserini/commit/ecfed61bfba065aa958848cff96ba9f22609aeb1))
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d)) 
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
++ Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`5f341b2`](https://github.com/castorini/pyserini/commit/5f341b28b1e408feaa17979c54e9c85f97df981c))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -142,4 +142,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results reproduced by [@andrewyguo](https://github.com/andrewyguo) on 2021-04-30 (commit [`ecfed61`](https://github.com/castorini/pyserini/commit/ecfed61bfba065aa958848cff96ba9f22609aeb1))
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d)) 
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
-+ Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`5f341b2`](https://github.com/castorini/pyserini/commit/5f341b28b1e408feaa17979c54e9c85f97df981c))
++ Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`f614111`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))


### PR DESCRIPTION
### Environments
```
  - MS MARCO Passage Ranking: 2020 Macbook Pro, macOS Big Sur, 8GB RAM, 500 GB HD
  - MS MARCO Document Ranking: GCP e2-standard-4, Ubuntu 18.04 LTS, 4 vCPU (8GB RAM), 1500 GB SSD
```

Tried running document ranking on 2020 Macbook Pro, but it runs out of memory at indexing. In `top`, Python seems to run out of memory at ~2 GB / ~500k documents indexed. Curious, since I was able to reproduce MS MARCO document ranking locally in Anserini.