### PR TITLE
Drop JString wrapping

### DIFF
--- a/docs/usage-pyjnius.md
+++ b/docs/usage-pyjnius.md
@@ -13,10 +13,9 @@ Now `autoclass` can be used to provide direct access to Java classes:
 ```python
 from jnius import autoclass
 
-JString = autoclass('java.lang.String')
 JIndexReaderUtils = autoclass('io.anserini.index.IndexReaderUtils')
-reader = JIndexReaderUtils.getReader(JString('indexes/index-robust04-20191213/'))
+reader = JIndexReaderUtils.getReader('indexes/index-robust04-20191213/')
 
 # Fetch raw document contents by id:
-rawdoc = JIndexReaderUtils.documentRaw(reader, JString('FT934-5418'))
+rawdoc = JIndexReaderUtils.documentRaw(reader, 'FT934-5418')
 ```

--- a/pyserini/analysis/_base.py
+++ b/pyserini/analysis/_base.py
@@ -16,7 +16,7 @@
 
 from typing import List
 
-from ..pyclass import autoclass, JString
+from ..pyclass import autoclass
 
 # Wrappers around Lucene classes
 JAnalyzer = autoclass('org.apache.lucene.analysis.Analyzer')
@@ -112,9 +112,9 @@ def get_lucene_analyzer(language='en', stemming=True, stemmer='porter', stopword
     elif language.lower() == 'en':
         if stemming:
             if stopwords:
-                return JDefaultEnglishAnalyzer.newStemmingInstance(JString(stemmer))
+                return JDefaultEnglishAnalyzer.newStemmingInstance(stemmer)
             else:
-                return JDefaultEnglishAnalyzer.newStemmingInstance(JString(stemmer), JCharArraySet.EMPTY_SET)
+                return JDefaultEnglishAnalyzer.newStemmingInstance(stemmer, JCharArraySet.EMPTY_SET)
         else:
             if stopwords:
                 return JDefaultEnglishAnalyzer.newNonStemmingInstance()
@@ -151,7 +151,7 @@ class Analyzer:
         List[str]
             List of tokens corresponding to the output of the analyzer.
         """
-        results = JAnalyzerUtils.analyze(self.analyzer, JString(text))
+        results = JAnalyzerUtils.analyze(self.analyzer, text)
         tokens = []
         for token in results.toArray():
             tokens.append(token)

--- a/pyserini/index/_base.py
+++ b/pyserini/index/_base.py
@@ -25,7 +25,7 @@ from enum import Enum
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from ..analysis import get_lucene_analyzer, JAnalyzer, JAnalyzerUtils
-from ..pyclass import autoclass, JString
+from ..pyclass import autoclass
 from pyserini.util import download_prebuilt_index, get_sparse_indexes_info
 from pyserini.prebuilt_index_info import TF_INDEX_INFO, IMPACT_INDEX_INFO
 
@@ -184,7 +184,7 @@ class IndexReader:
 
     def __init__(self, index_dir):
         self.object = JIndexReader()
-        self.reader = self.object.getReader(JString(index_dir))
+        self.reader = self.object.getReader(index_dir)
 
     @classmethod
     def from_prebuilt_index(cls, prebuilt_index_name: str):
@@ -256,9 +256,9 @@ class IndexReader:
             List of tokens corresponding to the output of the analyzer.
         """
         if analyzer is None:
-            results = JAnalyzerUtils.analyze(JString(text))
+            results = JAnalyzerUtils.analyze(text)
         else:
-            results = JAnalyzerUtils.analyze(analyzer, JString(text))
+            results = JAnalyzerUtils.analyze(analyzer, text)
         tokens = []
         for token in results.toArray():
             tokens.append(token)
@@ -296,9 +296,9 @@ class IndexReader:
         if analyzer is None:
             analyzer = get_lucene_analyzer(stemming=False, stopwords=False)
 
-        term_map = self.object.getTermCountsWithAnalyzer(self.reader, JString(term), analyzer)
+        term_map = self.object.getTermCountsWithAnalyzer(self.reader, term, analyzer)
 
-        return term_map.get(JString('docFreq')), term_map.get(JString('collectionFreq'))
+        return term_map.get('docFreq'), term_map.get('collectionFreq')
 
     def get_postings_list(self, term: str, analyzer=get_lucene_analyzer()) -> List[Posting]:
         """Return the postings list for a term.
@@ -316,9 +316,9 @@ class IndexReader:
             List of :class:`Posting` objects corresponding to the postings list for the term.
         """
         if analyzer is None:
-            postings_list = self.object.getPostingsListForAnalyzedTerm(self.reader, JString(term))
+            postings_list = self.object.getPostingsListForAnalyzedTerm(self.reader, term)
         else:
-            postings_list = self.object.getPostingsListWithAnalyzer(self.reader, JString(term),
+            postings_list = self.object.getPostingsListWithAnalyzer(self.reader, term,
                                                                     analyzer)
 
         if postings_list is None:
@@ -344,12 +344,12 @@ class IndexReader:
         Optional[Dict[str, int]]
             A dictionary with analyzed terms as keys and their term frequencies as values.
         """
-        doc_vector_map = self.object.getDocumentVector(self.reader, JString(docid))
+        doc_vector_map = self.object.getDocumentVector(self.reader, docid)
         if doc_vector_map is None:
             return None
         doc_vector_dict = {}
         for term in doc_vector_map.keySet().toArray():
-            doc_vector_dict[term] = doc_vector_map.get(JString(term))
+            doc_vector_dict[term] = doc_vector_map.get(term)
         return doc_vector_dict
 
     def get_term_positions(self, docid: str) -> Optional[Dict[str, int]]:
@@ -368,12 +368,12 @@ class IndexReader:
         Optional[Dict[str, int]]
             A tuple contains a dictionary with analyzed terms as keys and corresponding posting list as values
         """
-        java_term_position_map = self.object.getTermPositions(self.reader, JString(docid))
+        java_term_position_map = self.object.getTermPositions(self.reader, docid)
         if java_term_position_map is None:
             return None
         term_position_map = {}
         for term in java_term_position_map.keySet().toArray():
-            term_position_map[term] = java_term_position_map.get(JString(term)).toArray()
+            term_position_map[term] = java_term_position_map.get(term).toArray()
         return term_position_map
 
     def doc(self, docid: str) -> Optional[Document]:
@@ -390,7 +390,7 @@ class IndexReader:
         Optional[Document]
             :class:`Document` corresponding to the ``docid``.
         """
-        lucene_document = self.object.document(self.reader, JString(docid))
+        lucene_document = self.object.document(self.reader, docid)
         if lucene_document is None:
             return None
         return Document(lucene_document)
@@ -411,7 +411,7 @@ class IndexReader:
         Optional[Document]
             :class:`Document` whose ``field`` is ``id``.
         """
-        lucene_document = self.object.documentByField(self.reader, JString(field), JString(q))
+        lucene_document = self.object.documentByField(self.reader, field, q)
         if lucene_document is None:
             return None
         return Document(lucene_document)
@@ -429,7 +429,7 @@ class IndexReader:
         Optional[str]
             Raw document contents.
         """
-        return self.object.documentRaw(self.reader, JString(docid))
+        return self.object.documentRaw(self.reader, docid)
 
     def doc_contents(self, docid: str) -> Optional[str]:
         """Return the indexed document contents for a collection ``docid``.
@@ -444,7 +444,7 @@ class IndexReader:
         Optional[str]
             Index document contents.
         """
-        return self.object.documentContents(self.reader, JString(docid))
+        return self.object.documentContents(self.reader, docid)
 
     def compute_bm25_term_weight(self, docid: str, term: str, analyzer=get_lucene_analyzer(), k1=0.9, b=0.4) -> float:
         """Compute the BM25 weight of a term in a document. Specify ``analyzer=None`` for an already analyzed term,
@@ -469,12 +469,12 @@ class IndexReader:
             BM25 weight of the term in the document, or 0 if the term does not exist in the document.
         """
         if analyzer is None:
-            return self.object.getBM25AnalyzedTermWeightWithParameters(self.reader, JString(docid),
-                                                                       JString(term),
+            return self.object.getBM25AnalyzedTermWeightWithParameters(self.reader, docid,
+                                                                       term,
                                                                        float(k1), float(b))
         else:
-            return self.object.getBM25UnanalyzedTermWeightWithParameters(self.reader, JString(docid),
-                                                                         JString(term), analyzer,
+            return self.object.getBM25UnanalyzedTermWeightWithParameters(self.reader, docid,
+                                                                         term, analyzer,
                                                                          float(k1), float(b))
 
     def compute_query_document_score(self, docid: str, query: str, similarity=None):
@@ -532,6 +532,6 @@ class IndexReader:
 
         index_stats_dict = {}
         for term in index_stats_map.keySet().toArray():
-            index_stats_dict[term] = index_stats_map.get(JString(term))
+            index_stats_dict[term] = index_stats_map.get(term)
 
         return index_stats_dict

--- a/pyserini/ltr/_base.py
+++ b/pyserini/ltr/_base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from ..pyclass import autoclass, JString, JArrayList
+from ..pyclass import autoclass, JArrayList
 import json
 import numpy as np
 import pandas as pd
@@ -26,62 +26,62 @@ class Feature:
 class NormalizedTfIdf(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.NormalizedTfIdf')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class ProbalitySum(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.ProbalitySum')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class IbmModel1(Feature):
     def __init__(self, path, field, tag, qfield):
         Jclass = autoclass('io.anserini.ltr.feature.IbmModel1')
-        self.extractor = Jclass(JString(path), JString(field), JString(tag), JString(qfield))
+        self.extractor = Jclass(path, field, tag, qfield)
 
 class Proximity(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.Proximity')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class TpScore(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.TpScore')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class TpDist(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.TpDist')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class DocSize(Feature):
     def __init__(self, field='contents'):
         Jclass = autoclass('io.anserini.ltr.feature.DocSize')
-        self.extractor = Jclass(JString(field))
+        self.extractor = Jclass(field)
 
 class MatchingTermCount(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.MatchingTermCount')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class QueryLength(Feature):
     def __init__(self, qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.QueryLength')
-        self.extractor = Jclass(JString(qfield))
+        self.extractor = Jclass(qfield)
 
 class SCS(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.SCS')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class SumMatchingTF(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.SumMatchingTF')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class QueryCoverageRatio(Feature):
     def __init__(self, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.QueryCoverageRatio')
-        self.extractor = Jclass(JString(field), JString(qfield))
+        self.extractor = Jclass(field, qfield)
 
 class RunList(Feature):
     def __init__(self,filename,tag):
@@ -91,27 +91,27 @@ class RunList(Feature):
 class UniqueTermCount(Feature):
     def __init__(self, qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.UniqueTermCount')
-        self.extractor = Jclass(JString(qfield))
+        self.extractor = Jclass(qfield)
 
 class UnorderedSequentialPairs(Feature):
     def __init__(self, gap=8, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.UnorderedSequentialPairs')
-        self.extractor = Jclass(gap, JString(field), JString(qfield))
+        self.extractor = Jclass(gap, field, qfield)
 
 class OrderedSequentialPairs(Feature):
     def __init__(self, gap=8, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.OrderedSequentialPairs')
-        self.extractor = Jclass(gap, JString(field), JString(qfield))
+        self.extractor = Jclass(gap, field, qfield)
 
 class UnorderedQueryPairs(Feature):
     def __init__(self, gap=8, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.UnorderedQueryPairs')
-        self.extractor = Jclass(gap, JString(field), JString(qfield))
+        self.extractor = Jclass(gap, field, qfield)
 
 class OrderedQueryPairs(Feature):
     def __init__(self, gap=8, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.OrderedQueryPairs')
-        self.extractor = Jclass(gap, JString(field), JString(qfield))
+        self.extractor = Jclass(gap, field, qfield)
 
 class AvgPooler(Feature):
     def __init__(self):
@@ -156,59 +156,59 @@ class MaxMinRatioPooler(Feature):
 class TfStat(Feature):
     def __init__(self, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.TfStat')
-        self.extractor = Jclass(pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, field, qfield)
 
 class TfIdfStat(Feature):
     def __init__(self, sublinear, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.TfIdfStat')
         JBoolean = autoclass('java.lang.Boolean')
-        self.extractor = Jclass(JBoolean(sublinear), pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(JBoolean(sublinear), pooler.extractor, field, qfield)
 
 class NormalizedTfStat(Feature):
     def __init__(self, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.NormalizedTfStat')
-        self.extractor = Jclass(pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, field, qfield)
 
 class IdfStat(Feature):
     def __init__(self, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.IdfStat')
-        self.extractor = Jclass(pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, field, qfield)
 
 class IcTfStat(Feature):
     def __init__(self, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.IcTfStat')
-        self.extractor = Jclass(pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, field, qfield)
 
 class BM25Stat(Feature):
     def __init__(self, pooler, k1=0.9, b=0.4, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.BM25Stat')
-        self.extractor = Jclass(pooler.extractor, k1, b, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, k1, b, field, qfield)
 
 class DfrInExpB2Stat(Feature):
     def __init__(self, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.DfrInExpB2Stat')
-        self.extractor = Jclass(pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, field, qfield)
 
 class DphStat(Feature):
     def __init__(self, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.DphStat')
-        self.extractor = Jclass(pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, field, qfield)
 
 class LmDirStat(Feature):
     def __init__(self, pooler, mu=1000, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.LmDirStat')
-        self.extractor = Jclass(pooler.extractor, mu, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, mu, field, qfield)
 
 class DfrGl2Stat(Feature):
     def __init__(self, pooler, field='contents', qfield='analyzed'):
         Jclass = autoclass('io.anserini.ltr.feature.DfrGl2Stat')
-        self.extractor = Jclass(pooler.extractor, JString(field), JString(qfield))
+        self.extractor = Jclass(pooler.extractor, field, qfield)
 
 
 class FeatureExtractor:
     def __init__(self, index_dir, worker_num=1):
         JFeatureExtractorUtils = autoclass('io.anserini.ltr.FeatureExtractorUtils')
-        self.utils = JFeatureExtractorUtils(JString(index_dir), worker_num)
+        self.utils = JFeatureExtractorUtils(index_dir, worker_num)
         self.feature_name = []
 
     def add(self, pyclass):
@@ -234,7 +234,7 @@ class FeatureExtractor:
     def lazy_extract(self, qid, doc_ids, query_dict):
         input = {'qid': qid, 'docIds': doc_ids}
         input.update(query_dict)
-        self.utils.lazyExtract(JString(json.dumps(input)))
+        self.utils.lazyExtract(json.dumps(input))
 
     def batch_extract(self, tasks):
         need_rows = 0
@@ -252,7 +252,7 @@ class FeatureExtractor:
 
 
     def get_result(self, qid):
-        res = self.utils.getResult(JString(qid)).tostring()
+        res = self.utils.getResult(qid).tostring()
         dt = np.dtype(np.float32)
         dt = dt.newbyteorder('>')
         return np.frombuffer(res, dt)

--- a/pyserini/search/_impact_searcher.py
+++ b/pyserini/search/_impact_searcher.py
@@ -23,7 +23,7 @@ import os
 from typing import Dict, List, Optional, Union
 import numpy as np
 from pyserini.index import Document
-from pyserini.pyclass import autoclass, JFloat, JArrayList, JHashMap, JString
+from pyserini.pyclass import autoclass, JFloat, JArrayList, JHashMap
 from pyserini.util import download_prebuilt_index
 from pyserini.encode import QueryEncoder, TokFreqQueryEncoder, UniCoilQueryEncoder, CachedDataQueryEncoder
 from ..encode._splade import SpladeQueryEncoder
@@ -50,7 +50,7 @@ class ImpactSearcher:
         self.index_dir = index_dir
         self.idf = self._compute_idf(index_dir)
         self.min_idf = min_idf
-        self.object = JImpactSearcher(JString(index_dir))
+        self.object = JImpactSearcher(index_dir)
         self.num_docs = self.object.getTotalNumDocuments()
         if isinstance(query_encoder, str) or query_encoder is None:
             self.query_encoder = self._init_query_encoder_from_str(query_encoder)
@@ -108,13 +108,13 @@ class ImpactSearcher:
 
         jfields = JHashMap()
         for (field, boost) in fields.items():
-            jfields.put(JString(field), JFloat(boost))
+            jfields.put(field, JFloat(boost))
 
         encoded_query = self.query_encoder.encode(q)
         jquery = JHashMap()
         for (token, weight) in encoded_query.items():
             if token in self.idf and self.idf[token] > self.min_idf:
-                jquery.put(JString(token), JFloat(weight))
+                jquery.put(token, JFloat(weight))
 
         if not fields:
             hits = self.object.search(jquery, k)
@@ -155,16 +155,16 @@ class ImpactSearcher:
             jquery = JHashMap()
             for (token, weight) in encoded_query.items():
                 if token in self.idf and self.idf[token] > self.min_idf:
-                    jquery.put(JString(token), JFloat(weight))
+                    jquery.put(token, JFloat(weight))
             query_lst.add(jquery)
 
         for qid in qids:
-            jqid = JString(qid)
+            jqid = qid
             qid_lst.add(jqid)
 
         jfields = JHashMap()
         for (field, boost) in fields.items():
-            jfields.put(JString(field), JFloat(boost))
+            jfields.put(field, JFloat(boost))
 
         if not fields:
             results = self.object.batchSearch(query_lst, qid_lst, int(k), int(threads))
@@ -210,7 +210,7 @@ class ImpactSearcher:
         Document
             :class:`Document` whose ``field`` is ``id``.
         """
-        lucene_document = self.object.documentByField(JString(field), JString(q))
+        lucene_document = self.object.documentByField(field, q)
         if lucene_document is None:
             return None
         return Document(lucene_document)

--- a/pyserini/search/_nearest_neighbor.py
+++ b/pyserini/search/_nearest_neighbor.py
@@ -22,7 +22,7 @@ class, which wraps the Java class with the same name in Anserini.
 import logging
 from typing import List
 
-from ..pyclass import autoclass, JString
+from ..pyclass import autoclass
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ JSimpleNearestNeighborSearcherResult = autoclass('io.anserini.search.SimpleNeare
 class SimpleNearestNeighborSearcher:
 
     def __init__(self, index_dir: str):
-        self.object = JSimpleNearestNeighborSearcher(JString(index_dir))
+        self.object = JSimpleNearestNeighborSearcher(index_dir)
 
     def search(self, q: str, k=10) -> List[JSimpleNearestNeighborSearcherResult]:
         """Searches nearest neighbor of an embedding identified by its id.
@@ -52,7 +52,7 @@ class SimpleNearestNeighborSearcher:
         List(JSimpleNearestNeighborSearcherResult]
             List of (nearest neighbor) search results.
         """
-        return self.object.search(JString(q), k)
+        return self.object.search(q, k)
 
     def multisearch(self, q: str, k=10) -> List[List[JSimpleNearestNeighborSearcherResult]]:
         """Searches nearest neighbors of all the embeddings having the specified id.
@@ -69,6 +69,6 @@ class SimpleNearestNeighborSearcher:
         List(List[JSimpleNearestNeighborSearcherResult])
             List of List of (nearest neighbor) search results (one for each matching id).
         """
-        return self.object.multisearch(JString(q), k)
+        return self.object.multisearch(q, k)
 
 

--- a/pyserini/search/_searcher.py
+++ b/pyserini/search/_searcher.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Union
 
 from ._base import JQuery, JQueryGenerator
 from pyserini.index import Document
-from pyserini.pyclass import autoclass, JFloat, JArrayList, JHashMap, JString
+from pyserini.pyclass import autoclass, JFloat, JArrayList, JHashMap
 from pyserini.trectools import TrecRun
 from pyserini.fusion import FusionMethod, reciprocal_rank_fusion
 from pyserini.util import download_prebuilt_index, get_sparse_indexes_info
@@ -48,7 +48,7 @@ class SimpleSearcher:
 
     def __init__(self, index_dir: str):
         self.index_dir = index_dir
-        self.object = JSimpleSearcher(JString(index_dir))
+        self.object = JSimpleSearcher(index_dir)
         self.num_docs = self.object.getTotalNumDocuments()
 
     @classmethod
@@ -107,14 +107,14 @@ class SimpleSearcher:
 
         jfields = JHashMap()
         for (field, boost) in fields.items():
-            jfields.put(JString(field), JFloat(boost))
+            jfields.put(field, JFloat(boost))
 
         hits = None
         if query_generator:
             if not fields:
-                hits = self.object.search(query_generator, JString(q), k)
+                hits = self.object.search(query_generator, q, k)
             else:
-                hits = self.object.searchFields(query_generator, JString(q), jfields, k)
+                hits = self.object.searchFields(query_generator, q, jfields, k)
         elif isinstance(q, JQuery):
             # Note that RM3 requires the notion of a query (string) to estimate the appropriate models. If we're just
             # given a Lucene query, it's unclear what the "query" is for this estimation. One possibility is to extract
@@ -128,9 +128,9 @@ class SimpleSearcher:
             hits = self.object.search(q, k)
         else:
             if not fields:
-                hits = self.object.search(JString(q), k)
+                hits = self.object.search(q, k)
             else:
-                hits = self.object.searchFields(JString(q), jfields, k)
+                hits = self.object.searchFields(q, jfields, k)
 
         docids = set()
         filtered_hits = []
@@ -177,16 +177,14 @@ class SimpleSearcher:
         query_strings = JArrayList()
         qid_strings = JArrayList()
         for query in queries:
-            jq = JString(query)
-            query_strings.add(jq)
+            query_strings.add(query)
 
         for qid in qids:
-            jqid = JString(qid)
-            qid_strings.add(jqid)
+            qid_strings.add(qid)
 
         jfields = JHashMap()
         for (field, boost) in fields.items():
-            jfields.put(JString(field), JFloat(boost))
+            jfields.put(field, JFloat(boost))
 
         if query_generator:
             if not fields:
@@ -304,7 +302,7 @@ class SimpleSearcher:
         Document
             :class:`Document` whose ``field`` is ``id``.
         """
-        lucene_document = self.object.documentByField(JString(field), JString(q))
+        lucene_document = self.object.documentByField(field, q)
         if lucene_document is None:
             return None
         return Document(lucene_document)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -23,7 +23,6 @@ from urllib.request import urlretrieve
 
 from pyserini import analysis, index, search
 from pyserini.analysis import JAnalyzer, JAnalyzerUtils, Analyzer
-from pyserini.pyclass import JString
 
 
 class TestAnalyzers(unittest.TestCase):
@@ -53,7 +52,7 @@ class TestAnalyzers(unittest.TestCase):
     def test_analyze_with_analyzer(self):
         analyzer = analysis.get_lucene_analyzer(stemming=False)
         self.assertTrue(isinstance(analyzer, JAnalyzer))
-        query = JString('information retrieval')
+        query = 'information retrieval'
         only_tokenization = JAnalyzerUtils.analyze(analyzer, query)
         token_list = []
         for token in only_tokenization.toArray():

--- a/tests/test_index_reader.py
+++ b/tests/test_index_reader.py
@@ -70,13 +70,10 @@ class TestIndexUtils(unittest.TestCase):
         self.assertEqual(df, 1)
         self.assertEqual(cf, 1)
 
-        # Currently, this test case will pass if we do '🙂'.encode('utf-8')
         df, cf = temp_index_reader.get_term_counts('🙂')
         self.assertEqual(df, 1)
         self.assertEqual(cf, 1)
 
-        # This currently fails no matter what because by the time we retrieve the doc vector, None has already been
-        # inserted into the dictionary.
         doc_vector = temp_index_reader.get_document_vector('doc1')
         self.assertEqual(doc_vector['emoji'], 1)
         self.assertEqual(doc_vector['🙂'], 1)


### PR DESCRIPTION
As discussed in https://github.com/castorini/pyserini/issues/770, converting Python strings to Java strings using `JString(...)` does not work correctly if the string contains an emoji. However, letting the `pyjnius` library perform the conversion automatically without the explicit `JString` conversion seems to work correctly.

Unit tests pass successfully. @lintool, you can check the regression tests on your side to make sure it doesn't break anything.