### PR TITLE
Reproduction of ltr-msmarco-passage-training results

### DIFF
--- a/docs/experiments-ltr-msmarco-passage-training.md
+++ b/docs/experiments-ltr-msmarco-passage-training.md
@@ -60,3 +60,6 @@ The script trains a model which optimizes MRR@10 by default.
 You can change the `mrr_at_10`  of [this function](../scripts/ltr_msmarco-passage/train_ltr_model.py#L621) and [here](../scripts/ltr_msmarco-passage/train_ltr_model.py#L358) to `recall_at_20` to train a model which optimizes recall@20.
 
 You can also self defined a function format like [this](../scripts/ltr_msmarco-passage/train_ltr_model.py#L300) and change corresponding places mentioned above to have different optimization goal.
+
+## Reproduction Log[*](reproducibility.md)
++ Results reproduced by [@Dahlia-Chehata](https://github.com/Dahlia-Chehata) on 2021-07-18 (commit [`a6b6545`](https://github.com/castorini/pyserini/commit/a6b6545c0133c03d50d5c33fb2fea7c527de04bb))


### PR DESCRIPTION
```
recall@10:0.48367956064947465
recall@20:0.5796442215854822
recall@50:0.683966093600764
recall@100:0.7545964660936009
recall@200:0.8033428844317098
recall@500:0.8454512893982808
recall@1000:0.8573424068767909
```
Evaluating the results using:

1) MS MARCO evaluation script
```
python tools/scripts/msmarco/msmarco_passage_eval.py \
   tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.ltr.msmarco-passage.tsv
#####################
MRR @10: 0.24831019466048032
QueriesRanked: 6980
#####################
```
2) ` trec_eval`
```
tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
   collections/msmarco-passage/qrels.dev.small.trec runs/run.ltr.msmarco-passage.trec
map                   	all	0.2564
recall_1000           	all	0.8573 
```

