### PR TITLE
refactor vector prf and add negative prf passages for rocchio

### DIFF
--- a/docs/experiments-vector-prf.md
+++ b/docs/experiments-vector-prf.md
@@ -159,7 +159,7 @@ one can use `--encoded-queries ance-msmarco-passage-dev-subset`. For ADORE model
 
 With these parameters, one can easily reproduce the results above, for example, to reproduce `TREC DL 2019 Passage with ANCE Average Vector PRF 3` the command will be:
 ```
-$ python -m pyserini.dsearch --topics dl19-passage \
+$ python -m pyserini.search.faiss --topics dl19-passage \
     --index msmarco-passage-ance-bf \
     --encoder castorini/ance-msmarco-passage \
     --batch-size 64 \
@@ -171,14 +171,15 @@ $ python -m pyserini.dsearch --topics dl19-passage \
 
 To reproduce `TREC DL 2019 Passage with ANCE Rocchio Vector PRF 5 Alpha 0.4 Beta 0.6`, the command will be:
 ```
-$ python -m pyserini.dsearch --topics dl19-passage \
+$ python -m pyserini.search.faiss --topics dl19-passage \
     --index msmarco-passage-ance-bf \
     --encoder castorini/ance-msmarco-passage \
     --batch-size 64 \
     --threads 12 \
     --output runs/run.ance.dl19-passage.rocchio_prf5_a0.4_b0.6.trec \
-    --prf-depth 5 \
     --prf-method rocchio \
+    --prf-depth 5 \
+    --rocchio-topk 5 \
     --rocchio-alpha 0.4 \
     --rocchio-beta 0.6
 ```


### PR DESCRIPTION
Hi @lintool , I implemented the negative prf passage for vector Rocchio prf and did a bit of refactoring.

I tested this with `distilbert-dot-tas_b`, here is what I got:

This is the previous Rocchio run which uses the top 5 passages as positive prf signals and no negative passages:
```
python -m pyserini.search.faiss --topics dl19-passage \
    --index msmarco-passage-distilbert-dot-tas_b-b256-bf \
    --encoder sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco \
    --batch-size 64 \
    --threads 12 \
    --output runs/run.dl2019.distilbert-dot-tas_b.rocchio_a0.4_b0.6_g0.6_topk5_bottomk0.trec \
    --prf-method rocchio \
    --prf-depth 5 \
    --rocchio-alpha 0.4 \
    --rocchio-beta 0.6 \
    --rocchio-topk 5 \
```

This is using the top 5 passages as positive and the bottom 5 passages as negative prf signals:
```
python -m pyserini.search.faiss --topics dl19-passage \
    --index msmarco-passage-distilbert-dot-tas_b-b256-bf \
    --encoder sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco \
    --batch-size 64 \
    --threads 12 \
    --output runs/run.dl2019.distilbert-dot-tas_b.rocchio_a0.4_b0.6_g0.6_topk5_bottomk5.trec \
    --prf-depth 1000 \
    --prf-method rocchio \
    --rocchio-alpha 0.4 \
    --rocchio-beta 0.6 \
    --rocchio-gamma 0.6 \
    --rocchio-topk 5 \
    --rocchio-bottomk 5
```

Results:
```
python -m pyserini.eval.trec_eval -c -m map -m ndcg_cut.100 -m recall.1000 -l 2 dl19-passage runs/run.dl2019.distilbert-dot-tas_b.rocchio_a0.4_b0.6_g0.6_topk5_bottomk0.trec

map                     all     0.4974
recall_1000             all     0.8775
ndcg_cut_100            all     0.6684
```
```
python -m pyserini.eval.trec_eval -c -m map -m ndcg_cut.100 -m recall.1000 -l 2 dl19-passage runs/run.dl2019.distilbert-dot-tas_b.rocchio_a0.4_b0.6_g0.6_topk5_bottomk5.trec

map                     all     0.5043
recall_1000             all     0.8670
ndcg_cut_100            all     0.6735
```

This first quick try shows negatives may help Rocchio vector prf.