### PR TITLE
Fix one path of index module depending on search.

### DIFF
--- a/pyserini/dsearch/_dsearcher.py
+++ b/pyserini/dsearch/_dsearcher.py
@@ -32,7 +32,8 @@ from transformers.file_utils import is_faiss_available, requires_backends
 
 from pyserini.util import (download_encoded_queries, download_prebuilt_index,
                            get_dense_indexes_info, get_sparse_index)
-from pyserini.search import SimpleSearcher, Document
+from pyserini.search import SimpleSearcher
+from pyserini.index import Document
 
 from ._model import AnceEncoder
 import torch

--- a/pyserini/index/__init__.py
+++ b/pyserini/index/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-from ._base import Generator, IndexTerm, Posting, IndexReader
+from ._base import Document, Generator, IndexTerm, Posting, IndexReader
 
-__all__ = ['Generator', 'IndexTerm', 'Posting', 'IndexReader']
+__all__ = ['Document', 'Generator', 'IndexTerm', 'Posting', 'IndexReader']

--- a/pyserini/index/_base.py
+++ b/pyserini/index/_base.py
@@ -26,7 +26,6 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 from ..analysis import get_lucene_analyzer, JAnalyzer, JAnalyzerUtils
 from ..pyclass import autoclass, JString
-from ..search import Document
 from pyserini.util import download_prebuilt_index, get_sparse_indexes_info
 from pyserini.prebuilt_index_info import BM25_INDEX_INFO
 
@@ -34,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 # Wrappers around Anserini classes
+JDocument = autoclass('org.apache.lucene.document.Document')
 JIndexReader = autoclass('io.anserini.index.IndexReaderUtils')
 
 
@@ -49,6 +49,40 @@ class JIndexHelpers:
         IndexCollection = autoclass('io.anserini.index.IndexCollection')
         Counters = autoclass('io.anserini.index.IndexCollection$Counters')
         return Counters(IndexCollection)
+
+
+class Document:
+    """Wrapper class for a Lucene ``Document``.
+
+    Parameters
+    ----------
+    document : JDocument
+        Underlying Lucene ``Document``.
+    """
+
+    def __init__(self, document):
+        if document is None:
+            raise ValueError('Cannot create a Document with None.')
+        self.object = document
+
+    def docid(self: JDocument) -> str:
+        return self.object.getField('id').stringValue()
+
+    def id(self: JDocument) -> str:
+        # Convenient alias for docid()
+        return self.object.getField('id').stringValue()
+
+    def lucene_document(self: JDocument) -> JDocument:
+        return self.object
+
+    def contents(self: JDocument) -> str:
+        return self.object.get('contents')
+
+    def raw(self: JDocument) -> str:
+        return self.object.get('raw')
+
+    def get(self: JDocument, field: str) -> str:
+        return self.object.get(field)
 
 
 class JGenerators(Enum):

--- a/pyserini/search/__init__.py
+++ b/pyserini/search/__init__.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-from ._base import Document, JDocument, JQuery, JDisjunctionMaxQueryGenerator, get_topics, get_topics_with_reader, get_qrels_file, get_qrels
+from ._base import JQuery, JDisjunctionMaxQueryGenerator, get_topics, get_topics_with_reader, get_qrels_file, get_qrels
 from ._searcher import JSimpleSearcherResult, LuceneSimilarities, SimpleFusionSearcher, SimpleSearcher
 from ._nearest_neighbor import SimpleNearestNeighborSearcher, JSimpleNearestNeighborSearcherResult
 from ._impact_searcher import JImpactSearcherResult, ImpactSearcher
 
-__all__ = ['Document', 'JDocument', 'JQuery', 'LuceneSimilarities', 'SimpleFusionSearcher', 'SimpleSearcher',
+__all__ = ['JQuery', 'LuceneSimilarities', 'SimpleFusionSearcher', 'SimpleSearcher',
            'JSimpleSearcherResult', 'SimpleNearestNeighborSearcher', 'JSimpleNearestNeighborSearcherResult',
            'ImpactSearcher', 'JImpactSearcherResult', 'JDisjunctionMaxQueryGenerator', 'get_topics',
            'get_topics_with_reader', 'get_qrels_file', 'get_qrels']

--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 # Wrappers around Lucene classes
 JQuery = autoclass('org.apache.lucene.search.Query')
-JDocument = autoclass('org.apache.lucene.document.Document')
 
 # Wrappers around Anserini classes
 JQrels = autoclass('io.anserini.eval.Qrels')
@@ -40,40 +39,6 @@ JQueryGenerator = autoclass('io.anserini.search.query.QueryGenerator')
 JBagOfWordsQueryGenerator = autoclass('io.anserini.search.query.BagOfWordsQueryGenerator')
 JDisjunctionMaxQueryGenerator = autoclass('io.anserini.search.query.DisjunctionMaxQueryGenerator')
 JCovid19QueryGenerator = autoclass('io.anserini.search.query.Covid19QueryGenerator')
-
-
-class Document:
-    """Wrapper class for a Lucene ``Document``.
-
-    Parameters
-    ----------
-    document : JDocument
-        Underlying Lucene ``Document``.
-    """
-
-    def __init__(self, document):
-        if document is None:
-            raise ValueError('Cannot create a Document with None.')
-        self.object = document
-
-    def docid(self: JDocument) -> str:
-        return self.object.getField('id').stringValue()
-
-    def id(self: JDocument) -> str:
-        # Convenient alias for docid()
-        return self.object.getField('id').stringValue()
-
-    def lucene_document(self: JDocument) -> JDocument:
-        return self.object
-
-    def contents(self: JDocument) -> str:
-        return self.object.get('contents')
-
-    def raw(self: JDocument) -> str:
-        return self.object.get('raw')
-
-    def get(self: JDocument, field: str) -> str:
-        return self.object.get(field)
 
 
 def get_topics(collection_name):

--- a/pyserini/search/_impact_searcher.py
+++ b/pyserini/search/_impact_searcher.py
@@ -22,7 +22,7 @@ import logging
 import os
 from typing import Dict, List, Optional, Union
 import numpy as np
-from ._base import Document
+from pyserini.index import Document
 from pyserini.pyclass import autoclass, JFloat, JArrayList, JHashMap, JString
 from pyserini.util import download_prebuilt_index
 from pyserini.encode import QueryEncoder, TokFreqQueryEncoder, UniCoilQueryEncoder, CachedDataQueryEncoder

--- a/pyserini/search/_searcher.py
+++ b/pyserini/search/_searcher.py
@@ -22,7 +22,8 @@ class, which wraps the Java class with the same name in Anserini.
 import logging
 from typing import Dict, List, Optional, Union
 
-from ._base import Document, JQuery, JQueryGenerator
+from ._base import JQuery, JQueryGenerator
+from pyserini.index import Document
 from pyserini.pyclass import autoclass, JFloat, JArrayList, JHashMap, JString
 from pyserini.trectools import TrecRun
 from pyserini.fusion import FusionMethod, reciprocal_rank_fusion


### PR DESCRIPTION
When writing ColBert encoder, I found any complex or compositional
`encoder` has a good chance to depend on `index` module (because such an index
needs more complex RepresentationWriter), and if `index` module depends
on search module, it has a good chance to depend on the `encode` module
again, thus a loop of dependency is formed.

We can fix it by cutting the very counter-intuitive "index --> search"
dependency link because it violates our common abstraction.