### PR TITLE
Update MS MARCO V2 reproduction documentation (include variants)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ hits[0].raw
 hits[0].lucene_document
 ```
 
-Pre-built Anserini indexes are hosted at the University of Waterloo's [GitLab](https://git.uwaterloo.ca/jimmylin/anserini-indexes) and mirrored on Dropbox.
+Pre-built indexes are hosted on University of Waterloo servers and in some cases mirrored on Dropbox.
 The following method will list available pre-built indexes:
 
 ```

--- a/docs/experiments-dpr-compression.md
+++ b/docs/experiments-dpr-compression.md
@@ -3,7 +3,7 @@ This page describes how to reproduce the DPR compression experiments in the foll
 
 > Xueguang Ma, Minghan Li, Kai Sun, Ji Xin, and Jimmy Lin. 
 > [Simple and Effective Unsupervised Redundancy Elimination to Compress Dense Vectors for Passage Retrieval.](https://cs.uwaterloo.ca/~jimmylin/publications/Ma_etal_EMNLP2021.pdf)
-> _Proceedings of 1st Workshop on Multilingual Representation Learning, November 2021_.
+> _EMNLP 2021_, November 2021.
 
 In this page, we focus on Natural Question as an example.
 To reproduce results for other datasets, simply reply the topics `dpr-nq-test` into other datasets. e.g. (`dpr-trivia-qa`)
@@ -27,7 +27,7 @@ tar -xvf dpr-multi-question-encoder.tar.gz
 rm dpr-multi-question-encoder.tar.gz
 ```
 
-2. Download prebuilt index and PCA model from the summary table above.
+2. Download pre-built index and PCA model from the summary table above.
 > We use the setting for `DPR-PCA128-PQ2` as example below:
 ```bash
 wget https://www.dropbox.com/s/nq62qhodd237p9t/dindex-dpr-multi-pca128.tar.gz
@@ -47,7 +47,7 @@ DIMENSION=128
 ```
 
 ## Product Quantization
-Conduct Product Quantization on prebuilt index
+Conduct Product Quantization on pre-built index
 ```bash
 python -m pyserini.index.faiss --input ${BASE_DINDEX} \
                                --output ${TARGET_DINDEX} \

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -1,4 +1,4 @@
-# Pyserini: Baselines for MS MARCO V2 Collections
+# Pyserini: BM25 Baselines for the MS MARCO V2 Collections
 
 This guide contains instructions for running baselines on the MS MARCO V2 passage and document test collections,
 which mirrors a [similar guide in Anserini](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md) except that everything is in Python here (no Java).

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -1,94 +1,196 @@
-# Pyserini: Baseline for MS MARCO V2 Collections
+# Pyserini: Baselines for MS MARCO V2 Collections
 
-This guide contains instructions for running baselines on the V2 of the MS MARCO passage and document test collection, 
-which is nearly identical to a [similar guide in Anserini](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md), except that everything is in Python here (no Java).
-<!-- Note that there is a separate guide for the [MS MARCO *passage* ranking task](experiments-msmarco-passage.md). -->
-
-**Setup Note:** If you're instantiating an Ubuntu VM on your system or on cloud (AWS and GCP), try to provision enough resources as the tasks such as building the index could take some time to finish such as RAM > 8GB and storage > 100 GB (SSD). This will prevent going back and fixing machine configuration again and again. If you get a configuration which works for Anserini on this task, it will work with Pyserini as well.
-
+This guide contains instructions for running baselines on the MS MARCO V2 passage and document test collections,
+which mirrors a [similar guide in Anserini](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md) except that everything is in Python here (no Java).
+To reduce duplication of content, this guide will refer to the Anserini for shared instructions and descriptions.
 
 ## Data Prep
-<!-- # Anserini: Guide to Working with the MS MARCO V2 Collections -->
 
-<!-- This guide presents information for working with V2 of the MS MARCO passage and document test collections. -->
+These instructions are exactly the same as in the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
 
-If you're having issues downloading the collection via `wget`, try using [AzCopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10).
+## Passage Collection
 
-
-## MS MARCO Passage V2
-Indexing the passage collection, which is 20 GB compressed:
+This is the minimal indexing command:
 
 ```
-python -m pyserini.index -collection MsMarcoPassageV2Collection \
- -generator DefaultLuceneDocumentGenerator -threads 18 \
- -input collections/msmarco_v2_passage \
- -index indexes/msmarco-v2-passage \
- -storePositions -storeDocvectors -storeRaw
+python -m pyserini.index --collection MsMarcoV2PassageCollection \
+                         --generator DefaultLuceneDocumentGenerator \
+                         --input collections/msmarco_v2_passage \
+                         --index indexes/lucene-index.msmarco-v2-passage \
+                         --threads 12
 ```
 
 Adjust `-threads` as appropriate.
-The above configuration, on a 2017 iMac Pro with SSD, takes around 30min.
-
-The complete index occupies 72 GB (138,364,198 passages).
-It's big because it includes postions (for phrase queries), document vectors (for relevance feedback), and a complete copy of the collection itself.
-The index size can be reduced by removing the options `-storePositions`, `-storeDocvectors`, `-storeRaw` as appropriate.
-For reference:
-
-+ Without any of the three above option, index size reduces to 12 GB.
-+ With just `-storeRaw`, index size reduces to 47 GB. This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access.
-
-
-```
- python -m pyserini.search --index indexes/msmarco-v2-passage \
-        --topics collections/passv2_dev_queries.tsv \
-        --output runs/run.msmarco-pass-v2.dev.txt \
-        --bm25 --hits 1000 --batch-size 36 --threads 12
-```
-
-Evaluation:
-
-```bash
-$ tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100,1000 -m recip_rank collections/passv2_dev_qrels.uniq.tsv runs/run.msmarco-pass-v2.dev.txt
-map                     all     0.0718
-recip_rank              all     0.0728
-recall_100            	all     0.3397
-recall_1000             all     0.5733
-```
-
-## MS MARCO Doc V2
-Indexing the document collection, which is 32 GB compressed:
-
-```
-python -m pyserini.index -collection MsMarcoDocV2Collection \
- -generator DefaultLuceneDocumentGenerator -threads 18 \
- -input collections/msmarco_v2_doc \
- -index indexes/msmarco-v2-doc \
- -storePositions -storeDocvectors -storeRaw
-```
-
-Same instructions as above.
-On the same machine, indexing takes around 40min.
-Complete index occupies 134 GB (11,959,635 documents).
-Index size can be reduced by removing the options `-storePositions`, `-storeDocvectors`, `-storeRaw` as appropriate.
-For reference:
-
-+ Without any of the three above option, index size reduces to 9.4 GB.
-+ With just `-storeRaw`, index size reduces to 73 GB. This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access; evidently, the JSON docs don't compress well.
+Different configurations (`-storePositions`, `-storeDocvectors`, `-storeRaw`) support different features, but require different amounts of disk space; for the detailed tradeoffs, see the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+The above minimal index should be ~11 GB.
 
 Perform a run on the dev queries:
 
 ```
- python -m pyserini.search --index indexes/msmarco-v2-doc \
-        --topics collections/docv2_dev_queries.tsv \
-        --output runs/run.msmarco-v2-doc.dev.txt \
-        --bm25 --hits 100 --batch-size 36 --threads 12
+python -m pyserini.search --index indexes/lucene-index.msmarco-v2-passage \
+                          --topics msmarco-v2-passage-dev \
+                          --output runs/run.msmarco-v2-passage.dev.txt \
+                          --bm25 \
+                          --hits 1000 \
+                          --batch-size 36 \
+                          --threads 12
 ```
 
 Evaluation:
 
 ```bash
-$ tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/docv2_dev_qrels.uniq.tsv runs/run.msmarco-v2-doc.dev.txt
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev runs/run.msmarco-v2-passage.dev.txt
+Results:
+map                   	all	0.0709
+recip_rank            	all	0.0719
+
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev runs/run.msmarco-v2-passage.dev.txt
+Results:
+recall_100            	all	0.3397
+recall_1000           	all	0.5733
+```
+
+These results should be the same as in the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+To run on the `dev2` queries, just change everything from `msmarco-v2-passage-dev` to `msmarco-v2-passage-dev2`.
+
+## Passage Collection (Augmented)
+
+Refer to the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md) on how this collection was prepared.
+This is the minimal indexing command:
+
+```
+python -m pyserini.index --collection MsMarcoV2PassageCollection \
+                         --generator DefaultLuceneDocumentGenerator \
+                         --input collections/msmarco_v2_passage_augmented \
+                         --index indexes/lucene-index.msmarco-v2-passage-augmented \
+                         --threads 12
+```
+
+Adjust `-threads` as appropriate.
+Different configurations (`-storePositions`, `-storeDocvectors`, `-storeRaw`) support different features, but require different amounts of disk space; for the detailed tradeoffs, see the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+The above minimal index should be ~19 GB.
+
+Perform a run on the dev queries:
+
+```
+python -m pyserini.search --index indexes/lucene-index.msmarco-v2-passage-augmented \
+                          --topics msmarco-v2-passage-dev \
+                          --output runs/run.msmarco-v2-passage-augmented.dev.txt \
+                          --bm25 \
+                          --hits 1000 \
+                          --batch-size 36 \
+                          --threads 12
+```
+
+Evaluation:
+
+```bash
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev runs/run.msmarco-v2-passage-augmented.dev.txt
+Results:
+map                   	all	0.0863
+recip_rank            	all	0.0872
+
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev runs/run.msmarco-v2-passage-augmented.dev.txt
+Results:
+recall_100            	all	0.4030
+recall_1000           	all	0.6925
+```
+
+These results should be the same as in the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+To run on the `dev2` queries, just change everything from `msmarco-v2-passage-dev` to `msmarco-v2-passage-dev2`.
+
+## Document Collection
+
+This is the minimal indexing command:
+
+```
+python -m pyserini.index --collection MsMarcoV2DocCollection \
+                         --generator DefaultLuceneDocumentGenerator \
+                         --input collections/msmarco_v2_doc \
+                         --index indexes/lucene-index.msmarco-v2-doc \
+                         --threads 12
+```
+
+Adjust `-threads` as appropriate.
+Different configurations (`-storePositions`, `-storeDocvectors`, `-storeRaw`) support different features, but require different amounts of disk space; for the detailed tradeoffs, see the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+The above minimal index should be ~9.6 GB.
+
+Perform a run on the dev queries:
+
+```
+python -m pyserini.search --index indexes/lucene-index.msmarco-v2-doc \
+                          --topics msmarco-v2-doc-dev \
+                          --output runs/run.msmarco-v2-doc.dev.txt \
+                          --bm25 \
+                          --hits 1000 \
+                          --batch-size 36 \
+                          --threads 12
+```
+
+Evaluation:
+
+```bash
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev runs/run.msmarco-v2-doc.dev.txt
+Results:
 map                   	all	0.1552
 recip_rank            	all	0.1572
+
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev runs/run.msmarco-v2-doc.dev.txt
+Results:
 recall_100            	all	0.5956
+recall_1000           	all	0.8054
 ```
