### PR TITLE
Fix the Core17 clprf Regression Test Failure 

### DIFF
--- a/pyserini/trectools/_base.py
+++ b/pyserini/trectools/_base.py
@@ -110,7 +110,7 @@ class TrecRun:
         self.run_data = pd.read_csv(filepath, sep='\s+', names=TrecRun.columns, dtype={'docid': 'str'})
         if resort:
             self.run_data.sort_values(["topic", "score"], inplace=True, ascending=[True, False])
-            self.run_data["rank"] = self.run_data.groupby("topic")[["docid","score"]].rank(ascending=False,method='first')
+            self.run_data["rank"] = self.run_data.groupby("topic")["score"].rank(ascending=False,method='first')
 
     def topics(self) -> Set[str]:
         """Return a set with all topics."""


### PR DESCRIPTION
* The rank function is changed in pandas 1.3.5 from 1.1.4 which caused the Value Error in the fusion part of clprf regression tests. Fixed it by only ranking one column one now.