### PR TITLE
Add uniCOIL pre-encoded query bindings for MS MARCO V2 (doc, passage) + V1 doc

### DIFF
--- a/docs/experiments-msmarco-v2-unicoil.md
+++ b/docs/experiments-msmarco-v2-unicoil.md
@@ -32,8 +32,8 @@ Index the sparse vectors:
 ```bash
 python -m pyserini.index.lucene \
   --collection JsonVectorCollection \
-  --input collections/msmarco_v2_passage_unicoil_noexp_0shot \
-  --index indexes/lucene-index.msmarco-v2-passage.unicoil-noexp-0shot \
+  --input collections/msmarco_v2_passage_unicoil_noexp_0shot/ \
+  --index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   --generator DefaultLuceneDocumentGenerator \
   --threads 32 \
   --impact --pretokenized
@@ -45,10 +45,10 @@ Sparse retrieval with uniCOIL:
 
 ```bash
 python -m pyserini.search.lucene \
+  --index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   --topics msmarco-v2-passage-dev \
   --encoder castorini/unicoil-noexp-msmarco-passage \
-  --index indexes/lucene-index.msmarco-v2-passage.unicoil-noexp-0shot \
-  --output runs/run.msmarco-v2-passage.unicoil-noexp.0shot.txt \
+  --output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev.txt \
   --batch 144 --threads 36 \
   --hits 1000 \
   --impact
@@ -57,12 +57,16 @@ python -m pyserini.search.lucene \
 To evaluate, using `trec_eval`:
 
 ```bash
-$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev runs/run.msmarco-v2-passage.unicoil-noexp.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev \
+    runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev.txt
+
 Results:
 map                   	all	0.1334
 recip_rank            	all	0.1343
 
-$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev runs/run.msmarco-v2-passage.unicoil-noexp.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev \
+    runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev.txt
+
 Results:
 recall_100            	all	0.4983
 recall_1000           	all	0.7010
@@ -70,7 +74,9 @@ recall_1000           	all	0.7010
 
 Note that we evaluate MAP and MRR at a cutoff of 100 hits to match the official evaluation metrics.
 However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
+
 These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
+To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-passage-dev-unicoil-noexp`.
 
 ## Passage Ranking (With doc2query-T5 Expansion)
 
@@ -91,8 +97,8 @@ Index the sparse vectors:
 ```bash
 python -m pyserini.index.lucene \
   --collection JsonVectorCollection \
-  --input collections/msmarco_v2_passage_unicoil_0shot \
-  --index indexes/lucene-index.msmarco-v2-passage.unicoil-0shot \
+  --input collections/msmarco_v2_passage_unicoil_0shot/ \
+  --index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   --generator DefaultLuceneDocumentGenerator \
   --threads 32 \
   --impact --pretokenized
@@ -102,10 +108,10 @@ Sparse retrieval with uniCOIL:
 
 ```bash
 python -m pyserini.search.lucene \
+  --index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   --topics msmarco-v2-passage-dev \
   --encoder castorini/unicoil-msmarco-passage \
-  --index indexes/lucene-index.msmarco-v2-passage.unicoil-0shot \
-  --output runs/run.msmarco-v2-passage.unicoil.0shot.txt \
+  --output runs/run.msmarco-v2-passage-unicoil-0shot.dev.txt \
   --batch 144 --threads 36 \
   --hits 1000 \
   --impact
@@ -114,16 +120,26 @@ python -m pyserini.search.lucene \
 To evaluate, using `trec_eval`:
 
 ```bash
-$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev runs/run.msmarco-v2-passage.unicoil.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev \
+    runs/run.msmarco-v2-passage-unicoil-0shot.dev.txt
+
 Results:
 map                     all     0.1488
 recip_rank              all     0.1501
 
-$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev runs/run.msmarco-v2-passage.unicoil.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev \
+    runs/run.msmarco-v2-passage-unicoil-0shot.dev.txt
+
 Results:
 recall_100              all     0.5515
 recall_1000             all     0.7613
 ```
