### PR TITLE
Reduced DPR acccuracy's figures of precision

### DIFF
--- a/pyserini/eval/evaluate_dpr_retrieval.py
+++ b/pyserini/eval/evaluate_dpr_retrieval.py
@@ -266,7 +266,7 @@ def evaluate_retrieval(retrieval_file, topk, regex=False):
             accuracy[k].append(0 if has_ans_idx >= k else 1)
 
     for k in topk:
-        print(f'Top{k}\taccuracy: {np.mean(accuracy[k])}')
+        print(f'Top{k}\taccuracy: {np.around(np.mean(accuracy[k]), 4)}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes issue #1067 

I was not able to test this fix. I tried to download the index needed to get `runs/run.dpr.nq-test.single.bf.bm25.trec` and its DPR format before running the command:

> python -m pyserini.eval.evaluate_dpr_retrieval \
  --retrieval runs/run.dpr.nq-test.single.bf.bm25.json \
  --topk 20 100

However, the index was quite large (55GB). I believe the fix should work though as it's not a big change.

Are there much smaller indexes available that make it easier to test out functionalities and fixes quickly?