+
+These results should be the same as in the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+To run on the `dev2` queries, just change everything from `msmarco-v2-doc-dev` to `msmarco-v2-doc-dev2`.
+
+## Document Collection (Segmented)
+
+Refer to the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md) on how this collection was prepared.
+This is the minimal indexing command:
+
+```
+python -m pyserini.index --collection MsMarcoV2DocCollection \
+                         --generator DefaultLuceneDocumentGenerator \
+                         --input collections/msmarco_v2_doc_segmented \
+                         --index indexes/lucene-index.msmarco-v2-doc-segmented \
+                         --threads 12
+```
+
+Adjust `-threads` as appropriate.
+Different configurations (`-storePositions`, `-storeDocvectors`, `-storeRaw`) support different features, but require different amounts of disk space; for the detailed tradeoffs, see the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+The above minimal index should be ~27 GB.
+
+Perform a run on the dev queries:
+
+```bash
+python -m pyserini.search --index indexes/lucene-index.msmarco-v2-doc-segmented \
+                          --topics msmarco-v2-doc-dev \
+                          --index indexes/lucene-index.msmarco-v2-doc-segmented  \
+                          --output runs/run.msmarco-v2-doc-segmented.dev.txt \
+                          --hits 10000 \
+                          --batch 36 \
+                          --threads 12 \
+                          --max-passage-hits 1000 \
+                          --max-passage
+```
+
+Evaluation:
+
+```bash
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev runs/run.msmarco-v2-doc-segmented.dev.txt
+Results:
+map                   	all	0.1875
+recip_rank            	all	0.1896
+
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev runs/run.msmarco-v2-doc-segmented.dev.txt
+Results:
+recall_100            	all	0.6555
+recall_1000           	all	0.8542
+```
+
+These results should be the same as in the [Anserini guide](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-v2.md).
+To run on the `dev2` queries, just change everything from `msmarco-v2-doc-dev` to `msmarco-v2-doc-dev2`.
+
+## Reproduction Log[*](reproducibility.md)
+

