### PR TITLE
Install pre-built indexes for MS MARCO v1 (doc + passage), uniCOIL noexp

### DIFF
--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -8,7 +8,7 @@ To list what's available in code:
 from pyserini.search.lucene import LuceneSearcher
 LuceneSearcher.list_prebuilt_indexes()
 
-from pyserini.index import IndexReader
+from pyserini.index.lucene import IndexReader
 IndexReader.list_prebuilt_indexes()
 ```
 
@@ -63,6 +63,9 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-doc-per-passage-ltr</code></b>
 <dd>Lucene index of the MS MARCO document per-passage corpus with four extra preprocessed fields for LTR
+</dd>
+<dt></dt><b><code>msmarco-document-segment-ltr</code></b>
+<dd>Lucene index of the MS MARCO document segmented corpus with four extra preprocessed fields for LTR
 </dd>
 <dt></dt><b><code>msmarco-v1-doc</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc.20220131.9ea315.README.md">readme</a>]
@@ -331,9 +334,17 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-unicoil.20220219.6a7080.README.md">readme</a>]
 <dd>Lucene impact index of the MS MARCO V1 passage corpus for uniCOIL.
 </dd>
+<dt></dt><b><code>msmarco-v1-passage-unicoil-noexp</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-unicoil-noexp.20220322.2f4058.README.md">readme</a>]
+<dd>Lucene impact index of the MS MARCO V1 passage corpus for uniCOIL (noexp).
+</dd>
 <dt></dt><b><code>msmarco-v1-doc-segmented-unicoil</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-unicoil.20220219.6a7080.README.md">readme</a>]
 <dd>Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL.
+</dd>
+<dt></dt><b><code>msmarco-v1-doc-segmented-unicoil-noexp</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058.README.md">readme</a>]
+<dd>Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL (noexp).
 </dd>
 <dt></dt><b><code>msmarco-v2-passage-unicoil-0shot</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-unicoil-0shot.20220219.6a7080.README.md">readme</a>]
@@ -485,11 +496,9 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 <dd>Faiss index for Mr.TyDi v1.1 (Thai) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.
 </dd>
 <dt></dt><b><code>wikipedia-dpr-dkrr-nq</code></b>
-[<a href="../pyserini/resources/index-metadata/faiss-flat.wikipedia.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.README.md">readme</a>]
-<dd>Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from: 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on NQ.
+<dd>Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on NQ
 </dd>
 <dt></dt><b><code>wikipedia-dpr-dkrr-tqa</code></b>
-[<a href="../pyserini/resources/index-metadata/faiss-flat.wikipedia.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.README.md">readme</a>]
-<dd>Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from: 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on TriviaQA.
+<dd>Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on TriviaQA
 </dd>
 </dl>

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -1142,6 +1142,20 @@ IMPACT_INDEX_INFO = {
         "unique_terms": 27678,
         "downloaded": False
     },
+    "msmarco-v1-passage-unicoil-noexp": {
+        "description": "Lucene impact index of the MS MARCO V1 passage corpus for uniCOIL (noexp).",
+        "filename": "lucene-index.msmarco-v1-passage-unicoil-noexp.20220322.2f4058.tar.gz",
+        "readme": "lucene-index.msmarco-v1-passage-unicoil-noexp.20220322.2f4058.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage-unicoil-noexp.20220322.2f4058.tar.gz",
+        ],
+        "md5": "e1feea4ce3bbafc034330b2683b6503a",
+        "size compressed (bytes)": 890676484,
+        "total_terms": 26468530021,
+        "documents": 8841823,
+        "unique_terms": 27647,
+        "downloaded": False
+    },
     "msmarco-v1-doc-segmented-unicoil": {
         "description": "Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL.",
         "filename": "lucene-index.msmarco-v1-doc-segmented-unicoil.20220219.6a7080.tar.gz",
@@ -1153,6 +1167,20 @@ IMPACT_INDEX_INFO = {
         "md5": "393ad1227b9906c8776a4fbaddab4e9d",
         "size compressed (bytes)": 5891112039,
         "total_terms": 214505277898,
+        "documents": 20545677,
+        "unique_terms": 29142,
+        "downloaded": False
+    },
+    "msmarco-v1-doc-segmented-unicoil-noexp": {
+        "description": "Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL (noexp).",
+        "filename": "lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058.tar.gz",
+        "readme": "lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058.tar.gz",
+        ],
+        "md5": "df678edd015c4ad82a4be7f35fddaa47",
+        "size compressed (bytes)": 5371860391,
+        "total_terms": 152325913715,
         "documents": 20545677,
         "unique_terms": 29142,
         "downloaded": False

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058.README.md
@@ -1,0 +1,15 @@
+# msmarco-v1-doc-segmented-unicoil-noexp
+
+Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL (noexp).
+
+This index was generated on 2022/03/22 at Anserini commit [`2f4058`](https://github.com/castorini/anserini/commit/2f4058fbac852ec483c43e9e43ce9864db5a0027) on `orca` with the following command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /store/collections/msmarco/msmarco-doc-segmented-unicoil-noexp/ \
+  -index indexes/lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 \
+  -impact -pretokenized -optimize
+```

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-unicoil-noexp.20220322.2f4058.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-unicoil-noexp.20220322.2f4058.README.md
@@ -1,0 +1,15 @@
+# msmarco-v1-passage-unicoil-noexp
+
+Lucene impact index of the MS MARCO V1 passage corpus for uniCOIL (noexp).
+
+This index was generated on 2022/03/22 at Anserini commit [`2f4058`](https://github.com/castorini/anserini/commit/2f4058fbac852ec483c43e9e43ce9864db5a0027) on `orca` with the following command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /store/collections/msmarco/msmarco-passage-unicoil-noexp/ \
+  -index indexes/lucene-index.msmarco-v1-passage-unicoil-noexp.20220322.2f4058/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 \
+  -impact -pretokenized -optimize
+```


### PR DESCRIPTION
These commands now work:

```
python -m pyserini.search.lucene \
  --index msmarco-v1-passage-unicoil-noexp \
  --topics msmarco-passage-dev-subset-unicoil-noexp \
  --output runs/run.msmarco-passage.unicoil-noexp.tsv \
  --output-format trec \
  --batch 36 --threads 12 \
  --hits 1000 \
  --impact

python -m pyserini.eval.trec_eval -c -m map msmarco-passage-dev-subset runs/run.msmarco-passage.unicoil-noexp.tsv
python -m pyserini.eval.trec_eval -c -M 10 -m recip_rank msmarco-passage-dev-subset runs/run.msmarco-passage.unicoil-noexp.tsv
python -m pyserini.eval.trec_eval -c -m recall.100 msmarco-passage-dev-subset runs/run.msmarco-passage.unicoil-noexp.tsv
python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset runs/run.msmarco-passage.unicoil-noexp.tsv

python -m pyserini.search.lucene \
  --index msmarco-v1-doc-segmented-unicoil-noexp \
  --topics msmarco-doc-dev-unicoil-noexp \
  --output runs/run.msmarco-doc.unicoil-noexp.tsv \
  --output-format trec \
  --batch 36 --threads 12 \
  --hits 10000 --max-passage --max-passage-hits 1000 \
  --impact

python -m pyserini.eval.trec_eval -c -m map msmarco-doc-dev runs/run.msmarco-doc.unicoil-noexp.tsv
python -m pyserini.eval.trec_eval -c -M 100 -m recip_rank msmarco-doc-dev runs/run.msmarco-doc.unicoil-noexp.tsv
python -m pyserini.eval.trec_eval -c -m recall.100 msmarco-doc-dev runs/run.msmarco-doc.unicoil-noexp.tsv
python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-doc-dev runs/run.msmarco-doc.unicoil-noexp.tsv
```
