### PR TITLE
Deprecate old versions of MS MARCO (V1) pre-built indexes

### DIFF
--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -57,14 +57,6 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 <dd>Lucene index of TREC Disks 4 & 5 (minus Congressional Records), used in the TREC 2004 Robust Track
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-robust04-20191213-readme.txt">readme</a>]
 </dd>
-<dt></dt><b><code>msmarco-passage</code></b>
-<dd>Lucene index of the MS MARCO passage corpus
-[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-20201117-f87c94-readme.txt">readme</a>]
-</dd>
-<dt></dt><b><code>msmarco-passage-slim</code></b>
-<dd>Lucene index of the MS MARCO passage corpus (slim version, document text not stored)
-[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-slim-20201202-ab6e28-readme.txt">readme</a>]
-</dd>
 <dt></dt><b><code>msmarco-passage-expanded</code></b>
 <dd>Lucene index of the MS MARCO passage corpus with docTTTTTquery expansions
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-expanded-20201121-e127fb-readme.txt">readme</a>]
@@ -75,22 +67,6 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-doc-per-passage-ltr</code></b>
 <dd>Lucene index of the MS MARCO document per-passage corpus with four extra preprocessed fields for LTR
-</dd>
-<dt></dt><b><code>msmarco-doc</code></b>
-<dd>Lucene index of the MS MARCO document corpus
-[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-20201117-f87c94-readme.txt">readme</a>]
-</dd>
-<dt></dt><b><code>msmarco-doc-slim</code></b>
-<dd>Lucene index of the MS MARCO document corpus (slim version, document text not stored)
-[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-slim-20201202-ab6e28-readme.txt">readme</a>]
-</dd>
-<dt></dt><b><code>msmarco-doc-per-passage</code></b>
-<dd>Lucene index of the MS MARCO document corpus segmented into passages
-[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-20201204-f50dcc-readme.txt">readme</a>]
-</dd>
-<dt></dt><b><code>msmarco-doc-per-passage-slim</code></b>
-<dd>Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored)
-[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-slim-20201204-f50dcc-readme.txt">readme</a>]
 </dd>
 <dt></dt><b><code>msmarco-doc-expanded-per-doc</code></b>
 <dd>Lucene index of the MS MARCO document corpus with per-doc docTTTTTquery expansions
@@ -293,6 +269,30 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 <dt></dt><b><code>mrtydi-v1.1-thai</code></b>
 <dd>Lucene index for Mr.TyDi v1.1 (Thai).
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.mrtydi-v1.1-thai.20220108.6fcb89.README.md">readme</a>]
+</dd>
+<dt></dt><b><code>msmarco-passage</code></b>
+<dd>Lucene index of the MS MARCO passage corpus (deprecated; use `msmarco-v1-passage` instead).
+[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-20201117-f87c94-readme.txt">readme</a>]
+</dd>
+<dt></dt><b><code>msmarco-passage-slim</code></b>
+<dd>Lucene index of the MS MARCO passage corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-passage-slim` instead).
+[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-slim-20201202-ab6e28-readme.txt">readme</a>]
+</dd>
+<dt></dt><b><code>msmarco-doc</code></b>
+<dd>Lucene index of the MS MARCO document corpus (deprecated; use `msmarco-v1-doc` instead).
+[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-20201117-f87c94-readme.txt">readme</a>]
+</dd>
+<dt></dt><b><code>msmarco-doc-slim</code></b>
+<dd>Lucene index of the MS MARCO document corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-slim` instead).
+[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-slim-20201202-ab6e28-readme.txt">readme</a>]
+</dd>
+<dt></dt><b><code>msmarco-doc-per-passage</code></b>
+<dd>Lucene index of the MS MARCO document corpus segmented into passages (deprecated; use `msmarco-v1-doc-segmented` instead).
+[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-20201204-f50dcc-readme.txt">readme</a>]
+</dd>
+<dt></dt><b><code>msmarco-doc-per-passage-slim</code></b>
+<dd>Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-segmented-slim` instead).
+[<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-slim-20201204-f50dcc-readme.txt">readme</a>]
 </dd>
 </dl>
 

--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -271,27 +271,27 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.mrtydi-v1.1-thai.20220108.6fcb89.README.md">readme</a>]
 </dd>
 <dt></dt><b><code>msmarco-passage</code></b>
-<dd>Lucene index of the MS MARCO passage corpus (deprecated; use `msmarco-v1-passage` instead).
+<dd>Lucene index of the MS MARCO passage corpus (deprecated; use msmarco-v1-passage instead).
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-20201117-f87c94-readme.txt">readme</a>]
 </dd>
 <dt></dt><b><code>msmarco-passage-slim</code></b>
-<dd>Lucene index of the MS MARCO passage corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-passage-slim` instead).
+<dd>Lucene index of the MS MARCO passage corpus (slim version, document text not stored) (deprecated; use msmarco-v1-passage-slim instead).
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-slim-20201202-ab6e28-readme.txt">readme</a>]
 </dd>
 <dt></dt><b><code>msmarco-doc</code></b>
-<dd>Lucene index of the MS MARCO document corpus (deprecated; use `msmarco-v1-doc` instead).
+<dd>Lucene index of the MS MARCO document corpus (deprecated; use msmarco-v1-doc instead).
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-20201117-f87c94-readme.txt">readme</a>]
 </dd>
 <dt></dt><b><code>msmarco-doc-slim</code></b>
-<dd>Lucene index of the MS MARCO document corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-slim` instead).
+<dd>Lucene index of the MS MARCO document corpus (slim version, document text not stored) (deprecated; use msmarco-v1-doc-slim instead).
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-slim-20201202-ab6e28-readme.txt">readme</a>]
 </dd>
 <dt></dt><b><code>msmarco-doc-per-passage</code></b>
-<dd>Lucene index of the MS MARCO document corpus segmented into passages (deprecated; use `msmarco-v1-doc-segmented` instead).
+<dd>Lucene index of the MS MARCO document corpus segmented into passages (deprecated; use msmarco-v1-doc-segmented instead).
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-20201204-f50dcc-readme.txt">readme</a>]
 </dd>
 <dt></dt><b><code>msmarco-doc-per-passage-slim</code></b>
-<dd>Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-segmented-slim` instead).
+<dd>Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored) (deprecated; use msmarco-v1-doc-segmented-slim instead).
 [<a href="https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-slim-20201204-f50dcc-readme.txt">readme</a>]
 </dd>
 </dl>

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -124,7 +124,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-doc.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/aDRAfyZytQsQ9T3/download"
         ],
         "md5": "43b60b3fc75324c648a02375772e7fe8",
         "size compressed (bytes)": 13757573401,
@@ -138,7 +139,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-doc-slim.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-slim.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-slim.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-slim.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/iCnysqnaG9SL9pA/download"
         ],
         "md5": "17a7b079e9d527492904c7697a9cae59",
         "size compressed (bytes)": 1811599007,
@@ -152,7 +154,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-doc-full.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-full.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-full.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-full.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/KsqZ2AwkSrTM8yS/download"
         ],
         "md5": "ef60d7f8afa3919cdeedc6fea89aa3f7",
         "size compressed (bytes)": 25548064269,
@@ -168,7 +171,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/FKniAWGJjZHy3TF/download"
         ],
         "md5": "611bb83e043c0d6febe0fa3508d1d7f9",
         "size compressed (bytes)": 17091132803,