--- a/pyserini/index/__main__.py
+++ b/pyserini/index/__main__.py
@@ -22,6 +22,9 @@ args = sys.argv[1:]
 
 # argument check
 for i in range(len(args)):
+    # Convert double hyphen args into single hyphen args for Java: e.g., --input becomes -input
+    if args[i].startswith('--'):
+        args[i] = args[i][1:]
     if args[i] == '-input':
         collection_dir = args[i+1]
         if os.path.isfile(collection_dir):

--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -327,6 +327,8 @@ def get_qrels_file(collection_name):
         qrels = JQrels.TREC2018_BL
     elif collection_name == 'trec2019-bl':
         qrels = JQrels.TREC2019_BL
+    elif collection_name == 'trec2020-bl':
+        qrels = JQrels.TREC2020_BL
     if qrels:
         target_path = os.path.join(get_cache_home(), qrels.path)
         if os.path.exists(target_path):

--- a/tests/test_load_topics_qrels.py
+++ b/tests/test_load_topics_qrels.py
@@ -649,7 +649,7 @@ class TestLoadTopics(unittest.TestCase):
 
         qrels = search.get_qrels('trec2020-bl')
         self.assertIsNotNone(qrels)
-        self.assertEqual(len(qrels), 50)
+        self.assertEqual(len(qrels), 49)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     # General test cases

