### PR TITLE
Mrtydi mdpr index

### DIFF
--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -416,4 +416,37 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 [<a href="../pyserini/resources/index-metadata/faiss-hnsw.cast2019.tct_colbert-v2-readme.txt">readme</a>]
 <dd>Faiss HNSW index of the CAsT2019 passage corpus encoded by the tct_colbert-v2 passage encoder
 </dd>
+<dt></dt><b><code>mrtydi-v1.1-arabic-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Arabic).
+<dt></dt><b><code>mrtydi-v1.1-bengali-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Bengali).
+<dt></dt><b><code>mrtydi-v1.1-english-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (English).
+<dt></dt><b><code>mrtydi-v1.1-finnish-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Finnish).
+<dt></dt><b><code>mrtydi-v1.1-indonesian-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Indonesian).
+<dt></dt><b><code>mrtydi-v1.1-japanese-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Japanese).
+<dt></dt><b><code>mrtydi-v1.1-korean-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Korean).
+<dt></dt><b><code>mrtydi-v1.1-russian-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Russian).
+<dt></dt><b><code>mrtydi-v1.1-swahili-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Swahili).
+<dt></dt><b><code>mrtydi-v1.1-telugu-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Telugu).
+<dt></dt><b><code>mrtydi-v1.1-thai-mdpr-nq</code></b>
+[<a href="../pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README">readme</a>]
+<dd>Faiss mDPR (trained on NQ) index for Mr.TyDi v1.1 (Thai).
 </dl>

--- a/pyserini/encode/__main__.py
+++ b/pyserini/encode/__main__.py
@@ -77,6 +77,7 @@ if __name__ == '__main__':
     encoder_parser = commands.add_parser('encoder')
     encoder_parser.add_argument('--encoder', type=str, help='encoder name or path', required=True)
     encoder_parser.add_argument('--fields', help='fields to encode', nargs='+', default=['text'], required=False)
+    encoder_parser.add_argument('--delimiter', help='delimiter for the fields', default='\n', required=False)
     encoder_parser.add_argument('--batch-size', type=int, help='batch size', default=64, required=False)
     encoder_parser.add_argument('--device', type=str, help='device cpu or cuda [cuda:0, cuda:1...]',
                                 default='cuda:0', required=False)
@@ -89,7 +90,7 @@ if __name__ == '__main__':
         embedding_writer = FaissRepresentationWriter(args.output.embeddings)
     else:
         embedding_writer = JsonlRepresentationWriter(args.output.embeddings)
-    collection_iterator = JsonlCollectionIterator(args.input.corpus, args.input.fields)
+    collection_iterator = JsonlCollectionIterator(args.input.corpus, args.input.fields, args.input.delimiter)
 
     with embedding_writer:
         for batch_info in collection_iterator(args.encoder.batch_size, args.input.shard_id, args.input.shard_num):

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -57,7 +57,7 @@ class PcaEncoder:
 
 
 class JsonlCollectionIterator:
-    def __init__(self, collection_path: str, fields=None):
+    def __init__(self, collection_path: str, fields=None, delimiter="\n"):
         if fields:
             self.fields = fields
         else:
@@ -67,6 +67,7 @@ class JsonlCollectionIterator:
         self.batch_size = 1
         self.shard_id = 0
         self.shard_num = 1
+        self.delimiter = delimiter
 
     def __call__(self, batch_size=1, shard_id=0, shard_num=1):
         self.batch_size = batch_size
@@ -101,7 +102,7 @@ class JsonlCollectionIterator:
                 for line in tqdm(f):
                     info = json.loads(line)
                     all_info['id'].append(str(info['id']))
-                    fields_info = info['contents'].rstrip().split('\n')
+                    fields_info = info['contents'].rstrip().split(self.delimiter)
                     for i in range(len(fields_info)):
                         all_info[self.fields[i]].append(fields_info[i])
         return all_info

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -62,12 +62,12 @@ class JsonlCollectionIterator:
             self.fields = fields
         else:
             self.fields = ['text']
