### PR TITLE
reproduce TCT-ColBERTv2 for MS MARCO (V2)

### DIFF
--- a/docs/experiments-msmarco-v2-tct_colbert-v2.md
+++ b/docs/experiments-msmarco-v2-tct_colbert-v2.md
@@ -161,4 +161,4 @@ recall_1000           	all	0.8974
 ```
 
 ## Reproduction Log[*](reproducibility.md)
-
++ Results reproduced by [@crystina-z](https://github.com/crystina-z) on 2021-08-20 (commit [`45a2fb`](https://github.com/castorini/pyserini/commit/45a2fb4bacbbd92f54ff0f98463662cbc09d78bb))


### PR DESCRIPTION
Issue #738

Results:
1. passage v2 (zero-shot)
```
$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank collections/passv2_dev_qrels.tsv runs/run.msmarco-passage-v2-augmented.tct_colbert-v2-hnp.0shot.dev1.trec
map                     all     0.1461
recip_rank              all     0.1473

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 collections/passv2_dev_qrels.tsv runs/run.msmarco-passage-v2-augmented.tct_colbert-v2-hnp.0shot.dev1.trec
recall_100              all     0.5873
recall_1000             all     0.8321
```

2. passage v2 (fine-tuned)
```
$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank collections/passv2_dev_qrels.tsv runs/run.msmarco-passage-v2-augmented.tct_colbert-v2-hnp.psg_v2_ft.dev1.trec
map                     all     0.1981
recip_rank              all     0.2000

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 collections/passv2_dev_qrels.tsv runs/run.msmarco-passage-v2-augmented.tct_colbert-v2-hnp.psg_v2_ft.dev1.trec
recall_100              all     0.6403
recall_1000             all     0.8452
```

3. doc v2 (zero-shot)
```
$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank collections/docv2_dev_qrels.tsv runs/run.msmarco-document-v2-segmented.tct_colbert-v2-hnp.0shot.dev1.trec
map                     all     0.2440
recip_rank              all     0.2464

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 collections/docv2_dev_qrels.tsv runs/run.msmarco-document-v2-segmented.tct_colbert-v2-hnp.0shot.dev1.trec
recall_100              all     0.7873
recall_1000             all     0.9161
```

4. doc v2 (fine-tuned)
```
$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank collections/docv2_dev_qrels.tsv runs/run.msmarco-document-v2-segmented.tct_colbert-v2-hnp.psg_v2_ft.dev1.trec
map                     all     0.2719
recip_rank              all     0.2745

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 collections/docv2_dev_qrels.tsv runs/run.msmarco-document-v2-segmented.tct_colbert-v2-hnp.psg_v2_ft.dev1.trec
recall_100              all     0.7778
recall_1000             all     0.8974
```