+
+Note that we evaluate MAP and MRR at a cutoff of 100 hits to match the official evaluation metrics.
+However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
+
+These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-passage-unicoil-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
+To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-passage-dev-unicoil`.
 
 ## Document Ranking (No Expansion)
 
@@ -150,8 +166,8 @@ Index the sparse vectors:
 ```bash
 python -m pyserini.index.lucene \
   --collection JsonVectorCollection \
-  --input collections/msmarco_v2_doc_segmented_unicoil_noexp_0shot \
-  --index indexes/lucene-index.msmarco-doc-v2-segmented.unicoil-noexp.0shot \
+  --input collections/msmarco_v2_doc_segmented_unicoil_noexp_0shot/ \
+  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-noexp-0shot/ \
   --generator DefaultLuceneDocumentGenerator \
   --threads 32 \
   --impact --pretokenized
@@ -163,13 +179,13 @@ Sparse retrieval with uniCOIL:
 
 ```bash
 python -m pyserini.search.lucene \
+  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-noexp-0shot/ \
   --topics msmarco-v2-doc-dev \
   --encoder castorini/unicoil-noexp-msmarco-passage \
-  --index indexes/lucene-index.msmarco-doc-v2-segmented.unicoil-noexp.0shot \
-  --output runs/run.msmarco-doc-v2-segmented.unicoil-noexp.0shot.txt \
+  --output runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev.txt \
   --batch 144 --threads 36 \
   --hits 10000 --max-passage --max-passage-hits 1000 \
-  --impact  
+  --impact
 ```
 
 For the document corpus, since we are searching the segmented version, we retrieve the top 10k _segments_ and perform MaxP to obtain the top 1000 _documents_.
@@ -177,12 +193,16 @@ For the document corpus, since we are searching the segmented version, we retrie
 To evaluate, using `trec_eval`:
 
 ```bash
-$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev runs/run.msmarco-doc-v2-segmented.unicoil-noexp.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev \
+    runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev.txt
+
 Results:
 map                   	all	0.2047
 recip_rank            	all	0.2066
 
-$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev runs/run.msmarco-doc-v2-segmented.unicoil-noexp.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev \
+    runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev.txt
+
 Results:
 recall_100            	all	0.7198
 recall_1000           	all	0.8854
@@ -190,7 +210,9 @@ recall_1000           	all	0.8854
 
 We evaluate MAP and MRR at a cutoff of 100 hits to match the official evaluation metrics.
 However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
+
 These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
+To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-doc-dev-unicoil-noexp`.
 
 ## Document Ranking (With doc2query-T5 Expansion)
 
@@ -211,8 +233,8 @@ Index the sparse vectors:
 ```bash
 python -m pyserini.index.lucene \
   --collection JsonVectorCollection \
-  --input collections/msmarco_v2_doc_segmented_unicoil_0shot \
-  --index indexes/lucene-index.msmarco-doc-v2-segmented.unicoil.0shot \
+  --input collections/msmarco_v2_doc_segmented_unicoil_0shot/ \
+  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-0shot/ \
   --generator DefaultLuceneDocumentGenerator \
   --threads 32 \
   --impact --pretokenized
@@ -222,10 +244,10 @@ Sparse retrieval with uniCOIL:
 
 ```bash
 python -m pyserini.search.lucene \
+  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-0shot/ \
   --topics msmarco-v2-doc-dev \
   --encoder castorini/unicoil-msmarco-passage \
-  --index indexes/lucene-index.msmarco-doc-v2-segmented.unicoil.0shot \
-  --output runs/run.msmarco-doc-v2-segmented.unicoil.0shot.txt \
+  --output runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev.txt \
   --batch 144 --threads 36 \
   --hits 10000 --max-passage --max-passage-hits 1000 \
   --impact
