### PR TITLE
Refactor pre-built index metadata

### DIFF
--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -1325,7 +1325,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 33359100887,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-passage-tct_colbert-bf": {
         "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by TCT-ColBERT",
@@ -1338,7 +1338,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25204514289,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-doc-tct_colbert-bf": {
         "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT",
@@ -1351,7 +1351,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 58514325936,
         "documents": 20544550,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-doc-tct_colbert-v2-hnp-bf": {
         "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT-V2-HNP",
@@ -1364,7 +1364,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 58586765624,
         "documents": 20544550,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "wikipedia-dpr-multi-bf": {
         "description": "Faiss FlatIP index of Wikipedia encoded by the DPR doc encoder trained on multiple QA datasets",
@@ -1416,7 +1416,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25102344985,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-doc-ance-maxp-bf": {
         "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by the ANCE MaxP encoder",
@@ -1429,7 +1429,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 58312805496,
         "documents": 20544550,
         "downloaded": False,
-        "texts": "msmarco-doc"
+        "texts": "msmarco-v1-doc"
     },
     "wikipedia-ance-multi-bf": {
         "description": "Faiss FlatIP index of Wikipedia encoded by the ANCE-multi encoder",
@@ -1455,7 +1455,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25214193901,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-passage-distilbert-dot-margin_mse-T2-bf": {
         "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the distilbert-dot-margin_mse-T2-msmarco passage encoder",
@@ -1468,7 +1468,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25162770962,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-passage-distilbert-dot-tas_b-b256-bf": {
         "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by msmarco-passage-distilbert-dot-tas_b-b256 passage encoder",
@@ -1481,7 +1481,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25162328596,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-passage-tct_colbert-v2-bf": {
         "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2 passage encoder",
@@ -1494,7 +1494,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25211079381,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-passage-tct_colbert-v2-hn-bf": {
         "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2-hn passage encoder",
@@ -1507,7 +1507,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25205729786,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "msmarco-passage-tct_colbert-v2-hnp-bf": {
         "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2-hnp passage encoder",
@@ -1520,7 +1520,7 @@ FAISS_INDEX_INFO = {
         "size compressed (bytes)": 25225528775,
         "documents": 8841823,
         "downloaded": False,
-        "texts": "msmarco-passage"
+        "texts": "msmarco-v1-passage"
     },
     "cast2019-tct_colbert-v2-hnsw": {
         "description": "Faiss HNSW index of the CAsT2019 passage corpus encoded by the tct_colbert-v2 passage encoder",
@@ -1536,200 +1536,171 @@ FAISS_INDEX_INFO = {
         "downloaded": False,
         "texts": "cast2019"
     },
-    'mrtydi-v1.1-arabic-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 (Arabic) '
-            'corpus encoded by mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-arabic.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/Jgj3rYjbyRrmJs8/download'
+    "mrtydi-v1.1-arabic-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Arabic) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-arabic.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-arabic.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/Jgj3rYjbyRrmJs8/download"
         ],
-        'md5': 'de86c1ce43854bbeea4e3af5d95d6ffb',
-        'size compressed (bytes)': 5997718937,
-        'documents': 2106586,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-arabic'
+        "md5": "de86c1ce43854bbeea4e3af5d95d6ffb",
+        "size compressed (bytes)": 5997718937,
+        "documents": 2106586,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-arabic"
     },
-    'mrtydi-v1.1-bengali-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(Bengali) corpus encoded by '
-            'mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-bengali.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md',
-        'urls': [
+    "mrtydi-v1.1-bengali-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Bengali) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-bengali.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-bengali.20220207.5df364.README.md",
+        "urls": [
             "https://vault.cs.uwaterloo.ca/s/4PpkzXAQtXFFJHR/download"
         ],
-        'md5': 'e60cb6f1f7139cf0551f0ba4e4e83bf6',
-        'size compressed (bytes)': 865716848,
-        'documents': 304059,
-        'downloaded': False,
+        "md5": "e60cb6f1f7139cf0551f0ba4e4e83bf6",
+        "size compressed (bytes)": 865716848,
+        "documents": 304059,
+        "downloaded": False,
         "texts": "mrtydi-v1.1-bengali"
     },
-    'mrtydi-v1.1-english-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(English) corpus encoded by '
-            'mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-english.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-english.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/A7pjbwYeoT4Krnj/download'
+    "mrtydi-v1.1-english-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (English) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-english.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-english.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/A7pjbwYeoT4Krnj/download"
         ],
