### PR TITLE
Add to repro log for GAR-T5 experiments

### DIFF
--- a/docs/experiments-gar-t5.md
+++ b/docs/experiments-gar-t5.md
@@ -28,7 +28,7 @@ python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run --topics <nq-test 
 
 To run fusion RRF, you will need all three (answers, titles, sentences) trec files
 ```bash
-python -m $ANSERINI/src/main/python/fusion.py --runs <path to answers.trec> <path to sentences.trec> <path to titles.trec> --out <output path>
+python $ANSERINI/src/main/python/fusion.py --runs <path to answers.trec> <path to sentences.trec> <path to titles.trec> --out <output path>
 ```
 
 To evaluate the run:
@@ -44,7 +44,7 @@ This should give you the topk scores as you wanted
 |:--------:|:--------:|:-----:|:-----:|:-----:|:-----:|:-----:|:------:|:------:|:------:|:------:|:-------:|
 |    NQ    |  answer  | 40.33 | 57.76 | 64.26 | 70.38 | 76.96 |  81.20 |  84.33 |  85.91 |  87.83 |  89.94  |
 |    NQ    | sentence | 42.00 | 57.78 | 64.12 | 69.59 | 75.62 |  79.67 |  83.03 |  85.04 |  86.87 |  89.00  |
-|    NQ    |   title  | 32.15 | 50.66 | 58.68 | 65.76 | 73.30 |  78.25 |  82.19 |  84.45 |  85.91 |  88.01  |
+|    NQ    |   title  | 32.15 | 50.66 | 58.68 | 65.76 | 73.30 |  78.25 |  82.19 |  84.15 |  85.91 |  88.01  |
 |    NQ    |  fusion  | 45.44 | 64.89 | 71.82 | 77.16 | 82.55 |  85.34 |  88.00 |  89.15 |  90.13 |  91.74  |
 | TriviaQA |  answer  | 55.92 | 70.39 | 74.77 | 78.39 | 82.36 |  84.55 |  86.23 |  87.42 |  88.36 |  89.34  |
 | TriviaQA | sentence | 49.17 | 63.30 | 68.42 | 72.57 | 77.55 |  80.67 |  83.33 |  84.93 |  86.22 |  87.78  |
@@ -54,13 +54,15 @@ This should give you the topk scores as you wanted
 ### Test Scores from Gar-T5
 |  Dataset | Features |  Top1 |  Top5 | Top10 | Top20 | Top50 | Top100 | Top200 | Top300 | Top500 | Top1000 |
 |:--------:|:--------:|:-----:|:-----:|:-----:|:-----:|:-----:|:------:|:------:|:------:|:------:|:-------:|
-|    NQ    |  answer  | 40.30 | 57.51 | 64.24 | 70.11 | 77.23 |  81.75 |  85.10 |  85.79 |  88.39 |  90.80  |
-|    NQ    | sentence | 40.30 | 57.45 | 64.27 | 69.81 | 77.34 |  81.50 |  85.26 |  85.76 |  88.12 |  90.17  |
-|    NQ    |   title  | 32.11 | 51.66 | 59.47 | 66.90 | 74.85 |  79.17 |  82.96 |  84.96 |  86.70 |  88.95  |
-|    NQ    |  fusion  | 45.35 | 64.63 | 71.75 | 77.17 | 83.41 |  86.90 |  89.14 |  89.67 |  91.63 |  92.91  |
-| TriviaQA |  answer  | 55.89 | 69.57 | 73.96 | 77.95 | 82.14 |  84.76 |  86.86 |  86.97 |  88.60 |  89.56  |
-| TriviaQA | sentence | 48.96 | 62.68 | 68.05 | 72.47 | 77.51 |  80.84 |  83.54 |  84.47 |  86.23 |  87.93  |
-| TriviaQA |   title  | 47.70 | 61.28 | 66.37 | 71.24 | 76.59 |  80.04 |  82.90 |  84.51 |  85.96 |  87.64  |
-| TriviaQA |  fusion  | 59.00 | 72.82 | 76.93 | 80.66 | 84.10 |  85.95 |  87.39 |  87.62 |  89.07 |  90.06  |
+|    NQ    |  answer  | 40.30 | 57.51 | 64.24 | 70.11 | 77.23 |  81.75 |  85.10 |  86.68 |  88.39 |  90.80  |
+|    NQ    | sentence | 40.30 | 57.45 | 64.27 | 69.81 | 77.34 |  81.50 |  85.26 |  86.73 |  88.12 |  90.17  |
+|    NQ    |   title  | 32.11 | 51.66 | 59.47 | 66.90 | 74.85 |  79.17 |  82.96 |  84.65 |  86.70 |  88.95  |
+|    NQ    |  fusion  | 45.35 | 64.63 | 71.75 | 77.17 | 83.41 |  86.90 |  89.14 |  90.30 |  91.63 |  92.91  |
+| TriviaQA |  answer  | 55.89 | 69.57 | 73.96 | 77.95 | 82.14 |  84.76 |  86.86 |  87.66 |  88.60 |  89.56  |
+| TriviaQA | sentence | 48.96 | 62.68 | 68.05 | 72.47 | 77.51 |  80.84 |  83.54 |  85.01 |  86.23 |  87.93  |
+| TriviaQA |   title  | 47.70 | 61.28 | 66.37 | 71.24 | 76.59 |  80.04 |  82.90 |  84.49 |  85.96 |  87.64  |
+| TriviaQA |  fusion  | 59.00 | 72.82 | 76.93 | 80.66 | 84.10 |  85.95 |  87.39 |  88.15 |  89.07 |  90.06  |
 
 ## Reproduction Log[*](reproducibility.md)
++ Results reproduced by [@manveertamber](https://github.com/manveertamber) on 2022-05-04 (commit [`1facc72`](https://github.com/castorini/pyserini/commit/1facc72b3c8313149c763b76502f43352efaf974))
++ 

--- a/docs/experiments-gar-t5.md
+++ b/docs/experiments-gar-t5.md
@@ -64,5 +64,5 @@ This should give you the topk scores as you wanted
 | TriviaQA |  fusion  | 59.00 | 72.82 | 76.93 | 80.66 | 84.10 |  85.95 |  87.39 |  88.15 |  89.07 |  90.06  |
 
 ## Reproduction Log[*](reproducibility.md)
-+ Results reproduced by [@manveertamber](https://github.com/manveertamber) on 2022-05-04 (commit [`1facc72`](https://github.com/castorini/pyserini/commit/1facc72b3c8313149c763b76502f43352efaf974))
-+ 
+
++ Results reproduced by [@manveertamber](https://github.com/manveertamber) on 2022-05-04 (commit [`1facc72`](https://github.com/castorini/pyserini/commit/1facc72b3c8313149c763b76502f43352efaf974)) 


### PR DESCRIPTION
There were some differences in the top 300 scores. The other scores matched perfectly. I have updated the doc accordingly. 
 