@@ -236,16 +258,26 @@ For the document corpus, since we are searching the segmented version, we retrie
 To evaluate, using `trec_eval`:
 
 ```bash
-$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev runs/run.msmarco-doc-v2-segmented.unicoil.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev \
+    runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev.txt
+
 Results:
 map                     all     0.2217
 recip_rank              all     0.2242
 
-$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev runs/run.msmarco-doc-v2-segmented.unicoil.0shot.txt
+$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev \
+    runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev.txt
+
 Results:
 recall_100              all     0.7556
 recall_1000             all     0.9056
 ```
+
+We evaluate MAP and MRR at a cutoff of 100 hits to match the official evaluation metrics.
+However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
+
+These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
+To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-doc-dev-unicoil`.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/experiments-msmarco-v2-unicoil.md
+++ b/docs/experiments-msmarco-v2-unicoil.md
@@ -76,7 +76,7 @@ Note that we evaluate MAP and MRR at a cutoff of 100 hits to match the official 
 However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
 
 These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
-To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-passage-dev-unicoil-noexp`.
+To reproduce the Anserini results, use pre-encoded queries with `--topics msmarco-v2-passage-dev-unicoil-noexp`.
 
 ## Passage Ranking (With doc2query-T5 Expansion)
 
@@ -139,7 +139,7 @@ Note that we evaluate MAP and MRR at a cutoff of 100 hits to match the official 
 However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
 
 These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-passage-unicoil-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
-To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-passage-dev-unicoil`.
+To reproduce the Anserini results, use pre-encoded queries with `--topics msmarco-v2-passage-dev-unicoil`.
 
 ## Document Ranking (No Expansion)
 
@@ -212,7 +212,7 @@ We evaluate MAP and MRR at a cutoff of 100 hits to match the official evaluation
 However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
 
 These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
-To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-doc-dev-unicoil-noexp`.
+To reproduce the Anserini results, use pre-encoded queries with `--topics msmarco-v2-doc-dev-unicoil-noexp`.
 
 ## Document Ranking (With doc2query-T5 Expansion)
 
