### PR TITLE
Add to uniCOIL repro log

### DIFF
--- a/docs/experiments-msmarco-v2-unicoil.md
+++ b/docs/experiments-msmarco-v2-unicoil.md
@@ -209,3 +209,5 @@ recall_100            	all	0.8128
 ```
 
 ## Reproduction Log[*](reproducibility.md)
+
++ Results reproduced by [@lintool](https://github.com/lintool) on 2021-08-13 (commit [`2b96b9`](https://github.com/castorini/pyserini/commit/2b96b99773302315e4d7dbe4a373b36b3eadeaa6))


### PR DESCRIPTION
Confirmed uniCOIL by itself as well as hybrids:

+ Passage: Dense-sparse hybrid retrieval (uniCOIL zero-shot + TCT_ColBERT_v2 zero-shot)
+ Passage: Dense-sparse hybrid retrieval (uniCOIL zero-shot + TCT_ColBERT_v2 trained)
+ Doc: Dense-sparse hybrid retrieval (uniCOIL zero-shot + TCT_ColBERT_v2 zero-shot)
+ Doc: Dense-sparse hybrid retrieval (uniCOIL zero-shot + TCT_ColBERT_v2 trained)

Results for zero shot matched exactly.
Results for trained versions differed a tiny bit (four places after the decimal point).
