### PR TITLE
Reproduce MS MARCO passage and document ranking experiments results and fix unit tests failure

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -170,3 +170,4 @@ We can see that Anserini's (tuned) BM25 baseline is already much better than the
 + Results reproduced by [@jh8liang](https://github.com/jh8liang) on 2022-02-06 (commit [`e03e068`](https://github.com/castorini/pyserini/commit/e03e06880ad4f6d67a1666c1dd45ce4250adc95d))
 + Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-11 (commit [`7796685`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))
 + Results reproduced by [@jasper-xian](https://github.com/jasper-xian) on 2022-03-27 (commit [`5668edd`](https://github.com/castorini/pyserini/commit/5668edd6f1e61e9c57d600d41d3d1f58b775d371))
++ Results reproduced by [@jx3yang](https://github.com/jx3yang) on 2022-04-25 (commit [`53333e0`](https://github.com/castorini/pyserini/commit/53333e0fb77371e049e24b10da3a20646c7b5af7))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -170,3 +170,4 @@ On the other hand, recall@1000 provides the upper bound effectiveness of downstr
 + Results reproduced by [@jh8liang](https://github.com/jh8liang) on 2022-02-06 (commit [`e03e068`](https://github.com/castorini/pyserini/commit/e03e06880ad4f6d67a1666c1dd45ce4250adc95d))
 + Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-10 (commit [`7796685`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))
 + Results reproduced by [@jasper-xian](https://github.com/jasper-xian) on 2022-03-27 (commit [`5668edd`](https://github.com/castorini/pyserini/commit/5668edd6f1e61e9c57d600d41d3d1f58b775d371))
++ Results reproduced by [@jx3yang](https://github.com/jx3yang) on 2022-04-25 (commit [`53333e0`](https://github.com/castorini/pyserini/commit/53333e0fb77371e049e24b10da3a20646c7b5af7))

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -127,7 +127,7 @@ class JsonlRepresentationWriter(RepresentationWriter):
 
     def __enter__(self):
         if not os.path.exists(self.dir_path):
-            os.mkdir(self.dir_path)
+            os.makedirs(self.dir_path)
         self.file = open(os.path.join(self.dir_path, self.filename), 'w')
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -154,7 +154,7 @@ class FaissRepresentationWriter(RepresentationWriter):
 
     def __enter__(self):
         if not os.path.exists(self.dir_path):
-            os.mkdir(self.dir_path)
+            os.makedirs(self.dir_path)
         self.id_file = open(os.path.join(self.dir_path, self.id_file_name), 'w')
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
## Description

Reproduced the MS MARCO passage and document ranking experiments results as part of [initial screening](https://github.com/lintool/guide/blob/master/ura.md#initial-screening).

## Environment
- Java version 11.0.15
- Maven version 3.8.5
- Python version 3.8.13 with Conda version 4.11.0
- MacOS Monterey version 12.3.1 (21E258)

## Issue Encountered
When running the unit tests with `python -m unittest` for the first time, the following tests failed:
- `test_tct_colbert_v2_encoder_cmd`
- `test_tct_colbert_v2_encoder_cmd_shard`
- `test_faiss_hnsw`
- `test_faiss_pq`

This was due to the cache directories not being properly created, particularly `~/.cache/pyserini/temp_index` and `~/.cache/pyserini/temp_index-0`. The tests use `os.mkdir` to create the directories, which succeeds only when all the intermediate directories exist. In this case, the directory `~/.cache/pyserini` is likely to not exist the first time the tests are run, resulting in the failure of the tests when they try to access a nonexistent directory.

The fix is to change `os.mkdir` to `os.makedirs`, the latter being equivalent to `mkdir -p`, which creates the intermediate directories if they are not present.