### PR TITLE
SPLADEv2 and uniCOIL reproduction experiment

### DIFF
--- a/docs/experiments-msmarco-v2-unicoil-tilde-expansion.md
+++ b/docs/experiments-msmarco-v2-unicoil-tilde-expansion.md
@@ -39,7 +39,7 @@ To confirm, `msmarco-passage-v2-unicoil-tilde-expansion-b8.tar` is around 58 GB 
 We can now index these docs:
 
 ```
-python -m pyserini.index --collection JsonVectorCollection \
+python -m pyserini.index.lucene --collection JsonVectorCollection \
                          --input collections/msmarco-passage-v2-unicoil-tilde-expansion-b8/ \
                          --index indexes/lucene-index.msmarco-v2-passage-unicoil-tilde-expansion-b8 \
                          --generator DefaultLuceneDocumentGenerator \
@@ -77,7 +77,7 @@ This pre-built index was created with the above command, but with the addition o
 We can now run retrieval:
 
 ```bash
-python -m pyserini.search --topics msmarco-v2-passage-dev \
+python -m pyserini.search.lucene --topics msmarco-v2-passage-dev \
                           --encoder ielab/unicoil-tilde200-msmarco-passage \
                           --index indexes/lucene-index.msmarco-v2-passage-unicoil-tilde-expansion-b8 \
                           --output runs/run.msmarco-v2-passage-dev-unicoil-tilde-expansion-b8.txt \
@@ -139,3 +139,4 @@ These results may be slightly different from the figures above, but they should 
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-09-19 (commit [`6b9cc5b`](https://github.com/castorini/pyserini/commit/6b9cc5b1c2fee89597c5841a9f88395cf76bf60a))
 + Results reproduced by [@MXueguang](https://github.com/MXueguang) on 2021-09-22 (commit [`a4c12d2`](https://github.com/castorini/pyserini/commit/a4c12d28979b4ed9177845733932f94a1fcdfe64))
++ Results reproduced by [@prasys](https://github.com/prasys) on 2021-02-14 (commit [`3732c8e`](https://github.com/castorini/pyserini/commit/3732c8e3f1b72113a3961444b1ac37878afcbb64))

--- a/docs/experiments-spladev2.md
+++ b/docs/experiments-spladev2.md
@@ -138,3 +138,4 @@ There might be small differences in score due to non-determinism in neural infer
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-10-05 (commit [`58d286c`](https://github.com/castorini/pyserini/commit/58d286c3f9fe845e261c271f2a0f514462844d97))
 + Results reproduced by [@MXueguang](https://github.com/MXueguang) on 2021-10-07 (commit [`5d05426`](https://github.com/castorini/pyserini/commit/5d05426e1b40c513c6fa739a236b9c025b1a62fd))
++ Results reproduced by [@prasys](https://github.com/prasys) on 2021-02-14 (commit [`3732c8e`](https://github.com/castorini/pyserini/commit/3732c8e3f1b72113a3961444b1ac37878afcbb64))


### PR DESCRIPTION
I've re-run the following experiments (picked randomly). I've updated the documentation as well to cater for the new way of how to invoke search and index functions. I ran the following experiments :  

- Pyserini: SPLADEv2 for MS MARCO V1 Passage Ranking
- Pyserini: uniCOIL (w/ TILDE) for MS MARCO (V2) Passage Ranking

- Python 3.8.4 (with a pip install pyserini) 
-  Intel Xeon CPU 2.20Ghz 
- 16GB of RAM
- NVIDIA T4 GPU (CUDA version 11.4 - 495.53 driver version) 
- Debian 10 (4.19.0.18-cloud) 


There is a slight difference in the score I've obtained for Spladev2. This is within the reported value
```
#####################
MRR @10: 0.3681425125294513
QueriesRanked: 6980
#####################
```

Let me know if you do require any further information and I'm happy to provide 
