### PR TITLE
Add bindings for pre-tokenized queries for sparse learned models

### DIFF
--- a/docs/experiments-unicoil-tilde-expansion.md
+++ b/docs/experiments-unicoil-tilde-expansion.md
@@ -65,7 +65,7 @@ python -m pyserini.search --topics msmarco-passage-dev-subset \
                           --index indexes/lucene-index.msmarco-passage.unicoil-tilde-expansion-b8 \
                           --output runs/run.msmarco-passage.unicoil-tilde-expansion-b8.tsv \
                           --impact \
-                          --hits 1000 --batch 32 --threads 12 \
+                          --hits 1000 --batch 36 --threads 12 \
                           --output-format msmarco
 ```
 
@@ -110,7 +110,7 @@ python -m pyserini.search --topics collections/topics.msmarco-passage.dev-subset
                           --index indexes/lucene-index.msmarco-passage.unicoil-tilde-expansion-b8 \
                           --output runs/run.msmarco-passage.unicoil-tilde-expansion-b8.tsv \
                           --impact \
-                          --hits 1000 --batch 32 --threads 12 \
+                          --hits 1000 --batch 36 --threads 12 \
                           --output-format msmarco
 ```
 

--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -114,6 +114,18 @@ def get_topics(collection_name):
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_DOC_DEV)
     elif collection_name == 'msmarco-doc-test':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_DOC_TEST)
+    elif collection_name == 'msmarco-passage-dev-subset':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_DEV_SUBSET)
+    elif collection_name == 'msmarco-passage-dev-subset-deepimpact':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_DEV_SUBSET_DEEPIMPACT)
+    elif collection_name == 'msmarco-passage-dev-subset-unicoil-d2q':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL_D2Q)
+    elif collection_name == 'msmarco-passage-dev-subset-unicoil-tilde':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL_TILDE)
+    elif collection_name == 'msmarco-passage-dev-subset-distill-splade-max':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_DEV_SUBSET_DISTILL_SPLADE_MAX)
+    elif collection_name == 'msmarco-passage-test-subset':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_TEST_SUBSET)
     elif collection_name == 'msmarco-v2-doc-dev':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_DOC_DEV)
     elif collection_name == 'msmarco-v2-doc-dev2':
@@ -122,10 +134,6 @@ def get_topics(collection_name):
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV)
     elif collection_name == 'msmarco-v2-passage-dev2':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV2)
-    elif collection_name == 'msmarco-passage-dev-subset':
-        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_DEV_SUBSET)
-    elif collection_name == 'msmarco-passage-test-subset':
-        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_TEST_SUBSET)
     elif collection_name == 'ntcir8-zh':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.NTCIR8_ZH)
     elif collection_name == 'clef2006-fr':

--- a/tests/test_load_topics_qrels.py
+++ b/tests/test_load_topics_qrels.py
@@ -350,6 +350,30 @@ class TestLoadTopics(unittest.TestCase):
         self.assertEqual(len(topics), 6837)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
+    def test_msmarco_passage_dev_deepimpact(self):
+        topics = search.get_topics('msmarco-passage-dev-subset-deepimpact')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 6980)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+    def test_msmarco_passage_dev_unicoil_d2q(self):
+        topics = search.get_topics('msmarco-passage-dev-subset-unicoil-d2q')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 6980)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+    def test_msmarco_passage_dev_unicoil_tidle(self):
+        topics = search.get_topics('msmarco-passage-dev-subset-unicoil-tilde')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 6980)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+    def test_msmarco_passage_dev_distill_splade_max(self):
+        topics = search.get_topics('msmarco-passage-dev-subset-distill-splade-max')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 6980)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
     # MS MARCO V2
     def test_msmarco_v2_doc_dev(self):
         topics = search.get_topics('msmarco-v2-doc-dev')


### PR DESCRIPTION
Pyserini counterpart for this: https://github.com/castorini/anserini/pull/1670

Expose queries stored in Anserini jar in Python.