### PR TITLE
Logged Reproductions and Improved Docs

### DIFF
--- a/docs/experiments-bpr.md
+++ b/docs/experiments-bpr.md
@@ -55,3 +55,4 @@ Top100 accuracy: 0.857
 ## Reproduction Log[*](reproducibility.md)
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-09-08 (commit [`d7a7be`](https://github.com/castorini/pyserini/commit/d7a7bededc650dfa87eb89ba92907fd97a10310b))
++ Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-11 (commit [`7796685`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))

--- a/docs/experiments-ltr-msmarco-passage-reranking.md
+++ b/docs/experiments-ltr-msmarco-passage-reranking.md
@@ -49,7 +49,7 @@ tar -xzvf runs/model-ltr-msmarco-passage-mrr-v1.tar.gz -C runs
 The following command generates our reranking result:
 
 ```bash
-python -m pyserini.search.lucene.ltr 
+python -m pyserini.search.lucene.ltr \
   --input runs/run.msmarco-passage.bm25tuned.txt \
   --input-format tsv \
   --model runs/msmarco-passage-ltr-mrr-v1 \

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -7,7 +7,7 @@ Note that there is a separate guide for the [MS MARCO *passage* ranking task](ex
 
 ## Data Prep
 
-The guide requires the [development installation](https://github.com/castorini/pyserini/#development-installation) for additional resource that are not shipped with the Python module; for the (more limited) runs that directly work from the Python module installed via `pip`, see [this guide](pypi-reproduction.md).
+The guide requires the [development installation](https://github.com/castorini/pyserini/blob/master/docs/installation.md#development-installation) for additional resource that are not shipped with the Python module; for the (more limited) runs that directly work from the Python module installed via `pip`, see [this guide](pypi-reproduction.md).
 
 We're going to use the repository's root directory as the working directory.
 First, we need to download and extract the MS MARCO document dataset:

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -168,3 +168,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results reproduced by [@mikhail-tsir](https://github.com/mikhail-tsir) on 2022-01-10 (commit [`f1084a0`](https://github.com/castorini/pyserini/commit/f1084a05a3bf955bdd27acd33f2b95c636b2e5b6))
 + Results reproduced by [@AceZhan](https://github.com/AceZhan) on 2022-01-14 (commit [`68be809`](https://github.com/castorini/pyserini/commit/68be8090b8553fc6eaf352ac690a6de9d3dc82dd))
 + Results reproduced by [@jh8liang](https://github.com/jh8liang) on 2022-02-06 (commit [`e03e068`](https://github.com/castorini/pyserini/commit/e03e06880ad4f6d67a1666c1dd45ce4250adc95d))
++ Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-11 (commit [`7796685`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -47,7 +47,6 @@ python -m pyserini.index.lucene \
   --storePositions --storeDocvectors --storeRaw
 ```
 
-Note that the indexing program simply dispatches command-line arguments to an underlying Java program, and so we use the Java single dash convention, e.g., `-index` and not `--index`.
 
 Upon completion, we should have an index with 8,841,823 documents.
 The indexing speed may vary; on a modern desktop with an SSD, indexing takes a couple of minutes.
@@ -169,3 +168,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results reproduced by [@mikhail-tsir](https://github.com/mikhail-tsir) on 2022-01-10 (commit [`f1084a0`](https://github.com/castorini/pyserini/commit/f1084a05a3bf955bdd27acd33f2b95c636b2e5b6))
 + Results reproduced by [@AceZhan](https://github.com/AceZhan) on 2022-01-14 (commit [`68be809`](https://github.com/castorini/pyserini/commit/68be8090b8553fc6eaf352ac690a6de9d3dc82dd))
 + Results reproduced by [@jh8liang](https://github.com/jh8liang) on 2022-02-06 (commit [`e03e068`](https://github.com/castorini/pyserini/commit/e03e06880ad4f6d67a1666c1dd45ce4250adc95d))
++ Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-10 (commit [`7796685`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -7,7 +7,7 @@ Note that there is a separate guide for the [MS MARCO *document* ranking task](e
 
 ## Data Prep
 
-The guide requires the [development installation](https://github.com/castorini/pyserini/#development-installation) for additional resource that are not shipped with the Python module; for the (more limited) runs that directly work from the Python module installed via `pip`, see [this guide](pypi-reproduction.md).
+The guide requires the [development installation](https://github.com/castorini/pyserini/blob/master/docs/installation.md#development-installation) for additional resource that are not shipped with the Python module; for the (more limited) runs that directly work from the Python module installed via `pip`, see [this guide](pypi-reproduction.md).
 
 We're going to use `collections/msmarco-passage/` as the working directory.
 First, we need to download and extract the MS MARCO passage dataset:

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -13,7 +13,7 @@ These instructions are exactly the same as in the [Anserini guide](https://githu
 This is the minimal indexing command:
 
 ```bash
-python -m pyserini.index.lucene
+python -m pyserini.index.lucene \
   --collection MsMarcoV2PassageCollection \
   --input collections/msmarco_v2_passage \
   --index indexes/lucene-index.msmarco-v2-passage \

--- a/docs/experiments-trec2021-clinical-trials.md
+++ b/docs/experiments-trec2021-clinical-trials.md
@@ -4,7 +4,7 @@ This guide contains instructions for running BM25 and RM3 baselines on the [TREC
 
 ## Data Prep
 
-The guide requires the [development installation](https://github.com/castorini/pyserini/#development-installation) for additional resource that are not shipped with the Python module; for the (more limited) runs that directly work from the Python module installed via `pip`, see [this guide](pypi-reproduction.md).
+The guide requires the [development installation](https://github.com/castorini/pyserini/blob/master/docs/installation.md#development-installation) for additional resource that are not shipped with the Python module; for the (more limited) runs that directly work from the Python module installed via `pip`, see [this guide](pypi-reproduction.md).
 
 We're going to use the repository's root directory as the working directory.
 First, we need to download and extract the Clinical Trials documents and topics.

--- a/docs/experiments-tripclick-doc.md
+++ b/docs/experiments-tripclick-doc.md
@@ -7,7 +7,7 @@ This will prevent going back and fixing machine configuration again and again. I
 
 ## Data Preparation
 
-The guide requires the [development installation](https://github.com/castorini/pyserini/#development-installation) for additional resources that are not shipped with the Python module;
+The guide requires the [development installation](https://github.com/castorini/pyserini/blob/master/docs/installation.md#development-installation) for additional resources that are not shipped with the Python module;
 
 We're going to use the repository's root directory as the working directory.
 First, obtain the TripClick benchmark package, following instructions on the [TripClick benchmark collection web page](https://tripdatabase.github.io/tripclick/).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,6 +148,12 @@ $ pip install torch==1.8.1 torchvision==0.9.1 torchaudio===0.8.1 -f https://down
 $ conda install faiss-cpu -c pytorch
 ```
 
+You'll need to download the Spacy English model to reproduce tasks such as [LTR Filtering for MS MARCO Passage](https://github.com/castorini/pyserini/blob/master/docs/experiments-ltr-msmarco-passage-reranking.md).
+
+```bash
+python -m spacy download en_core_web_sm
+```
+
 Next, you'll need to clone and build [Anserini](http://anserini.io/).
 It makes sense to put both `pyserini/` and `anserini/` in a common folder.
 After you've successfully built Anserini, copy the fatjar, which will be `target/anserini-X.Y.Z-SNAPSHOT-fatjar.jar` into `pyserini/resources/jars/`.


### PR DESCRIPTION
I spent some time trying out the reproductions, making some fixes to the documentation where I saw necessary. 

I was able to do the following experiments: [BM25 baseline for MS MARCO V1 Passage Ranking](https://github.com/castorini/pyserini/blob/master/docs/experiments-msmarco-passage.md), [BM25 baseline for MS MARCO V1 Document Ranking](https://github.com/castorini/pyserini/blob/master/docs/experiments-msmarco-doc.md), [BPR experiments](https://github.com/castorini/pyserini/blob/master/docs/experiments-bpr.md).

I also attempted the LTR Filtering experiments: [MS MARCO V1 Passage](https://github.com/castorini/pyserini/blob/master/docs/experiments-ltr-msmarco-passage-reranking.md) and [MS MARCO V1 Document](https://github.com/castorini/pyserini/blob/master/docs/experiments-ltr-msmarco-document-reranking.md). However, I had memory issues or reproduction taking too long.

For example:

In the case of MS MARCO V1 Passage, more than 5 hours after running the following command:

> python -m pyserun.msmarco-passage.bm25tuned.txt   --input-format tsv   --model runs/msmarco-passage-ltr-mrr-v1   --index msmarco-passage-ltr   --data passage   --ibm-model collections/msmarco-ltr-passage/ibm_model/   --queries collections/msmarco-ltr-passage   --output runs/run.ltr.msmarco-passage.tsv

the experiment crashed with the following traceback:

> ...
> recall@2000:0.8573424068767909
> recall@5000:0.8573424068767909
> recall@10000:0.8573424068767909
> ---------------------loading queries----------------------------------------
>  14%|███████████▏                                                                  | 999/6980 [12:09<1:12:45,  1.37it/s]
> Traceback (most recent call last):
>   File "/home/haks/anaconda3/envs/pyserini-dev/lib/python3.8/runpy.py", line 194, in _run_module_as_main
>     return _run_code(code, main_globals, None,
>   File "/home/haks/anaconda3/envs/pyserini-dev/lib/python3.8/runpy.py", line 87, in _run_code
>     exec(code, run_globals)
>   File "/mnt/c/Users/HAKS/dev/pyserini/pyserini/search/lucene/ltr/__main__.py", line 253, in <module>
>     batch_info = searcher.search(dev, queries)
>   File "/mnt/c/Users/HAKS/dev/pyserini/pyserini/search/lucene/ltr/_search_msmarco.py", line 240, in search
>     for dev_extracted in self.batch_extract(dev, queries, self.fe):
>   File "/mnt/c/Users/HAKS/dev/pyserini/pyserini/search/lucene/ltr/_search_msmarco.py", line 200, in batch_extract
>     features = fe.batch_extract(tasks)
>   File "/mnt/c/Users/HAKS/dev/pyserini/pyserini/search/lucene/ltr/_base.py", line 242, in batch_extract
>     self.lazy_extract(task['qid'], task['docIds'], task['query_dict'])
>   File "/mnt/c/Users/HAKS/dev/pyserini/pyserini/search/lucene/ltr/_base.py", line 237, in lazy_extract
>     self.utils.lazyExtract(json.dumps(input))
>   File "jnius/jnius_export_class.pxi", line 885, in jnius.JavaMethod.__call__
>   File "jnius/jnius_export_class.pxi", line 965, in jnius.JavaMethod.call_method
>   File "jnius/jnius_utils.pxi", line 91, in jnius.check_exception
> jnius.JavaException: JVM exception occurred: Java heap space java.lang.OutOfMemoryError


In the case of MS MARCO V1 Document, more than 5 hours after running the following command:

> python scripts/ltr_msmarco/convert_msmarco_passage_doc_to_anserini.py \
>   --original_docs_path collections/msmarco-doc/msmarco-docs.tsv.gz \
>   --doc_ids_path collections/msmarco-doc/msmarco_doc_passage_ids.txt \
>   --output_docs_path collections/msmarco-doc/msmarco_pass_doc.jsonl

The process was killed by my OS, which I believe was a result of memory issues:

> Spliting documents...
> 8444399it [5:28:15, 1726.16it/s]Killed


I ran the experiments using the Windows Subsystem for Linux running Ubuntu 18.04 with about 12GB of RAM (I believe there was definitely way less available RAM while running the experiments). This is probably not the optimal set-up for the experiments, but aside from these issues, I found the experiments easy to reproduce.