### PR TITLE
Update replication log for MS-MARCO passage and document ranking experiments

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -169,3 +169,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results reproduced by [@AceZhan](https://github.com/AceZhan) on 2022-01-14 (commit [`68be809`](https://github.com/castorini/pyserini/commit/68be8090b8553fc6eaf352ac690a6de9d3dc82dd))
 + Results reproduced by [@jh8liang](https://github.com/jh8liang) on 2022-02-06 (commit [`e03e068`](https://github.com/castorini/pyserini/commit/e03e06880ad4f6d67a1666c1dd45ce4250adc95d))
 + Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-11 (commit [`7796685`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))
++ Results reproduced by [@jasper-xian](https://github.com/jasper-xian) on 2022-03-27 (commit [`5668edd`](https://github.com/castorini/pyserini/commit/5668edd6f1e61e9c57d600d41d3d1f58b775d371))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -169,3 +169,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results reproduced by [@AceZhan](https://github.com/AceZhan) on 2022-01-14 (commit [`68be809`](https://github.com/castorini/pyserini/commit/68be8090b8553fc6eaf352ac690a6de9d3dc82dd))
 + Results reproduced by [@jh8liang](https://github.com/jh8liang) on 2022-02-06 (commit [`e03e068`](https://github.com/castorini/pyserini/commit/e03e06880ad4f6d67a1666c1dd45ce4250adc95d))
 + Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-10 (commit [`7796685`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))
++ Results reproduced by [@jasper-xian](https://github.com/jasper-xian) on 2022-03-27 (commit [`5668edd`](https://github.com/castorini/pyserini/commit/5668edd6f1e61e9c57d600d41d3d1f58b775d371))


### PR DESCRIPTION
Reproduced the pyserini passage and document ranking experiments for the [initial screening exercise](https://github.com/lintool/guide/blob/master/ura.md).

Environment:
```
$ java --version
openjdk 11.0.9.1 2020-11-04 LTS
OpenJDK Runtime Environment Zulu11.43+55-CA (build 11.0.9.1+1-LTS)
OpenJDK 64-Bit Server VM Zulu11.43+55-CA (build 11.0.9.1+1-LTS, mixed mode)

$ mvn --version
Apache Maven 3.8.5 (3599d3414f046de2324203b78ddcf9b5e4388aa0)
Maven home: /Users/jxian/opt/anaconda3/envs/pyserini-dev/opt/maven
Java version: 11.0.9.1, vendor: Azul Systems, Inc., runtime: /Users/jxian/opt/anaconda3/envs/pyserini-dev
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.16", arch: "x86_64", family: "mac"
 ```

<img width="211" alt="Screen Shot 2022-03-27 at 1 08 34 PM" src="https://user-images.githubusercontent.com/41269031/160292547-6fcb894d-64f3-48bb-ad42-9b8481233717.png">

Issues Encountered:
When running the unit tests, I get the following error:
```
$ python -m unittest
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGILL (0x4) at pc=0x00000001985c7d7f, pid=11678, tid=259
#
# JRE version: OpenJDK Runtime Environment Zulu11.43+55-CA (11.0.9.1+1) (build 11.0.9.1+1-LTS)
# Java VM: OpenJDK 64-Bit Server VM Zulu11.43+55-CA (11.0.9.1+1-LTS, mixed mode, tiered, compressed oops, g1 gc, bsd-amd64)
# Problematic frame:
# C  [nmslib.cpython-38-darwin.so+0x44d7f]  _GLOBAL__sub_I_nmslib.cc+0x1f
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   http://www.azulsystems.com/support/
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
zsh: abort      python -m unittest
```

I've spent some time digging into this issue but I'm still not quite sure why this happens, and I could not find a fix. When I remove the anserini fatjar file from `pyserini/resources/jars`, the unit tests run successfully (with a few failed tests).

However, despite this issue, I was still able to reproduce the experiment results successfully.