--- a/tests/test_load_topics_qrels.py
+++ b/tests/test_load_topics_qrels.py
@@ -24,423 +24,517 @@ class TestLoadTopics(unittest.TestCase):
 
     def test_trec1_adhoc(self):
         topics = search.get_topics('trec1-adhoc')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec1_adhoc_qrels(self):
         qrels = search.get_qrels('trec1-adhoc')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2_adhoc(self):
         topics = search.get_topics('trec2-adhoc')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2_adhoc_qrels(self):
         qrels = search.get_qrels('trec2-adhoc')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec3_adhoc(self):
         topics = search.get_topics('trec3-adhoc')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec3_adhoc_qrels(self):
         qrels = search.get_qrels('trec3-adhoc')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_robust04(self):
         topics = search.get_topics('robust04')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 250)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_robust04_qrels(self):
         qrels = search.get_qrels('robust04')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 249)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_robust05(self):
         topics = search.get_topics('robust05')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_robust05_qrels(self):
         qrels = search.get_qrels('robust05')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_core17(self):
         topics = search.get_topics('core17')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_core17_qrels(self):
         qrels = search.get_qrels('core17')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_core18(self):
         topics = search.get_topics('core18')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_core18_qrels(self):
         qrels = search.get_qrels('core18')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_wt10g(self):
         topics = search.get_topics('wt10g')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 100)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_wt10g_qrels(self):
         qrels = search.get_qrels('wt10g')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 100)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2004_terabyte(self):
         topics = search.get_topics('trec2004-terabyte')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2004_terabyte_qrels(self):
         qrels = search.get_qrels('trec2004-terabyte')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 49)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2005_terabyte(self):
         topics = search.get_topics('trec2005-terabyte')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2005_terabyte_qrels(self):
         qrels = search.get_qrels('trec2005-terabyte')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2006_terabyte(self):
         topics = search.get_topics('trec2006-terabyte')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2006_terabyte_qrels(self):
         qrels = search.get_qrels('trec2006-terabyte')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2007_million_query(self):
         topics = search.get_topics('trec2007-million-query')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 10000)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_trec2008_million_query(self):
         topics = search.get_topics('trec2008-million-query')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 10000)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_trec2009_million_query(self):
         topics = search.get_topics('trec2009-million-query')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 40000)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_trec2010_web(self):
         topics = search.get_topics('trec2010-web')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_trec2011_web(self):
         topics = search.get_topics('trec2011-web')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2011_web_qrels(self):
         qrels = search.get_qrels('trec2011-web')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2012_web(self):
         topics = search.get_topics('trec2012-web')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2012_web_qrels(self):
         qrels = search.get_qrels('trec2012-web')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2013_web(self):
         topics = search.get_topics('trec2013-web')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2013_web_qrels(self):
         qrels = search.get_topics('trec2013-web')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_trec2014_web(self):
         topics = search.get_topics('trec2014-web')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2014_web_qrels(self):
         qrels = search.get_qrels('trec2014-web')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_mb11(self):
         topics = search.get_topics('mb11')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_mb11_qrels(self):
         qrels = search.get_qrels('mb11')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 49)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_mb12(self):
         topics = search.get_topics('mb12')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 60)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_mb12_qrels(self):
         qrels = search.get_qrels('mb12')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 59)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_mb13(self):
         topics = search.get_topics('mb13')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 60)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_mb13_qrels(self):
         qrels = search.get_qrels('mb13')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 60)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_mb14(self):
         topics = search.get_topics('mb14')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 55)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_mb14_qrels(self):
         qrels = search.get_qrels('mb14')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 55)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_car15(self):
         topics = search.get_topics('car17v1.5-benchmarkY1test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 2125)
         self.assertFalse(isinstance(next(iter(topics.keys())), int))
 
-    def test_car15_qrels(self):
         qrels = search.get_qrels('car17v1.5-benchmarkY1test')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 2125)
         self.assertFalse(isinstance(next(iter(qrels.keys())), int))
 
     def test_car20(self):
         topics = search.get_topics('car17v2.0-benchmarkY1test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 2254)
         self.assertFalse(isinstance(next(iter(topics.keys())), int))
 
-    def test_car20_qrels(self):
         qrels = search.get_qrels('car17v2.0-benchmarkY1test')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 2254)
         self.assertFalse(isinstance(next(iter(qrels.keys())), int))
 
     def test_dl19_doc(self):
         topics = search.get_topics('dl19-doc')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 43)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
 