@@ -182,7 +186,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-doc-segmented-slim.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-slim.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented-slim.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented-slim.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/QNYpaAcLXERr74y/download"
         ],
         "md5": "d42113cfeeea862b51765329795948ad",
         "size compressed (bytes)": 3408754542,
@@ -196,7 +201,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-doc-segmented-full.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-full.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented-full.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented-full.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/RzRBC6xkmaTsmX9/download"
         ],
         "md5": "2ed7457c8804d2d6370a1a7f604eb360",
         "size compressed (bytes)": 30771630666,
@@ -212,7 +218,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-passage.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/L7yNfCXpqK5yf8e/download"
         ],
         "md5": "4d8fdbdcd119c1f47a4cc5d01a45dad3",
         "size compressed (bytes)": 2178557129,
@@ -226,7 +233,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-passage-slim.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-slim.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage-slim.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage-slim.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/swtPDQAGg6oHD8m/download"
         ],
         "md5": "2f1e50d60a0df32a50111a986159de51",
         "size compressed (bytes)": 498355616,
@@ -240,7 +248,8 @@ TF_INDEX_INFO = {
         "filename": "lucene-index.msmarco-v1-passage-full.20220131.9ea315.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-full.20220131.9ea315.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage-full.20220131.9ea315.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage-full.20220131.9ea315.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/wzGLFMQyKAc2TTC/download"
         ],
         "md5": "3283069c6e8451659c8ea83e2140d739",
         "size compressed (bytes)": 3781721749,

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -900,7 +900,7 @@ TF_INDEX_INFO = {
 
     # These indexes are deprecated, but keeping around for archival reasons
     "msmarco-passage": {
-        "description": "Lucene index of the MS MARCO passage corpus (deprecated; use `msmarco-v1-passage` instead).",
+        "description": "Lucene index of the MS MARCO passage corpus (deprecated; use msmarco-v1-passage instead).",
         "filename": "index-msmarco-passage-20201117-f87c94.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-20201117-f87c94-readme.txt",
         "urls": [
@@ -915,7 +915,7 @@ TF_INDEX_INFO = {
         "downloaded": False
     },
     "msmarco-passage-slim": {
-        "description": "Lucene index of the MS MARCO passage corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-passage-slim` instead).",
+        "description": "Lucene index of the MS MARCO passage corpus (slim version, document text not stored) (deprecated; use msmarco-v1-passage-slim instead).",
         "filename": "index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-slim-20201202-ab6e28-readme.txt",
         "urls": [
@@ -930,7 +930,7 @@ TF_INDEX_INFO = {
         "downloaded": False
     },
     "msmarco-doc": {
-        "description": "Lucene index of the MS MARCO document corpus (deprecated; use `msmarco-v1-doc` instead).",
+        "description": "Lucene index of the MS MARCO document corpus (deprecated; use msmarco-v1-doc instead).",
         "filename": "index-msmarco-doc-20201117-f87c94.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-20201117-f87c94-readme.txt",
         "urls": [
@@ -945,7 +945,7 @@ TF_INDEX_INFO = {
         "downloaded": False
     },
     "msmarco-doc-slim": {
-        "description": "Lucene index of the MS MARCO document corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-slim` instead).",
+        "description": "Lucene index of the MS MARCO document corpus (slim version, document text not stored) (deprecated; use msmarco-v1-doc-slim instead).",
         "filename": "index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-slim-20201202-ab6e28-readme.txt",
         "urls": [
@@ -960,7 +960,7 @@ TF_INDEX_INFO = {
         "downloaded": False
     },
     "msmarco-doc-per-passage": {
-        "description": "Lucene index of the MS MARCO document corpus segmented into passages (deprecated; use `msmarco-v1-doc-segmented` instead).",
+        "description": "Lucene index of the MS MARCO document corpus segmented into passages (deprecated; use msmarco-v1-doc-segmented instead).",
         "filename": "index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-20201204-f50dcc-readme.txt",
         "urls": [
@@ -975,7 +975,7 @@ TF_INDEX_INFO = {
         "downloaded": False
     },
     "msmarco-doc-per-passage-slim": {
-        "description": "Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-segmented-slim` instead).",
+        "description": "Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored) (deprecated; use msmarco-v1-doc-segmented-slim instead).",
         "filename": "index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
         "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-slim-20201204-f50dcc-readme.txt",
         "urls": [

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -41,36 +41,7 @@ TF_INDEX_INFO = {
         "documents": 528030,
         "unique_terms": 923436,
     },
-    "msmarco-passage": {
-        "description": "Lucene index of the MS MARCO passage corpus",
-        "filename": "index-msmarco-passage-20201117-f87c94.tar.gz",
-        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-20201117-f87c94-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-passage-20201117-f87c94.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/QQsZMFG8MpF4P8M/download"
-        ],
-        "md5": "1efad4f1ae6a77e235042eff4be1612d",
-        "size compressed (bytes)": 2218470796,
-        "total_terms": 352316036,
-        "documents": 8841823,
-        "unique_terms": 2660824,
-        "downloaded": False
-    },
-    "msmarco-passage-slim": {
-        "description": "Lucene index of the MS MARCO passage corpus (slim version, document text not stored)",
-        "filename": "index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
-        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-slim-20201202-ab6e28-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Kx6K9NJFmwnaAP8/download"
-        ],
-        "md5": "5e11da4cebd2e8dda2e73c589ffb0b4c",
-        "size compressed (bytes)": 513566686,
-        "total_terms": 352316036,
-        "documents": 8841823,
-        "unique_terms": 2660824,
-        "downloaded": False
-    },
+
     "msmarco-passage-expanded": {
         "description": "Lucene index of the MS MARCO passage corpus with docTTTTTquery expansions",
         "filename": "index-msmarco-passage-expanded-20201121-e127fb.tar.gz",
@@ -115,66 +86,7 @@ TF_INDEX_INFO = {
         "unique_terms": 10123678,
         "downloaded": False
     },
-    "msmarco-doc": {
-        "description": "Lucene index of the MS MARCO document corpus",
-        "filename": "index-msmarco-doc-20201117-f87c94.tar.gz",
-        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-20201117-f87c94-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-20201117-f87c94.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/5NC7A2wAL7opJKH/download"
-        ],
-        "md5": "ac747860e7a37aed37cc30ed3990f273",
-        "size compressed (bytes)": 13642330935,
-        "total_terms": 2748636047,
-        "documents": 3213835,
-        "unique_terms": 29823078,
-        "downloaded": False
-    },
-    "msmarco-doc-slim": {
-        "description": "Lucene index of the MS MARCO document corpus (slim version, document text not stored)",
-        "filename": "index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
-        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-slim-20201202-ab6e28-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/BMZ6oYBoEPgTFqs/download"
-        ],
-        "md5": "c56e752f7992bf6149761097641d515a",
-        "size compressed (bytes)": 1874471867,
-        "total_terms": 2748636047,
-        "documents": 3213835,
-        "unique_terms": 29823078,
-        "downloaded": False
-    },
-    "msmarco-doc-per-passage": {
-        "description": "Lucene index of the MS MARCO document corpus segmented into passages",
-        "filename": "index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
-        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-20201204-f50dcc-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/q6sAxE6q57q2TBo/download"
-        ],
-        "md5": "797367406a7542b649cefa6b41cf4c33",
-        "size compressed (bytes)": 11602951258,
-        "total_terms": 3197886407,
-        "documents": 20544550,
-        "unique_terms": 21173582,
-        "downloaded": False
-    },
-    "msmarco-doc-per-passage-slim": {
-        "description": "Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored)",
-        "filename": "index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
-        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-slim-20201204-f50dcc-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/mKTjbTKMwWF9kY3/download"
-        ],
-        "md5": "77c2409943a8c9faffabf57cb6adca69",
-        "size compressed (bytes)": 2834865200,
-        "total_terms": 3197886407,
-        "documents": 20544550,
-        "unique_terms": 21173582,
-        "downloaded": False
-    },
+
     "msmarco-doc-expanded-per-doc": {
         "description": "Lucene index of the MS MARCO document corpus with per-doc docTTTTTquery expansions",
         "filename": "index-msmarco-doc-expanded-per-doc-20201126-1b4d0a.tar.gz",
@@ -974,6 +886,98 @@ TF_INDEX_INFO = {
         "total_terms": 31550936,
         "documents": 568855,
         "unique_terms": 663628,
+        "downloaded": False
+    },
+
+    # These indexes are deprecated, but keeping around for archival reasons
+    "msmarco-passage": {
+        "description": "Lucene index of the MS MARCO passage corpus (deprecated; use `msmarco-v1-passage` instead).",
+        "filename": "index-msmarco-passage-20201117-f87c94.tar.gz",
+        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-20201117-f87c94-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-passage-20201117-f87c94.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/QQsZMFG8MpF4P8M/download"
+        ],
+        "md5": "1efad4f1ae6a77e235042eff4be1612d",
+        "size compressed (bytes)": 2218470796,
+        "total_terms": 352316036,
+        "documents": 8841823,
+        "unique_terms": 2660824,
+        "downloaded": False
+    },
+    "msmarco-passage-slim": {
+        "description": "Lucene index of the MS MARCO passage corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-passage-slim` instead).",
+        "filename": "index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
+        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-passage-slim-20201202-ab6e28-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/Kx6K9NJFmwnaAP8/download"
+        ],
+        "md5": "5e11da4cebd2e8dda2e73c589ffb0b4c",
+        "size compressed (bytes)": 513566686,
+        "total_terms": 352316036,
+        "documents": 8841823,
+        "unique_terms": 2660824,
+        "downloaded": False
+    },
+    "msmarco-doc": {
+        "description": "Lucene index of the MS MARCO document corpus (deprecated; use `msmarco-v1-doc` instead).",
+        "filename": "index-msmarco-doc-20201117-f87c94.tar.gz",
+        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-20201117-f87c94-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-20201117-f87c94.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/5NC7A2wAL7opJKH/download"
+        ],
+        "md5": "ac747860e7a37aed37cc30ed3990f273",
+        "size compressed (bytes)": 13642330935,
+        "total_terms": 2748636047,
+        "documents": 3213835,
+        "unique_terms": 29823078,
+        "downloaded": False
+    },
+    "msmarco-doc-slim": {
+        "description": "Lucene index of the MS MARCO document corpus (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-slim` instead).",
+        "filename": "index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
+        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-slim-20201202-ab6e28-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/BMZ6oYBoEPgTFqs/download"
+        ],
+        "md5": "c56e752f7992bf6149761097641d515a",
+        "size compressed (bytes)": 1874471867,
+        "total_terms": 2748636047,
+        "documents": 3213835,
+        "unique_terms": 29823078,
+        "downloaded": False
+    },
+    "msmarco-doc-per-passage": {
+        "description": "Lucene index of the MS MARCO document corpus segmented into passages (deprecated; use `msmarco-v1-doc-segmented` instead).",
+        "filename": "index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
+        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-20201204-f50dcc-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/q6sAxE6q57q2TBo/download"
+        ],
+        "md5": "797367406a7542b649cefa6b41cf4c33",
+        "size compressed (bytes)": 11602951258,
+        "total_terms": 3197886407,
+        "documents": 20544550,
+        "unique_terms": 21173582,
+        "downloaded": False
+    },
+    "msmarco-doc-per-passage-slim": {
+        "description": "Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored) (deprecated; use `msmarco-v1-doc-segmented-slim` instead).",
+        "filename": "index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
+        "readme": "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/index-msmarco-doc-per-passage-slim-20201204-f50dcc-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/mKTjbTKMwWF9kY3/download"
+        ],
+        "md5": "77c2409943a8c9faffabf57cb6adca69",
+        "size compressed (bytes)": 2834865200,
+        "total_terms": 3197886407,
+        "documents": 20544550,
+        "unique_terms": 21173582,
         "downloaded": False
     }
 }


### PR DESCRIPTION
Added CS Vault mirrors for new versions.