@@ -277,7 +277,7 @@ We evaluate MAP and MRR at a cutoff of 100 hits to match the official evaluation
 However, we measure recall at both 100 and 1000 hits; the latter is a common setting for reranking.
 
 These results differ slightly from [the regressions in Anserini](https://github.com/castorini/anserini/blob/master/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot.md) because here we are performing on-the-fly query encoding, whereas the Anserini indexes use pre-encoded queries.
-To reproduce exactly the same results in Anserini, use the pre-encoded queries by setting `--topics msmarco-v2-doc-dev-unicoil`.
+To reproduce the Anserini results, use pre-encoded queries with `--topics msmarco-v2-doc-dev-unicoil`.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/experiments-unicoil.md
+++ b/docs/experiments-unicoil.md
@@ -195,23 +195,13 @@ QueriesRanked: 5193
 There might be small differences in score due to non-determinism in neural inference; see [these notes](reproducibility.md) for detail.
 The above score was obtained on Linux.
 
-Alternatively, we can use pre-tokenized queries with pre-computed weights.
-First, fetch the MS MARCO passage ranking dev set queries:
-
-```bash
-# Alternate mirrors of the same data, pick one:
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/topics.msmarco-doc.dev.unicoil.tsv.gz -P collections/
-wget https://vault.cs.uwaterloo.ca/s/6D5JtJQxYpPbByM/download -O collections/topics.msmarco-doc.dev.unicoil.tsv.gz
-```
-
-The MD5 checksum of the topics file is `40e5f64500272ecde270e55beecd5e94`.
-
-We can now run retrieval:
+Alternatively, we can use pre-tokenized queries with pre-computed weights, which are already included in Pyserini.
+We can run retrieval as follows:
 
 ```bash
 python -m pyserini.search.lucene \
   --index indexes/lucene-index.msmarco-doc-segmented-unicoil \
-  --topics collections/topics.msmarco-doc.dev.unicoil.tsv.gz \
+  --topics msmarco-doc-dev-unicoil \
   --output runs/run.msmarco-doc-segmented-unicoil.tsv \
   --output-format msmarco \
   --batch 36 --threads 12 \

--- a/pyserini/search/lucene/_base.py
+++ b/pyserini/search/lucene/_base.py
@@ -112,6 +112,8 @@ def get_topics(collection_name):
         topics = JTopicReader.getTopicsWithStringIds(JTopics.TREC2020_DL)
     elif collection_name == 'msmarco-doc-dev':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_DOC_DEV)
+    elif collection_name == 'msmarco-doc-dev-unicoil':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_DOC_DEV_UNICOIL)
     elif collection_name == 'msmarco-doc-test':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_DOC_TEST)
     elif collection_name == 'msmarco-passage-dev-subset':

--- a/pyserini/search/lucene/_base.py
+++ b/pyserini/search/lucene/_base.py
@@ -128,12 +128,28 @@ def get_topics(collection_name):
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_PASSAGE_TEST_SUBSET)
     elif collection_name == 'msmarco-v2-doc-dev':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_DOC_DEV)
+    elif collection_name == 'msmarco-v2-doc-dev-unicoil':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_DOC_DEV_UNICOIL)
+    elif collection_name == 'msmarco-v2-doc-dev-unicoil-noexp':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_DOC_DEV_UNICOIL_NOEXP)
     elif collection_name == 'msmarco-v2-doc-dev2':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_DOC_DEV2)
+    elif collection_name == 'msmarco-v2-doc-dev2-unicoil':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_DOC_DEV2_UNICOIL)
+    elif collection_name == 'msmarco-v2-doc-dev2-unicoil-noexp':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_DOC_DEV2_UNICOIL_NOEXP)
     elif collection_name == 'msmarco-v2-passage-dev':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV)
+    elif collection_name == 'msmarco-v2-passage-dev-unicoil':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV_UNICOIL)
+    elif collection_name == 'msmarco-v2-passage-dev-unicoil-noexp':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV_UNICOIL_NOEXP)
     elif collection_name == 'msmarco-v2-passage-dev2':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV2)
+    elif collection_name == 'msmarco-v2-passage-dev2-unicoil':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV2_UNICOIL)
+    elif collection_name == 'msmarco-v2-passage-dev2-unicoil-noexp':
+        topics = JTopicReader.getTopicsWithStringIds(JTopics.MSMARCO_V2_PASSAGE_DEV2_UNICOIL_NOEXP)
     elif collection_name == 'ntcir8-zh':
         topics = JTopicReader.getTopicsWithStringIds(JTopics.NTCIR8_ZH)
     elif collection_name == 'clef2006-fr':


### PR DESCRIPTION
Update docs. Confirmed the following:

MS MARCO V2 passage:

```
python -m pyserini.search.lucene \
  --topics msmarco-v2-passage-dev-unicoil-noexp \
  --index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
  --output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev.txt \
  --batch 144 --threads 36 \
  --hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev \
    runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev.txt

Results:
map                   	all	0.1333
recip_rank            	all	0.1342

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev \
    runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev.txt

Results:
recall_100            	all	0.4976
recall_1000           	all	0.7010

---

python -m pyserini.search.lucene \
  --topics msmarco-v2-passage-dev2-unicoil-noexp \
  --index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
  --output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev2.txt \
  --batch 144 --threads 36 \
  --hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev2 \
    runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev2.txt

Results:
map                   	all	0.1374
recip_rank            	all	0.1385

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev2 \
    runs/run.msmarco-v2-passage-unicoil-noexp-0shot.dev2.txt

Results:
recall_100            	all	0.5217
recall_1000           	all	0.7114

---

python -m pyserini.search.lucene \
  --topics msmarco-v2-passage-dev-unicoil \
  --index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
  --output runs/run.msmarco-v2-passage-unicoil-0shot.dev.txt \
  --batch 144 --threads 36 \
  --hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev \
    runs/run.msmarco-v2-passage-unicoil-0shot.dev.txt

Results:
map                   	all	0.1485
recip_rank            	all	0.1499

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev \
    runs/run.msmarco-v2-passage-unicoil-0shot.dev.txt

Results:
recall_100            	all	0.5518
recall_1000           	all	0.7616

---

python -m pyserini.search.lucene \
  --topics msmarco-v2-passage-dev2-unicoil \
  --index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
  --output runs/run.msmarco-v2-passage-unicoil-0shot.dev2.txt \
  --batch 144 --threads 36 \
  --hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev2 \
    runs/run.msmarco-v2-passage-unicoil-0shot.dev2.txt

Results:
map                   	all	0.1561
recip_rank            	all	0.1577

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-passage-dev2 \
    runs/run.msmarco-v2-passage-unicoil-0shot.dev2.txt

Results:
recall_100            	all	0.5661
recall_1000           	all	0.7671
```

MS MARO V2 doc:

```
python -m pyserini.search.lucene \
  --topics msmarco-v2-doc-dev-unicoil-noexp \
  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-noexp-0shot/ \
  --output runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev.txt \
  --batch 144 --threads 36 \
  --hits 10000 --max-passage --max-passage-hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev \
    runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev.txt

Results:
map                   	all	0.2050
recip_rank            	all	0.2069

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev \
    runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev.txt

Results:
recall_100            	all	0.7198
recall_1000           	all	0.8854

---

python -m pyserini.search.lucene \
  --topics msmarco-v2-doc-dev2-unicoil-noexp \
  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-noexp-0shot/ \
  --output runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev2.txt \
  --batch 144 --threads 36 \
  --hits 10000 --max-passage --max-passage-hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev2 \
    runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev2.txt

Results:
map                   	all	0.2082
recip_rank            	all	0.2098

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev2 \
    runs/run.msmarco-doc-v2-segmented-unicoil-noexp-0shot.dev2.txt

Results:
recall_100            	all	0.7266
recall_1000           	all	0.8899

---

python -m pyserini.search.lucene \
  --topics msmarco-v2-doc-dev-unicoil \
  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-0shot/ \
  --output runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev.txt \
  --batch 144 --threads 36 \
  --hits 10000 --max-passage --max-passage-hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev \
    runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev.txt

Results:
map                   	all	0.2218
recip_rank            	all	0.2243

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev \
    runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev.txt

Results:
recall_100            	all	0.7551
recall_1000           	all	0.9056

---

python -m pyserini.search.lucene \
  --topics msmarco-v2-doc-dev2-unicoil \
  --index indexes/lucene-index.msmarco-doc-v2-segmented-unicoil-0shot/ \
  --output runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev2.txt \
  --batch 144 --threads 36 \
  --hits 10000 --max-passage --max-passage-hits 1000 \
  --impact

$ python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-doc-dev2 \
    runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev2.txt

Results:
map                   	all	0.2270
recip_rank            	all	0.2291

$ python -m pyserini.eval.trec_eval -c -m recall.100,1000 msmarco-v2-doc-dev2 \
    runs/run.msmarco-doc-v2-segmented-unicoil-0shot.dev2.txt

Results:
recall_100            	all	0.7550
recall_1000           	all	0.9097
```

MS MARCO V1 doc:

```
python -m pyserini.search.lucene \
  --index msmarco-doc-per-passage-unicoil-d2q \
  --topics msmarco-doc-dev-unicoil \
  --output runs/run.msmarco-doc-segmented-unicoil.tsv \
  --output-format msmarco \
  --batch 36 --threads 12 \
  --hits 1000 --max-passage --max-passage-hits 100 \
  --impact
```