-    def test_dl19_doc_qrels(self):
         qrels = search.get_qrels('dl19-doc')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 43)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
     def test_dl19_passage(self):
         topics = search.get_topics('dl19-passage')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 43)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
 
-    def test_dl19_passage_qrels(self):
         qrels = search.get_qrels('dl19-passage')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 43)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
     def test_dl20(self):
         topics = search.get_topics('dl20')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 200)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
 
-    def test_dl20_doc_qrels(self):
         qrels = search.get_qrels('dl20-doc')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 45)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
-    def test_dl20_passage_qrels(self):
         qrels = search.get_qrels('dl20-passage')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 54)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
+    # MS MARCO V1
     def test_msmarco_doc(self):
         topics = search.get_topics('msmarco-doc-dev')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 5193)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_msmarco_doc_qrels(self):
         qrels = search.get_qrels('msmarco-doc-dev')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 5193)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_msmarco_doc_test(self):
         topics = search.get_topics('msmarco-doc-test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 5793)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_msmarco_passage(self):
+    def test_msmarco_passage_dev(self):
         topics = search.get_topics('msmarco-passage-dev-subset')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 6980)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_msmarco_passage_qrels(self):
         qrels = search.get_qrels('msmarco-passage-dev-subset')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 6980)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_msmarco_passage_test(self):
         topics = search.get_topics('msmarco-passage-test-subset')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 6837)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