-        'md5': 'a0a8cc39e8af782ec82188a18c4c97c3',
-        'size compressed (bytes)': 93585951488,
-        'documents': 32907100,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-english'
+        "md5": "a0a8cc39e8af782ec82188a18c4c97c3",
+        "size compressed (bytes)": 93585951488,
+        "documents": 32907100,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-english"
     },
-    'mrtydi-v1.1-finnish-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(Finnish) corpus encoded by '
-            'mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-finnish.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md',
-        'urls': ['https://vault.cs.uwaterloo.ca/s/erNYkrYzRZxpecz/download'],
-        'md5': '3e4e18aacf07ca551b474315f267ead6',
-        'size compressed (bytes)': 5435516778,
-        'documents': 1908757,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-finnish'
-    },
-    'mrtydi-v1.1-indonesian-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi '
-            'v1.1 (Indonesian) corpus '
-            'encoded by mDPR passage '
-            'encoder pre-fine-tuned on '
-            'NQ.',
-        'filename': 'faiss.mrtydi-v1.1-indonesian.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md',
-        'urls': ['https://vault.cs.uwaterloo.ca/s/BpR3MzT7KJ6edx7/download'],
-        'md5': '0bf693e4046d9a565ae18b9f5939d193',
-        'size compressed (bytes)': 865716848,
-        'documents': 4179177829,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-indonesian'
-    },
-    'mrtydi-v1.1-japanese-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(Japanese) corpus encoded by '
-            'mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-japanese.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/k7bptHT8GwMJpnF/download'
+    "mrtydi-v1.1-finnish-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Finnish) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-finnish.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-finnish.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/erNYkrYzRZxpecz/download"
         ],
-        'md5': '4ba566e27bc0158108259b18a153e2fc',
-        'size compressed (bytes)': 19920816424,
-        'documents': 7000027,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-japanese'
+        "md5": "3e4e18aacf07ca551b474315f267ead6",
+        "size compressed (bytes)": 5435516778,
+        "documents": 1908757,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-finnish"
     },
-    'mrtydi-v1.1-korean-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(Korean) corpus encoded by '
-            'mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-korean.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-korean.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/TigfYMde94YWAoE/download'
+    "mrtydi-v1.1-indonesian-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Indonesian) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-indonesian.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-indonesian.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/BpR3MzT7KJ6edx7/download"
         ],
-        'md5': '44212e5722632d5bcb14f0680741638c',
-        'size compressed (bytes)': 4257414237,
-        'documents': 1496126,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-korean'
+        "md5": "0bf693e4046d9a565ae18b9f5939d193",
+        "size compressed (bytes)": 865716848,
+        "documents": 4179177829,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-indonesian"
     },
-    'mrtydi-v1.1-russian-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(Russian) corpus encoded by '
-            'mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-russian.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-russian.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/eN7demnmnspqxjk/download'
+    "mrtydi-v1.1-japanese-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Japanese) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-japanese.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-japanese.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/k7bptHT8GwMJpnF/download"
         ],
-        'md5': 'e7634093f2a3362928e9699441ce8a3b',
-        'size compressed (bytes)': 27317759143,
-        'documents': 9597504,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-russian'
+        "md5": "4ba566e27bc0158108259b18a153e2fc",
+        "size compressed (bytes)": 19920816424,
+        "documents": 7000027,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-japanese"
     },
-    'mrtydi-v1.1-swahili-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-                '(Swahili) corpus encoded by '
-                'mDPR passage encoder '
-                'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-swahili.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/JgiX8PRftnqcPwy/download'
+    "mrtydi-v1.1-korean-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Korean) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-korean.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-korean.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/TigfYMde94YWAoE/download"
         ],
-        'md5': '5061bdd1d81bc32490bbb3682096acdd',
-        'size compressed (bytes)': 389658394,
-        'documents': 136689,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-swahili'
+        "md5": "44212e5722632d5bcb14f0680741638c",
+        "size compressed (bytes)": 4257414237,
+        "documents": 1496126,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-korean"
     },
-    'mrtydi-v1.1-telugu-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(Telugu) corpus encoded by '
-            'mDPR passage encoder '
-            'pre-fine-tuned on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-telugu.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/dkm6RGdgRbnwiX2/download'
+    "mrtydi-v1.1-russian-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Russian) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-russian.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-russian.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/eN7demnmnspqxjk/download"
         ],
