### PR TITLE
Change topic reader from TsvIntTopicReader to TsvStringTopicReader for beir datasets

### DIFF
--- a/pyserini/query_iterator.py
+++ b/pyserini/query_iterator.py
@@ -84,6 +84,8 @@ class DefaultQueryIterator(QueryIterator):
             if topics_path.endswith('.json'):
                 with open(topics_path, 'r') as f:
                     topics = json.load(f)
+            elif "beir" in topics_path:
+                topics = get_topics_with_reader('io.anserini.search.topicreader.TsvStringTopicReader', topics_path)
             elif topics_path.endswith('.tsv') or topics_path.endswith('.tsv.gz'):
                 topics = get_topics_with_reader('io.anserini.search.topicreader.TsvIntTopicReader', topics_path)
             elif topics_path.endswith('.trec'):


### PR DESCRIPTION
BEIR datasets may contain string type topic ids. This throws an error with ``TsvIntTopicReader``.  
By default to work on this, we change our topic reader to ``TsvStringTopicReader`` for BEIR dataset evaluation.

Kind Regards,
Nandan Thakur