+    # MS MARCO V2
+    def test_msmarco_v2_doc_dev(self):
+        topics = search.get_topics('msmarco-v2-doc-dev')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 4552)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+        qrels = search.get_qrels('msmarco-v2-doc-dev')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 4552)
+        self.assertTrue(isinstance(next(iter(qrels.keys())), int))
+
+    def test_msmarco_v2_doc_dev2(self):
+        topics = search.get_topics('msmarco-v2-doc-dev2')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 5000)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+        qrels = search.get_qrels('msmarco-v2-doc-dev2')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 5000)
+        self.assertTrue(isinstance(next(iter(qrels.keys())), int))
+
+    def test_msmarco_v2_passage_dev(self):
+        topics = search.get_topics('msmarco-v2-passage-dev')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 3903)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+        qrels = search.get_qrels('msmarco-v2-passage-dev')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 3903)
+        self.assertTrue(isinstance(next(iter(qrels.keys())), int))
+
+    def test_msmarco_v2_passage_dev2(self):
+        topics = search.get_topics('msmarco-v2-passage-dev2')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 4281)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+        qrels = search.get_qrels('msmarco-v2-passage-dev2')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 4281)
+        self.assertTrue(isinstance(next(iter(qrels.keys())), int))
+
+    # Various multi-lingual test collections
     def test_ntcir8_zh(self):
         topics = search.get_topics('ntcir8-zh')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 73)
         self.assertTrue(isinstance(next(iter(topics.keys())), str))
 
-    def test_ntcir8_zh_qrels(self):
         qrels = search.get_qrels('ntcir8-zh')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 100)
         self.assertTrue(isinstance(next(iter(qrels.keys())), str))
 
     def test_clef2006_fr(self):
         topics = search.get_topics('clef2006-fr')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 49)
         self.assertTrue(isinstance(next(iter(topics.keys())), str))
 
-    def test_clef2006_fr_qrels(self):
         qrels = search.get_qrels('clef2006-fr')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 49)
         self.assertTrue(isinstance(next(iter(qrels.keys())), str))
 
     def test_trec2002_ar(self):
         topics = search.get_topics('trec2002-ar')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2002_ar_qrels(self):
         qrels = search.get_qrels('trec2002-ar')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_fire2012_bn(self):
         topics = search.get_topics('fire2012-bn')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_fire2012_bn_qrels(self):
         qrels = search.get_qrels('fire2012-bn')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_fire2012_hi(self):
         topics = search.get_topics('fire2012-hi')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_fire2012_hi_qrels(self):
         qrels = search.get_qrels('fire2012-hi')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_fire2012_en(self):
         topics = search.get_topics('fire2012-en')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_fire2012_en_qrels(self):
         qrels = search.get_qrels('fire2012-en')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
-    def test_trec2020_bl(self):
-        topics = search.get_topics('trec2020-bl')
-        self.assertEqual(len(topics), 50)
-        self.assertTrue(isinstance(next(iter(topics.keys())), int))
-
+    # Epidemic QA
     def test_epidemic_qa_expert_prelim(self):
         topics = search.get_topics('epidemic-qa-expert-prelim')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 45)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_epidemic_qa_consumer_prelim(self):
         topics = search.get_topics('epidemic-qa-consumer-prelim')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 42)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
+    # DPR datasets
     def test_dpr_nq_dev(self):
         topics = search.get_topics('dpr-nq-dev')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 8757)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_dpr_nq_test(self):
         topics = search.get_topics('dpr-nq-test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 3610)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_dpr_wq_test(self):
         topics = search.get_topics('dpr-wq-test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 2032)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_dpr_squad_test(self):
         topics = search.get_topics('dpr-squad-test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 10570)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_dpr_curated_test(self):
         topics = search.get_topics('dpr-curated-test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 694)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_dpr_trivia_test(self):
         topics = search.get_topics('dpr-trivia-test')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 11313)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_dpr_trivia_dev(self):
         topics = search.get_topics('dpr-trivia-dev')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 8837)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
+    # TREC-COVID
     def test_covid_round1(self):
         topics = search.get_topics('covid-round1')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 30)
         self.assertEqual('coronavirus origin', topics[1]['query'])
         self.assertEqual('coronavirus remdesivir', topics[30]['query'])
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_covid_round1_qrels(self):
         qrels = search.get_qrels('covid-round1')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 30)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_covid_round1_udel(self):
         topics = search.get_topics('covid-round1-udel')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 30)
         self.assertEqual('coronavirus origin origin COVID-19', topics[1]['query'])
         self.assertEqual('coronavirus remdesivir remdesivir effective treatment COVID-19', topics[30]['query'])
