### PR TITLE
not removing trailing \n in contents when encoding, as it is probably…

### DIFF
--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -88,6 +88,25 @@ class JsonlCollectionIterator:
                 to_yield[key] = self.all_info[key][idx: min(idx + self.batch_size, end_idx)]
             yield to_yield
 
+    def _parse_fields_from_contents(self, contents):
+        """
+        :params contents: str, the text containing all fields as speicifed in self.fields
+        This function will parse the input contents into each fields based the self.delimiter
+        return: List, each corresponds to the value of self.fields
+        """
+        n_fields = len(self.fields)
+
+        # whether to remove the final self.delimiter (especially \n)
+        # in CACM, a \n is always there at the end of contents, which we want to remove;
+        # but in SciFact, Fiqa, and more, there are documents that only have title but not text (e.g. "This is title\n")
+        # where the trailing \n indicates empty fields
+        if contents.count(self.delimiter) == n_fields:
+            # the user appends one more delimiter to the end, we remove it
+            if contents.endswith(self.delimiter):
+                # not using .rstrip() as there might be more than one delimiters at the end
+                contents = contents[:-len(self.delimiter)]
+        return [field.strip(" ") for field in contents.split(self.delimiter)]
+
     def _load(self, collection_path):
         filenames = []
         if os.path.isfile(collection_path):
@@ -99,10 +118,10 @@ class JsonlCollectionIterator:
         all_info['id'] = []
         for filename in filenames:
             with open(filename) as f:
-                for line in tqdm(f):
+                for line_i, line in tqdm(enumerate(f)):
                     info = json.loads(line)
                     all_info['id'].append(str(info['id']))
-                    fields_info = info['contents'].split(self.delimiter)
+                    fields_info = self._parse_fields_from_contents(info['contents'])
                     if len(fields_info) != len(self.fields):
                         raise ValueError(
                             f"{len(fields_info)} fields are found at Line#{line_i} in file {filename}." \

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -102,7 +102,14 @@ class JsonlCollectionIterator:
                 for line in tqdm(f):
                     info = json.loads(line)
                     all_info['id'].append(str(info['id']))
-                    fields_info = info['contents'].rstrip().split(self.delimiter)
+                    fields_info = info['contents'].split(self.delimiter)
+                    if len(fields_info) != len(self.fields):
+                        raise ValueError(
+                            f"{len(fields_info)} fields are found at Line#{line_i} in file {filename}." \
+                            f"{len(self.fields)} fields expected." \
+                            f"Line content: {info['contents']}"
+                        )
+
                     for i in range(len(fields_info)):
                         all_info[self.fields[i]].append(fields_info[i])
         return all_info

--- a/tests/resources/simple_scifact.jsonl
+++ b/tests/resources/simple_scifact.jsonl
@@ -1,0 +1,3 @@
+{"id": "e275f643c97ca1f4c7715635bb72cf02df928d06", "contents": "From Databases to Big Data\n"}
+{"id": "bf003bb2d52304fea114d824bc0bf7bfbc7c3106", "contents": "Dissecting social engineering\n"}
+{"id": "50bc77f3ec070940b1923b823503a4c2b09e9921", "contents": "PHANTOM: A Scalable BlockDAG Protocol\n"}

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -144,6 +144,22 @@ class TestJsonlCollectionIterator(unittest.TestCase):
     def setUp(self):
         return
 
+    def test_missing_fields(self):
+        json_fn = 'tests/resources/simple_scifact.jsonl'
+        all_expected_info = [
+            ("e275f643c97ca1f4c7715635bb72cf02df928d06", "From Databases to Big Data", ""),
+            ("bf003bb2d52304fea114d824bc0bf7bfbc7c3106", "Dissecting social engineering", ""),
+            ("50bc77f3ec070940b1923b823503a4c2b09e9921", "PHANTOM: A Scalable BlockDAG Protocol", ""),
+        ]
+        collection_iterator = JsonlCollectionIterator(json_fn, ["title", "text"], delimiter="\n")
+        for i, info in enumerate(collection_iterator):
+            expected_info = all_expected_info[i]
+
+            self.assertEqual(expected_info[0], info["id"][0])
+            self.assertEqual(expected_info[1], info["title"][0])
+            self.assertEqual(expected_info[2], info["text"][0])
+
+
     def test_upper_lower_case(self):
         json_fn = 'tests/resources/simple_cacm_corpus.json'
         all_expected_info = [


### PR DESCRIPTION
… the delimiter before an empty field; add field length checking

To solve the issue that @NThakur20 met when encoding SciFact documents