+        self.delimiter = delimiter
         self.all_info = self._load(collection_path)
         self.size = len(self.all_info['id'])
         self.batch_size = 1
         self.shard_id = 0
         self.shard_num = 1
-        self.delimiter = delimiter
 
     def __call__(self, batch_size=1, shard_id=0, shard_num=1):
         self.batch_size = batch_size

--- a/pyserini/encode/merge_faiss_index.py
+++ b/pyserini/encode/merge_faiss_index.py
@@ -1,0 +1,48 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import glob
+import argparse
+
+import faiss
+from tqdm import tqdm
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dimension', type=int, help='dimension of passage embeddings', required=False, default=768)
+parser.add_argument('--input', type=str, help='wildcard directory to input indexes', required=True)
+parser.add_argument('--output', type=str, help='directory to output full indexes', required=True)
+args = parser.parse_args()
+os.makedirs(args.output, exist_ok=True)
+
+# merge index
+new_index = faiss.IndexFlatIP(args.dimension)
+docid_files = []
+for index_dir in tqdm(sorted(glob.glob(args.input)), desc="Merging Faiss Index"):
+    index = faiss.read_index(os.path.join(index_dir, 'index'))
+    docid_files.append(os.path.join(index_dir, 'docid'))
+    vectors = index.reconstruct_n(0, index.ntotal)
+    new_index.add(vectors)
+
+faiss.write_index(new_index, os.path.join(args.output, 'index'))
+
+# merge docid
+with open(os.path.join(args.output, 'docid'), 'w') as wfd:
+    for f in docid_files:
+        with open(f, 'r') as f1:
+            for line in f1:
+                wfd.write(line)

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -1447,5 +1447,177 @@ FAISS_INDEX_INFO = {
         "documents": 38429835,
         "downloaded": False,
         "texts": "cast2019"
+    },
+    'mrtydi-v1.1-arabic-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 (Arabic) '
+            'corpus encoded by mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-arabic.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/Jgj3rYjbyRrmJs8/download'
+        ],
+        'md5': 'de86c1ce43854bbeea4e3af5d95d6ffb',
+        'size compressed (bytes)': 5997718937,
+        'documents': 2106586,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-arabic'
+    },
+    'mrtydi-v1.1-bengali-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(Bengali) corpus encoded by '
+            'mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-bengali.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md',
+        'urls': [
+            "https://vault.cs.uwaterloo.ca/s/4PpkzXAQtXFFJHR/download"
+        ],
+        'md5': 'e60cb6f1f7139cf0551f0ba4e4e83bf6',
+        'size compressed (bytes)': 865716848,
+        'documents': 304059,
+        'downloaded': False,
+        "texts": "mrtydi-v1.1-bengali"
+    },
+    'mrtydi-v1.1-english-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(English) corpus encoded by '
+            'mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-english.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-english.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/A7pjbwYeoT4Krnj/download'
+        ],
+        'md5': 'a0a8cc39e8af782ec82188a18c4c97c3',
+        'size compressed (bytes)': 93585951488,
+        'documents': 32907100,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-english'
+    },
+    'mrtydi-v1.1-finnish-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(Finnish) corpus encoded by '
+            'mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-finnish.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md',
+        'urls': ['https://vault.cs.uwaterloo.ca/s/erNYkrYzRZxpecz/download'],
+        'md5': '3e4e18aacf07ca551b474315f267ead6',
+        'size compressed (bytes)': 5435516778,
+        'documents': 1908757,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-finnish'
+    },
+    'mrtydi-v1.1-indonesian-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi '
+            'v1.1 (Indonesian) corpus '
+            'encoded by mDPR passage '
+            'encoder pre-fine-tuned on '
+            'NQ.',
+        'filename': 'faiss.mrtydi-v1.1-indonesian.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md',
+        'urls': ['https://vault.cs.uwaterloo.ca/s/BpR3MzT7KJ6edx7/download'],
+        'md5': '0bf693e4046d9a565ae18b9f5939d193',
+        'size compressed (bytes)': 865716848,
+        'documents': 4179177829,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-indonesian'
+    },
+    'mrtydi-v1.1-japanese-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(Japanese) corpus encoded by '
+            'mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-japanese.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/k7bptHT8GwMJpnF/download'
+        ],
+        'md5': '4ba566e27bc0158108259b18a153e2fc',
+        'size compressed (bytes)': 19920816424,
+        'documents': 7000027,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-japanese'
+    },
+    'mrtydi-v1.1-korean-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(Korean) corpus encoded by '
+            'mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-korean.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-korean.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/TigfYMde94YWAoE/download'
+        ],
+        'md5': '44212e5722632d5bcb14f0680741638c',
+        'size compressed (bytes)': 4257414237,
+        'documents': 1496126,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-korean'
+    },
+    'mrtydi-v1.1-russian-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(Russian) corpus encoded by '
+            'mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-russian.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-russian.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/eN7demnmnspqxjk/download'
+        ],
+        'md5': 'e7634093f2a3362928e9699441ce8a3b',
+        'size compressed (bytes)': 27317759143,
+        'documents': 9597504,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-russian'
+    },
+    'mrtydi-v1.1-swahili-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+                '(Swahili) corpus encoded by '
+                'mDPR passage encoder '
+                'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-swahili.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/JgiX8PRftnqcPwy/download'
+        ],
+        'md5': '5061bdd1d81bc32490bbb3682096acdd',
+        'size compressed (bytes)': 389658394,
+        'documents': 136689,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-swahili'
+    },
+    'mrtydi-v1.1-telugu-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(Telugu) corpus encoded by '
+            'mDPR passage encoder '
+            'pre-fine-tuned on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-telugu.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/dkm6RGdgRbnwiX2/download'
+        ],
+        'md5': '4952dacaeae89185d3757f9f26af4e88',
+        'size compressed (bytes)': 1561173721,
+        'documents': 548224,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-telugu'
+    },
+    'mrtydi-v1.1-thai-mdpr-nq': {
+        'description': 'Faiss index for Mr.TyDi v1.1 '
+            '(Thai) corpus encoded by mDPR '
+            'passage encoder pre-fine-tuned '
+            'on NQ.',
+        'filename': 'faiss.mrtydi-v1.1-thai.20220207.5df364.tar.gz',
+        'readme': 'faiss.mrtydi-v1.1-thai.20220207.5df364.README.md',
+        'urls': [
+            'https://vault.cs.uwaterloo.ca/s/fFrRYefd3nWFR3J/download'
+        ],
+        'md5': '2458f704b277fa8ffe2509b6296892a0',
+        'size compressed (bytes)': 1616059846,
+        'documents': 568855,
+        'downloaded': False,
+        'texts': 'mrtydi-v1.1-thai'
     }
 }

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-arabic
+
+Faiss index for Mr.TyDi v1.1 (Arabic), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=arabic
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-bengali
+
+Faiss index for Mr.TyDi v1.1 (Bengali), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 The index is then reproduced on commit [17c7fe4](https://github.com/crystina-z/pyserini/commit/17c7fe43efecbc8029ebea948418491f7504c89a) (after supporting controlling --delimiter via arguments.)

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
@@ -1,6 +1,6 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
-The index is then reproduced on commit `17c7fe4` (after supporting controlling --delimiter via arguments.)
+The index is then reproduced on commit [17c7fe4](https://github.com/crystina-z/pyserini/commit/17c7fe43efecbc8029ebea948418491f7504c89a) (after supporting controlling --delimiter via arguments.)
 
 ```bash
 lang=bengali

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
@@ -16,7 +16,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -31,10 +31,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md
@@ -1,0 +1,40 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+The index is then reproduced on commit `17c7fe4` (after supporting controlling --delimiter via arguments.)
+
+```bash
+lang=bengali
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-english
+
+Faiss index for Mr.TyDi v1.1 (English), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=english
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-english.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-finnish
+
+Faiss index for Mr.TyDi v1.1 (Finnish), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=finnish
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=indonesian
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-indonesian
+
+Faiss index for Mr.TyDi v1.1 (Indonesian), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=japanese
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-japanese
+
+Faiss index for Mr.TyDi v1.1 (Japanese), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-korean
+
+Faiss index for Mr.TyDi v1.1 (Korean), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=korean
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-korean.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-russian
+
+Faiss index for Mr.TyDi v1.1 (Russian), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=russian
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-russian.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=swahili
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-swahili
+
+Faiss index for Mr.TyDi v1.1 (Swahili), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=telugu
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-telugu
+
+Faiss index for Mr.TyDi v1.1 (Telugu), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
@@ -1,3 +1,7 @@
+# mrtydi-v1.1-thai
+
+Faiss index for Mr.TyDi v1.1 (Thai), using mDPR fine-tuned on NQ.
+
 This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
@@ -1,0 +1,39 @@
+This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+(manually change the delimiter in encoding from \n into \n\n).
+
+```bash
+lang=thai
+
+tarfn=mrtydi-v1.1-$lang.tar.gz
+encoder=models/mdpr-context-encoder
+corpus=mrtydi-v1.1-$lang/collection/docs.jsonl
+index_dir=mrtydi-mdpr-dindex/$lang
+
+wget https://git.uwaterloo.ca/jimmylin/mr.tydi/-/raw/master/data/$tarfn
+tar –xvf $tarfn
+gzip -cvf $corpus.gz > $corpus
+
+mkdir -p $index_dir
+
+python -m pyserini.encode input   --corpus $corpus \
+                                    --fields title text \
+                                    --delimiter "\n\n" \
+                            output  --embeddings  $index_dir \
+                                    --to-faiss \
+                            encoder --encoder $encoder \
+                                    --fields title text \
+                                    --batch 128 \
+                                    --fp16
+``` 
+
+which can be dsearched using:
+```bash
+set_name=test
+python -m pyserini.dsearch \
+    --encoder castorini/mdpr-question-nq \
+    --topics mrtydi-v1.1-${lang}-${set_name} \
+    --index ${index_dir} \
+    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
+    --batch-size 36 \
+    --threads 12
+```

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
@@ -1,4 +1,4 @@
-This index was generated on 2022/02/07 at commit 5df364 on narval with the following command:
+This index was generated on 2022/02/07 at commit [5df364](https://github.com/castorini/pyserini/commit/5df3649b128ece125ce8a9171ed4001ce3a6ef23) on narval with the following command:
 (manually change the delimiter in encoding from \n into \n\n).
 
 ```bash

--- a/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
+++ b/pyserini/resources/index-metadata/faiss.mrtydi-v1.1-thai.20220207.5df364.README.md
@@ -15,7 +15,7 @@ gzip -cvf $corpus.gz > $corpus
 
 mkdir -p $index_dir
 
-python -m pyserini.encode input   --corpus $corpus \
+python -m pyserini.encode   input   --corpus $corpus \
                                     --fields title text \
                                     --delimiter "\n\n" \
                             output  --embeddings  $index_dir \
@@ -30,10 +30,10 @@ which can be dsearched using:
 ```bash
 set_name=test
 python -m pyserini.dsearch \
-    --encoder castorini/mdpr-question-nq \
-    --topics mrtydi-v1.1-${lang}-${set_name} \
-    --index ${index_dir} \
-    --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt 
-    --batch-size 36 \
-    --threads 12
+  --encoder castorini/mdpr-question-nq \
+  --topics mrtydi-v1.1-${lang}-${set_name} \
+  --index ${index_dir} \
+  --output runs/run.mrtydi-v1.1-$lang.${set_name}.txt
+  --batch-size 36 \
+  --threads 12
 ```

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -17,7 +17,7 @@ import json
 import unittest
 
 from pyserini.encode import TctColBertDocumentEncoder, DprDocumentEncoder, UniCoilDocumentEncoder
-
+from pyserini.encode import JsonlCollectionIterator
 
 class TestSearch(unittest.TestCase):
     def setUp(self):
@@ -49,6 +49,56 @@ class TestSearch(unittest.TestCase):
         self.assertAlmostEqual(vectors[0]['normal'], 2.4618067741394043, places=4)
         self.assertAlmostEqual(vectors[2]['rounding'], 3.9474332332611084, places=4)
         self.assertAlmostEqual(vectors[2]['commercial'], 3.288801670074463, places=4)
+
+
+class TestJsonlCollectionIterator(unittest.TestCase):
+    def setUp(self):
+        return
+
+    def test_upper_lower_case(self):
+        json_fn = 'tests/resources/simple_cacm_corpus.json'
+        all_expected_info = [
+            ("CACM-2636",
+                "Generation of Random Correlated Normal Variables (Algorithm R425) CACM June, 1974 Page, R. L. CA740610 JB January 17, 1978 2:57 PM 2636 5 2636 2636 5 2636 2636 5 2636"),
+            ("CACM-2274",
+                "Generating English Discourse from Semantic Networks A system is described for generating English sentences from a form of semantic nets in which the nodes are word-sense meanings and the paths are primarily deep case relations. The grammar used by the system is in the form of a network that imposes an ordering on a set of syntactic transformations that are expressed as LISP functions. The generation algorithm uses the information in the semantic network to select appropriate generation paths through the grammar. The system is designed for use as a computational tool that allows a linguist to develop and study methods for generating surface strings from an underlying semantic structure. Initial finding with regard to form determiners such as voice, form, tense, and mood, some rules for embedding sentences, and some attention to pronominal substitution are reported. The system is programmed in LISP 1.5 and is available from the authors. CACM October, 1972 Simmons, R. Slocum, J. semantic nets, grammars, deep case relations, semantic generation, discourse generation 3.42 3.65 CA721004 JB January 27, 1978 3:10 PM 2274 5 2274 2274 5 2274 2274 5 2274 2795 5 2274 1928 6 2274 1989 6 2274 2274 6 2274"),
+            ("CACM-0981",
+                "Rounding Problems in Commercial Data Processing A common requirement in commercial data processing is that the sum of a set of numbers, rounded in a generally understood manner, be equal to the sum of the numbers rounded individually. Four rounding procedures are described to accomplish this. The particular procedure that is appropriate depends upon whether the numbers being accumulated can vary in sign, whether their sum can vary in sign, and whether the last number being summed can be recognized as such prior to its rounding. CACM November, 1964 Kelley, T. B. CA641102 JB March 9, 1978 4:25 PM 981 5 981 981 5 981 981 5 981"),
+        ]
+        collection_iterator = JsonlCollectionIterator(json_fn, ["text"], delimiter="\n")
+        for i, info in enumerate(collection_iterator):
+            expected_info = all_expected_info[i]
+            print(info)
+            self.assertEqual(expected_info[0], info["id"][0])
+            self.assertEqual(expected_info[1], info["text"][0])
+
+    def test_delimiter(self):
+        json_fn = 'tests/resources/simple_mrtydi_corpus.json'
+        all_expected_info = [
+            ("arabic-7#0", "ماء", "الماء مادةٌ شفافةٌ عديمة اللون والرائحة، وهو المكوّن الأساسي للجداول والبحيرات والبحار والمحيطات وكذلك للسوائل في جميع الكائنات الحيّة، وهو أكثر المركّبات الكيميائيّة انتشاراً على سطح الأرض. يتألّف جزيء الماء من ذرّة أكسجين مركزية ترتبط بها ذرّتي هيدروجين برابطة تساهميّة لتكون صيغته H2O. عند الظروف القياسية من الضغط ودرجة الحرارة يكون الماء سائلاً، ولكنّ حالاته الأخرى شائعة الوجود أيضاً؛ وهي حالة الجليد الصلبة والبخار الغازيّة."),
+            ("bengali-608#0", "বাংলা ভাষা", "বাংলা ভাষা (/bɑːŋlɑː/; pronunciation) দক্ষিণ এশিয়ার বঙ্গ অঞ্চলের মানুষের স্থানীয় ভাষা, এই অঞ্চলটি বর্তমানে রাজনৈতিকভাবে স্বাধীন রাষ্ট্র বাংলাদেশ ও ভারতের অঙ্গরাজ্য পশ্চিমবঙ্গ নিয়ে গঠিত। এছাড়াও ভারতের ত্রিপুরা রাজ্য, অসম রাজ্যের বরাক উপত্যকা এবং আন্দামান দ্বীপপুঞ্জেও বাংলা ভাষাতে কথা বলা হয়। এই ভাষার লিপি হল বাংলা লিপি। এই অঞ্চলের প্রায় বাইশ কোটি স্থানীয় মানুষের ও পৃথিবীর মোট ৩০ কোটি মানুষের ভাষা হওয়ায়, এই ভাষা বিশ্বের সর্বাধিক প্রচলিত ভাষাগুলির মধ্যে চতুর্থ স্থান অধিকার করেছে।[1][4][5][6] বাংলাদেশ, ভারত ও শ্রীলঙ্কার জাতীয় সঙ্গীত, এবং ভারতের জাতীয় স্তোত্র এই ভাষাতেই রচিত এবং তা থেকেই দক্ষিণ এশিয়ায় এই ভাষার গুরুত্ব বোঝা যায়।"),
+            ("english-12#0", "Anarchism", "Anarchism is a political philosophy that advocates self-governed societies based on voluntary, cooperative institutions and the rejection of hierarchies those societies view as unjust. These institutions are often described as stateless societies, although several authors have defined them more specifically as institutions based on non-hierarchical or free associations. Anarchism holds capitalism, the state, and representative democracy to be undesirable, unnecessary, and harmful."),
+            ("finnish-1#0", "Amsterdam", "Amsterdam on Alankomaiden pääkaupunki. Amsterdam on väkiluvultaan Alankomaiden suurin kaupunki, huhtikuun alussa 2006 siellä asui 743 905 asukasta eli noin joka 20. hollantilainen asuu Amsterdamissa. Yhteensä Amsterdamissa ja sitä ympäröivällä kaupunkialueella asuu noin 1 450 000 ihmistä eli vajaa kymmenesosa Alankomaiden asukkaista. Amsterdam sijaitsee Amstelin suistossa IJsselmeerin rannalla Alankomaiden Pohjois-Hollannin provinssissa. Vaikka Amsterdam on Alankomaiden perustuslain mukaan maan pääkaupunki, sijaitsevat niin kuningashuone, hallitus, parlamentti kuin korkein oikeuskin Haagissa."),
+            ("indonesian-1#0", "Asam deoksiribonukleat", "Asam deoksiribonukleat, lebih dikenal dengan singkatan DNA (bahasa Inggris: d</b>eoxyribo<b data-parsoid='{\"dsr\":[417,424,3,3]}'>n</b>ucleic a</b>cid), adalah sejenis biomolekul yang menyimpan dan menyandi instruksi-instruksi genetika setiap organisme dan banyak jenis virus. Instruksi-instruksi genetika ini berperan penting dalam pertumbuhan, perkembangan, dan fungsi organisme dan virus. DNA merupakan asam nukleat; bersamaan dengan protein dan karbohidrat, asam nukleat adalah makromolekul esensial bagi seluruh makhluk hidup yang diketahui. Kebanyakan molekul DNA terdiri dari dua unting biopolimer yang berpilin satu sama lainnya membentuk heliks ganda. Dua unting DNA ini dikenal sebagai polinukleotida karena keduanya terdiri dari satuan-satuan molekul yang disebut nukleotida. Tiap-tiap nukleotida terdiri atas salah satu jenis basa nitrogen (guanina (G), adenina (A), timina (T), atau sitosina (C)), gula monosakarida yang disebut deoksiribosa, dan gugus fosfat. Nukleotida-nukelotida ini kemudian tersambung dalam satu rantai ikatan kovalen antara gula satu nukleotida dengan fosfat nukelotida lainnya. Hasilnya adalah rantai punggung gula-fosfat yang berselang-seling. Menurut kaidah pasangan basa (A dengan T dan C dengan G), ikatan hidrogen mengikat basa-basa dari kedua unting polinukleotida membentuk DNA unting ganda"),
+            ("japanese-5#0", "アンパサンド", "アンパサンド (&、英語名：) とは並立助詞「…と…」を意味する記号である。ラテン語の の合字で、Trebuchet MSフォントでは、と表示され \"et\" の合字であることが容易にわかる。ampersa、すなわち \"and per se and\"、その意味は\"and [the symbol which] by itself [is] and\"である。"),
+            ("korean-5#0", "지미 카터", "제임스 얼 \"지미\" 카터 주니어(, 1924년 10월 1일 ~ )는 민주당 출신 미국 39번째 대통령 (1977년 ~ 1981년)이다."),
+            ("russian-7#0", "Литва", "Литва́ (), официальное название — Лито́вская Респу́блика () — государство, расположенное в северо-восточной части Европы. Столица страны — Вильнюс."),
+            ("swahili-2#0", "Akiolojia", "Akiolojia (kutoka Kiyunani αρχαίος = \"zamani\" na λόγος = \"neno, usemi\") ni somo linalohusu mabaki ya tamaduni za watu wa nyakati zilizopita. Wanaakiolojia wanatafuta vitu vilivyobaki, kwa mfano kwa kuchimba ardhi na kutafuta mabaki ya majengo, makaburi, silaha, vifaa, vyombo na mifupa ya watu."),
+            ("telugu-786#0", "గుంటూరు జిల్లా", "గుంటూరు జిల్లా [1] 11,391 చ.కి.మీ. ల విస్తీర్ణములో వ్యాపించి, 48,89,230 (2011 గణన) జనాభా కలిగిఉన్నది. ఆగ్నేయాన బంగాళాఖాతము, దక్షిణాన ప్రకాశం జిల్లా, పశ్చిమాన మహబూబ్ నగర్ జిల్లా, మరియు వాయువ్యాన నల్గొండ జిల్లా సరిహద్దులుగా ఉన్నాయి. దీని ముఖ్యపట్టణం గుంటూరు"),
+            ("thai-1#0", "หน้าหลัก", "วิกิพีเดียดำเนินการโดยมูลนิธิวิกิมีเดีย องค์กรไม่แสวงผลกำไร ผู้ดำเนินการอีกหลาย ได้แก่"),
+        ]
+        delimiter = "\n\n"
+        collection_iterator = JsonlCollectionIterator(json_fn, ["title", "text"], delimiter=delimiter)
+        for i, info in enumerate(collection_iterator):
+            expected_info = all_expected_info[i]
+            if i == 0:
+                print(expected_info[0])
+                print(expected_info[1])
+                print(expected_info[2])
+
+            self.assertEqual(expected_info[0], info["id"][0])
+            self.assertEqual(expected_info[1], info["title"][0])
+            self.assertEqual(expected_info[2], info["text"][0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. the mdpr index on mrtydi v1.1 and corresponding readme; 
2. the script (to merge the faiss indexes generated per shard;
   - merge_faiss_index.py
3. add a `--delimiter` argument for the `encode` module, use to parse the fields under `doc['contents']`
   - pyserini/encode/_\_main__.py
   - pyserini/encode/_base.py
4. allow the directory extracted from tarball different from the specified index name, as long as there is only one directory under it. This is for the case when ppl didn't name the file correctly before compressing it into tarball and upload to server, which is costly to redo. **probably need more review attention**
   - pyserini/util.py