@@ -448,18 +542,20 @@ class TestLoadTopics(unittest.TestCase):
 
     def test_covid_round2(self):
         topics = search.get_topics('covid-round2')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 35)
         self.assertEqual('coronavirus origin', topics[1]['query'])
         self.assertEqual('coronavirus public datasets', topics[35]['query'])
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_covid_round2_qrels(self):
         qrels = search.get_qrels('covid-round2')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 35)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_covid_round2_udel(self):
         topics = search.get_topics('covid-round2-udel')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 35)
         self.assertEqual('coronavirus origin origin COVID-19', topics[1]['query'])
         self.assertEqual('coronavirus public datasets public datasets COVID-19', topics[35]['query'])
@@ -467,18 +563,20 @@ class TestLoadTopics(unittest.TestCase):
 
     def test_covid_round3(self):
         topics = search.get_topics('covid-round3')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 40)
         self.assertEqual('coronavirus origin', topics[1]['query'])
         self.assertEqual('coronavirus mutations', topics[40]['query'])
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_covid_round3_qrels(self):
         qrels = search.get_qrels('covid-round3')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 40)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_covid_round3_udel(self):
         topics = search.get_topics('covid-round3-udel')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 40)
         self.assertEqual('coronavirus origin origin COVID-19', topics[1]['query'])
         self.assertEqual('coronavirus mutations observed mutations SARS-CoV-2 genome mutations', topics[40]['query'])
@@ -486,58 +584,75 @@ class TestLoadTopics(unittest.TestCase):
 
     def test_covid_round4(self):
         topics = search.get_topics('covid-round4')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 45)
         self.assertEqual('coronavirus origin', topics[1]['query'])
         self.assertEqual('coronavirus mental health impact', topics[45]['query'])
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_covid_round4_qrels(self):
         qrels = search.get_qrels('covid-round4')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 45)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
     def test_covid_round4_udel(self):
         topics = search.get_topics('covid-round4-udel')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 45)
         self.assertEqual('coronavirus origin origin COVID-19', topics[1]['query'])
-        self.assertEqual('coronavirus mental health impact COVID-19 pandemic impacted mental health',
-                         topics[45]['query'])
+        self.assertEqual('coronavirus mental health impact COVID-19 pandemic impacted mental health', topics[45]['query'])
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
     def test_covid_round5(self):
         topics = search.get_topics('covid-round5')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_covid_round5_qrels(self):
         qrels = search.get_qrels('covid-round5')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
+    # TREC News Tracks
     def test_trec2018_bl(self):
         topics = search.get_topics('trec2018-bl')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 50)
         self.assertEqual('fef0f232a9bd94bdb96bac48c7705503', topics[393]['title'])
         self.assertEqual('a1c41a70-35c7-11e3-8a0e-4e2cf80831fc', topics[825]['title'])
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2018_bl_qrels(self):
         qrels = search.get_qrels('trec2018-bl')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 50)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
     
     def test_trec2019_bl(self):
         topics = search.get_topics('trec2019-bl')
+        self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 60)
         self.assertEqual('d7d906991e2883889f850de9ae06655e', topics[870]['title'])
         self.assertEqual('0d7f5e24cafc019265d3ee4b9745e7ea', topics[829]['title'])
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
-    def test_trec2019_bl_qrels(self):
         qrels = search.get_qrels('trec2019-bl')
+        self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 57)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
+    def test_trec2020_bl(self):
+        topics = search.get_topics('trec2020-bl')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 50)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+        qrels = search.get_qrels('trec2020-bl')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 50)
+        self.assertTrue(isinstance(next(iter(qrels.keys())), int))
+
+    # General test cases
     def test_tsv_int_topicreader(self):
         # Running from command-line, we're in root of repo, but running in IDE, we're in tests/
         path = 'tools/topics-and-qrels/topics.msmarco-doc.dev.txt'


### PR DESCRIPTION
+ Closes #745, #715.
+ Added bindings to JQrels.TREC2020_BL
+ For Lucene indexing supports single and double hyphens (e.g., `--collection` and `-collection`)