### PR TITLE
Reproduce pyserini: BM25 Baselines for MS MARCO Passage/Document Ranking Experiment 

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -144,4 +144,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d))
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`f614111`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))
-+ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`dc730ff`](https://github.com/castorini/pyserini/commit/dc730ffb24e1ff2a34999166ac4d14e41b8312d5))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`45083f5`](https://github.com/castorini/pyserini/commit/45083f5ecb986651301c1fe26d09981d0baee8ee))

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -144,3 +144,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d))
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`f614111`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`dc730ff`](https://github.com/castorini/pyserini/commit/dc730ffb24e1ff2a34999166ac4d14e41b8312d5))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -143,4 +143,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d)) 
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`f614111`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))
-+ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`dc730ff`](https://github.com/castorini/pyserini/commit/dc730ffb24e1ff2a34999166ac4d14e41b8312d5))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`45083f5`](https://github.com/castorini/pyserini/commit/45083f5ecb986651301c1fe26d09981d0baee8ee))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -143,3 +143,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results reproduced by [@mayankanand007](https://github.com/mayankanand007) on 2021-05-04 (commit [`a9d6f66`](https://github.com/castorini/pyserini/commit/a9d6f66234b5dd2859a0dc116ef3e38a52d0f81d)) 
 + Results reproduced by [@rootofallevii](https://github.com/rootofallevii) on 2021-05-14 (commit [`e764797`](https://github.com/castorini/pyserini/commit/e764797081eebf487fa7e1fa34872a59ff97fdf7))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-13 (commit [`f614111`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`dc730ff`](https://github.com/castorini/pyserini/commit/dc730ffb24e1ff2a34999166ac4d14e41b8312d5))


### PR DESCRIPTION
Get exactly same result as provided. Screenshots are post
<img width="292" alt="p_Document" src="https://user-images.githubusercontent.com/39313997/124512546-a2c41080-dda6-11eb-988c-83e8550c40a6.png">
<img width="420" alt="Pyserini_BM25_Passage_2" src="https://user-images.githubusercontent.com/39313997/124512548-a35ca700-dda6-11eb-8302-8c58d6c898c8.png">

Environment:
OS: macOS Big Sur 11.4
Python: 3.9.5
Java: openjdk 11.0.5 2019-10-15

Issue encountered:
mvn doesn't set ANSERINI_CLASSPATH properly when compile code
<img width="1018" alt="issue" src="https://user-images.githubusercontent.com/39313997/124512592-bf604880-dda6-11eb-8fe9-3851f2dae2f1.png">

Solved: Manually adding `export ANSERINI_CLASSPATH='/Users/zizeng/Code/anserini/target'` (Change `zizeng` to your username) to `.bash_profile`(or `.zshrc` depends on our shell) 