-        'md5': '4952dacaeae89185d3757f9f26af4e88',
-        'size compressed (bytes)': 1561173721,
-        'documents': 548224,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-telugu'
+        "md5": "e7634093f2a3362928e9699441ce8a3b",
+        "size compressed (bytes)": 27317759143,
+        "documents": 9597504,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-russian"
     },
-    'mrtydi-v1.1-thai-mdpr-nq': {
-        'description': 'Faiss index for Mr.TyDi v1.1 '
-            '(Thai) corpus encoded by mDPR '
-            'passage encoder pre-fine-tuned '
-            'on NQ.',
-        'filename': 'faiss.mrtydi-v1.1-thai.20220207.5df364.tar.gz',
-        'readme': 'faiss.mrtydi-v1.1-thai.20220207.5df364.README.md',
-        'urls': [
-            'https://vault.cs.uwaterloo.ca/s/fFrRYefd3nWFR3J/download'
+    "mrtydi-v1.1-swahili-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Swahili) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-swahili.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-swahili.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/JgiX8PRftnqcPwy/download"
         ],
-        'md5': '2458f704b277fa8ffe2509b6296892a0',
-        'size compressed (bytes)': 1616059846,
-        'documents': 568855,
-        'downloaded': False,
-        'texts': 'mrtydi-v1.1-thai'
+        "md5": "5061bdd1d81bc32490bbb3682096acdd",
+        "size compressed (bytes)": 389658394,
+        "documents": 136689,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-swahili"
     },
-    'wikipedia-dpr-dkrr-nq': {
-        'description': "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from: 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on NQ",
-        'filename': 'faiss-flat.wikipedia.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz',
-        'urls': [
-            'https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/faiss-flat.wikipedia.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz',
+    "mrtydi-v1.1-telugu-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Telugu) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-telugu.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-telugu.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/dkm6RGdgRbnwiX2/download"
         ],
-        'md5': 'e58886fd5485b84f2c44963ce644561b',
-        'size compressed (bytes)': 37812137819,
-        'documents': 21015324,
-        'downloaded': False,
-        'texts': 'wikipedia-dpr'
+        "md5": "4952dacaeae89185d3757f9f26af4e88",
+        "size compressed (bytes)": 1561173721,
+        "documents": 548224,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-telugu"
     },
-    'wikipedia-dpr-dkrr-tqa': {
-        'description': "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from: 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on TriviaQA",
-        'filename': 'faiss-flat.wikipedia.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz',
-        'urls': [
-            'https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/faiss-flat.wikipedia.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz',
+    "mrtydi-v1.1-thai-mdpr-nq": {
+        "description": "Faiss index for Mr.TyDi v1.1 (Thai) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
+        "filename": "faiss.mrtydi-v1.1-thai.20220207.5df364.tar.gz",
+        "readme": "faiss.mrtydi-v1.1-thai.20220207.5df364.README.md",
+        "urls": [
+            "https://vault.cs.uwaterloo.ca/s/fFrRYefd3nWFR3J/download"
         ],
-        'md5': 'a6b02d33c9c0376ad1bf6550212ecdcb',
-        'size compressed (bytes)': 37802648060,
-        'documents': 21015324,
-        'downloaded': False,
-        'texts': 'wikipedia-dpr'
+        "md5": "2458f704b277fa8ffe2509b6296892a0",
+        "size compressed (bytes)": 1616059846,
+        "documents": 568855,
+        "downloaded": False,
+        "texts": "mrtydi-v1.1-thai"
+    },
+    "wikipedia-dpr-dkrr-nq": {
+        "description": "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on NQ",
+        "filename": "faiss-flat.wikipedia.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/faiss-flat.wikipedia.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        ],
+        "md5": "e58886fd5485b84f2c44963ce644561b",
+        "size compressed (bytes)": 37812137819,
+        "documents": 21015324,
+        "downloaded": False,
+        "texts": "wikipedia-dpr"
+    },
+    "wikipedia-dpr-dkrr-tqa": {
+        "description": "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on TriviaQA",
+        "filename": "faiss-flat.wikipedia.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/faiss-flat.wikipedia.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        ],
+        "md5": "a6b02d33c9c0376ad1bf6550212ecdcb",
+        "size compressed (bytes)": 37802648060,
+        "documents": 21015324,
+        "downloaded": False,
+        "texts": "wikipedia-dpr"
     }
 }


### PR DESCRIPTION
+ change 'text' pointer field of Faiss indexes to point to new pre-built indexes.
+ change single to double quotes. 
(Rationale is that these are supposed to be JSON entities, and JSON does not allow single quotes.)