### PR TITLE
late import AnceEncoder in dindex.

### DIFF
--- a/pyserini/dindex/_base.py
+++ b/pyserini/dindex/_base.py
@@ -19,8 +19,6 @@ import torch
 from transformers import AutoModel, AutoTokenizer, BertModel, BertTokenizer, DPRContextEncoder, \
     DPRContextEncoderTokenizer, RobertaTokenizer
 
-from pyserini.dsearch import AnceEncoder
-
 
 class DocumentEncoder:
     def encode(self, texts, titles=None):
@@ -85,6 +83,7 @@ class DprDocumentEncoder(DocumentEncoder):
 
 class AnceDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
+        from pyserini.dsearch import AnceEncoder
         self.device = device
         self.model = AnceEncoder.from_pretrained(model_name)
         self.model.to(self.device)


### PR DESCRIPTION
This cuts the dindex dependence on javac.

Dependence chain:

pyserini/pyserini/dindex/_base.py
from pyserini.dsearch import AnceEncoder

pyserini/pyserini/dsearch/_dsearcher.py
from pyserini.search import SimpleSearcher, Document

/home/tk/Desktop/pyserini/pyserini/search/__init__.py
from ._base import Document, JDocument ...