### PR TITLE
Installing Pre-built Indexes for MS MARCO V1/V2 doc2query-T5 w/ RM3 

### DIFF
--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -81,7 +81,11 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-v1-doc-d2q-t5</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-d2q-t5.20220201.9ea315.README.md">readme</a>]
-<dd>Lucene index of the MS MARCO V1 document corpus, with doc2query-T5 expansions.
+<dd>Lucene index of the MS MARCO V1 document corpus with doc2query-T5 expansions.
+</dd>
+<dt></dt><b><code>msmarco-v1-doc-d2q-t5-docvectors</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.README.md">readme</a>]
+<dd>Lucene index (+docvectors) of the MS MARCO V1 document corpus with doc2query-T5 expansions.
 </dd>
 <dt></dt><b><code>msmarco-v1-doc-segmented</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.README.md">readme</a>]
@@ -97,7 +101,11 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-v1-doc-segmented-d2q-t5</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-d2q-t5.20220201.9ea315.README.md">readme</a>]
-<dd>Lucene index of the MS MARCO V1 segmented document corpus, with doc2query-T5 expansions.
+<dd>Lucene index of the MS MARCO V1 segmented document corpus with doc2query-T5 expansions.
+</dd>
+<dt></dt><b><code>msmarco-v1-doc-segmented-d2q-t5-docvectors</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md">readme</a>]
+<dd>Lucene index (+docvectors) of the MS MARCO V1 segmented document corpus with doc2query-T5 expansions.
 </dd>
 <dt></dt><b><code>msmarco-v1-passage</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage.20220131.9ea315.README.md">readme</a>]
@@ -113,7 +121,11 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-v1-passage-d2q-t5</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-d2q-t5.20220201.9ea315.README.md">readme</a>]
-<dd>Lucene index of the MS MARCO V1 passage corpus, with doc2query-T5 expansions.
+<dd>Lucene index of the MS MARCO V1 passage corpus with doc2query-T5 expansions.
+</dd>
+<dt></dt><b><code>msmarco-v1-passage-d2q-t5-docvectors</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.README.md">readme</a>]
+<dd>Lucene index (+docvectors) of the MS MARCO V1 passage corpus with doc2query-T5 expansions.
 </dd>
 <dt></dt><b><code>msmarco-v2-doc</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc.20220111.06fb4f.README.md">readme</a>]
@@ -129,7 +141,11 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-v2-doc-d2q-t5</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-d2q-t5.20220201.9ea315.README.md">readme</a>]
-<dd>Lucene index of the MS MARCO V2 document corpus, with doc2query-T5 expansions.
+<dd>Lucene index of the MS MARCO V2 document corpus with doc2query-T5 expansions.
+</dd>
+<dt></dt><b><code>msmarco-v2-doc-d2q-t5-docvectors</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.README.md">readme</a>]
+<dd>Lucene index (+docvectors) of the MS MARCO V2 document corpus with doc2query-T5 expansions.
 </dd>
 <dt></dt><b><code>msmarco-v2-doc-segmented</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented.20220111.06fb4f.README.md">readme</a>]
@@ -145,7 +161,11 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-v2-doc-segmented-d2q-t5</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-d2q-t5.20220201.9ea315.README.md">readme</a>]
-<dd>Lucene index of the MS MARCO V2 segmented document corpus, with doc2query-T5 expansions.
+<dd>Lucene index of the MS MARCO V2 segmented document corpus with doc2query-T5 expansions.
+</dd>
+<dt></dt><b><code>msmarco-v2-doc-segmented-d2q-t5-docvectors</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md">readme</a>]
+<dd>Lucene index (+docvectors) of the MS MARCO V2 segmented document corpus with doc2query-T5 expansions.
 </dd>
 <dt></dt><b><code>msmarco-v2-passage</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage.20220111.06fb4f.README.md">readme</a>]
@@ -161,7 +181,11 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-v2-passage-d2q-t5</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-d2q-t5.20220201.9ea315.README.md">readme</a>]
-<dd>Lucene index of the MS MARCO V2 passage corpus, with doc2query-T5 expansions.
+<dd>Lucene index of the MS MARCO V2 passage corpus with doc2query-T5 expansions.
+</dd>
+<dt></dt><b><code>msmarco-v2-passage-d2q-t5-docvectors</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.README.md">readme</a>]
+<dd>Lucene index (+docvectors) of the MS MARCO V2 passage corpus with doc2query-T5 expansions.
 </dd>
 <dt></dt><b><code>msmarco-v2-passage-augmented</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-augmented.20220111.06fb4f.README.md">readme</a>]
@@ -177,7 +201,11 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 </dd>
 <dt></dt><b><code>msmarco-v2-passage-augmented-d2q-t5</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-augmented-d2q-t5.20220201.9ea315.README.md">readme</a>]
-<dd>Lucene index of the MS MARCO V2 augmented passage corpus, with doc2query-T5 expansions.
+<dd>Lucene index of the MS MARCO V2 augmented passage corpus with doc2query-T5 expansions.
+</dd>
+<dt></dt><b><code>msmarco-v2-passage-augmented-d2q-t5-docvectors</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.README.md">readme</a>]
+<dd>Lucene index (+docvectors) of the MS MARCO V2 augmented passage corpus with doc2query-T5 expansions.
 </dd>
 <dt></dt><b><code>enwiki-paragraphs</code></b>
 <dd>Lucene index of English Wikipedia for BERTserini
@@ -575,8 +603,8 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 <dd>Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL.
 </dd>
 <dt></dt><b><code>msmarco-v1-doc-segmented-unicoil-noexp</code></b>
-[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220322.2f4058.README.md">readme</a>]
-<dd>Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL (noexp).
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-unicoil-noexp.20220419.c47993.README.md">readme</a>]
+<dd>Lucene impact index of the MS MARCO V1 segmented document corpus for uniCOIL (noexp) with title prepended.
 </dd>
 <dt></dt><b><code>msmarco-v2-passage-unicoil-0shot</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-unicoil-0shot.20220219.6a7080.README.md">readme</a>]
@@ -590,9 +618,17 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot.20220219.6a7080.README.md">readme</a>]
 <dd>Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL.
 </dd>
+<dt></dt><b><code>msmarco-v2-doc-segmented-unicoil-0shot-v2</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2.20220419.c47993.README.md">readme</a>]
+<dd>Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL, with title prepended.
+</dd>
 <dt></dt><b><code>msmarco-v2-doc-segmented-unicoil-noexp-0shot</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot.20220219.6a7080.README.md">readme</a>]
 <dd>Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL (noexp).
+</dd>
+<dt></dt><b><code>msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.20220419.c47993.README.md">readme</a>]
+<dd>Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL (noexp) with title prepended
 </dd>
 <dt></dt><b><code>msmarco-passage-deepimpact</code></b>
 [<a href="../pyserini/resources/index-metadata/lucene-index.msmarco-passage.deepimpact.20211012.58d286.readme.txt">readme</a>]

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -133,7 +133,7 @@ TF_INDEX_INFO = {
 
     # MS MARCO V1 document corpus, doc2query-T5 expansions.
     "msmarco-v1-doc-d2q-t5": {
-        "description": "Lucene index of the MS MARCO V1 document corpus, with doc2query-T5 expansions.",
+        "description": "Lucene index of the MS MARCO V1 document corpus with doc2query-T5 expansions.",
         "filename": "lucene-index.msmarco-v1-doc-d2q-t5.20220201.9ea315.tar.gz",
         "readme": "lucene-index.msmarco-v1-doc-d2q-t5.20220201.9ea315.README.md",
         "urls": [
@@ -142,6 +142,20 @@ TF_INDEX_INFO = {
         ],
         "md5": "37c639c9c26a34d2612ea6549fb866df",
         "size compressed (bytes)": 1904879520,
+        "total_terms": 3748333319,
+        "documents": 3213835,
+        "unique_terms": 30627687,
+        "downloaded": False
+    },
+    "msmarco-v1-doc-d2q-t5-docvectors": {
+        "description": "Lucene index (+docvectors) of the MS MARCO V1 document corpus with doc2query-T5 expansions.",
+        "filename": "lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        "readme": "lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        ],
+        "md5": "987088270d4df2d51bcdffb1588f6915",
+        "size compressed (bytes)": 11169880136,
         "total_terms": 3748333319,
         "documents": 3213835,
         "unique_terms": 30627687,
@@ -197,7 +211,7 @@ TF_INDEX_INFO = {
 
     # MS MARCO V1 segmented document corpus, doc2query-T5 expansions.
     "msmarco-v1-doc-segmented-d2q-t5": {
-        "description": "Lucene index of the MS MARCO V1 segmented document corpus, with doc2query-T5 expansions.",
+        "description": "Lucene index of the MS MARCO V1 segmented document corpus with doc2query-T5 expansions.",
         "filename": "lucene-index.msmarco-v1-doc-segmented-d2q-t5.20220201.9ea315.tar.gz",
         "readme": "lucene-index.msmarco-v1-doc-segmented-d2q-t5.20220201.9ea315.README.md",
         "urls": [
@@ -206,6 +220,20 @@ TF_INDEX_INFO = {
         ],
         "md5": "6c1f86ee4f7175eed4d3a7acc3d567b8",
         "size compressed (bytes)": 3638703522,
+        "total_terms": 4206639543,
+        "documents": 20545677,
+        "unique_terms": 22054207,
+        "downloaded": False
+    },
+    "msmarco-v1-doc-segmented-d2q-t5-docvectors": {
+        "description": "Lucene index (+docvectors) of the MS MARCO V1 segmented document corpus with doc2query-T5 expansions.",
+        "filename": "lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        "readme": "lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        ],
+        "md5": "a67e6854187f084a8a3eee11dd30bc31",
+        "size compressed (bytes)": 16627681594,
         "total_terms": 4206639543,
         "documents": 20545677,
         "unique_terms": 22054207,
@@ -261,7 +289,7 @@ TF_INDEX_INFO = {
 
     # MS MARCO V1 passage corpus, doc2query-T5 expansions.
     "msmarco-v1-passage-d2q-t5": {
-        "description": "Lucene index of the MS MARCO V1 passage corpus, with doc2query-T5 expansions.",
+        "description": "Lucene index of the MS MARCO V1 passage corpus with doc2query-T5 expansions.",
         "filename": "lucene-index.msmarco-v1-passage-d2q-t5.20220201.9ea315.tar.gz",
         "readme": "lucene-index.msmarco-v1-passage-d2q-t5.20220201.9ea315.README.md",
         "urls": [
@@ -270,6 +298,20 @@ TF_INDEX_INFO = {
         ],
         "md5": "136205f35bd895077c0874eaa063376c",
         "size compressed (bytes)": 819441969,
+        "total_terms": 1986612263,
+        "documents": 8841823,
+        "unique_terms": 3929111,
+        "downloaded": False
+    },
+    "msmarco-v1-passage-d2q-t5-docvectors": {
+        "description": "Lucene index (+docvectors) of the MS MARCO V1 passage corpus with doc2query-T5 expansions.",
+        "filename": "lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        "readme": "lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        ],
+        "md5": "5eb8178e48a4a9b85714be156d85b2d1",
+        "size compressed (bytes)": 4433982542,
         "total_terms": 1986612263,
         "documents": 8841823,
         "unique_terms": 3929111,
@@ -325,7 +367,7 @@ TF_INDEX_INFO = {
 
     # MS MARCO V2 document corpus, doc2query-T5 expansions.
     "msmarco-v2-doc-d2q-t5": {
-        "description": "Lucene index of the MS MARCO V2 document corpus, with doc2query-T5 expansions.",
+        "description": "Lucene index of the MS MARCO V2 document corpus with doc2query-T5 expansions.",
         "filename": "lucene-index.msmarco-v2-doc-d2q-t5.20220201.9ea315.tar.gz",
         "readme": "lucene-index.msmarco-v2-doc-d2q-t5.20220201.9ea315.README.md",
         "urls": [
@@ -334,6 +376,20 @@ TF_INDEX_INFO = {
         ],
         "md5": "431391554854c51f347ba38c5e07ef94",
         "size compressed (bytes)": 8254297093,
+        "total_terms": 19760777295,
+        "documents": 11959635,
+        "unique_terms": 54143053,
+        "downloaded": False
+    },
+    "msmarco-v2-doc-d2q-t5-docvectors": {
+        "description": "Lucene index (+docvectors) of the MS MARCO V2 document corpus with doc2query-T5 expansions.",
+        "filename": "lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        "readme": "lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        ],
+        "md5": "200176909cd31d750919f38410f20b8a",
+        "size compressed (bytes)": 54511069668,
         "total_terms": 19760777295,
         "documents": 11959635,
         "unique_terms": 54143053,
@@ -386,7 +442,7 @@ TF_INDEX_INFO = {
 
     # MS MARCO V2 segmented document corpus, doc2query-T5 expansions.
     "msmarco-v2-doc-segmented-d2q-t5": {
-        "description": "Lucene index of the MS MARCO V2 segmented document corpus, with doc2query-T5 expansions.",
+        "description": "Lucene index of the MS MARCO V2 segmented document corpus with doc2query-T5 expansions.",
         "filename": "lucene-index.msmarco-v2-doc-segmented-d2q-t5.20220201.9ea315.tar.gz",
         "readme": "lucene-index.msmarco-v2-doc-segmented-d2q-t5.20220201.9ea315.README.md",
         "urls": [
@@ -395,6 +451,20 @@ TF_INDEX_INFO = {
         ],
         "md5": "3ce9eaca885e1e8a79466bee5e6a4084",
         "size compressed (bytes)": 24125355549,
+        "total_terms": 30376032067,
+        "documents": 124131414,
+        "unique_terms": 38930475,
+        "downloaded": False
+    },
+    "msmarco-v2-doc-segmented-d2q-t5-docvectors": {
+        "description": "Lucene index (+docvectors) of the MS MARCO V2 segmented document corpus with doc2query-T5 expansions.",
+        "filename": "lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        "readme": "lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        ],
+        "md5": "d7fd3d9fbca6ca0b5ffeb8b824db0cd7",
+        "size compressed (bytes)": 114312032964,
         "total_terms": 30376032067,
         "documents": 124131414,
         "unique_terms": 38930475,
@@ -447,7 +517,7 @@ TF_INDEX_INFO = {
 
     # MS MARCO V2 passage corpus, doc2query-T5 expansions.
     "msmarco-v2-passage-d2q-t5": {
-        "description": "Lucene index of the MS MARCO V2 passage corpus, with doc2query-T5 expansions.",
+        "description": "Lucene index of the MS MARCO V2 passage corpus with doc2query-T5 expansions.",
         "filename": "lucene-index.msmarco-v2-passage-d2q-t5.20220201.9ea315.tar.gz",
         "readme": "lucene-index.msmarco-v2-passage-d2q-t5.20220201.9ea315.README.md",
         "urls": [
@@ -456,6 +526,20 @@ TF_INDEX_INFO = {
         ],
         "md5": "72f3f0f56b9c7a1bdff836419f2f30bd",
         "size compressed (bytes)": 14431987438,
+        "total_terms": 16961479226,
+        "documents": 138364198,
+        "unique_terms": 36650715,
+        "downloaded": False
+    },
+    "msmarco-v2-passage-d2q-t5-docvectors": {
+        "description": "Lucene index (+docvectors) of the MS MARCO V2 passage corpus with doc2query-T5 expansions.",
+        "filename": "lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        "readme": "lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        ],
+        "md5": "e0ed749284f67db1f0890cb709ecb690",
+        "size compressed (bytes)": 59320157969,
         "total_terms": 16961479226,
         "documents": 138364198,
         "unique_terms": 36650715,
@@ -508,7 +592,7 @@ TF_INDEX_INFO = {
 
     # MS MARCO V2 augmented passage corpus, doc2query-T5 expansions.
     "msmarco-v2-passage-augmented-d2q-t5": {
-        "description": "Lucene index of the MS MARCO V2 augmented passage corpus, with doc2query-T5 expansions.",
+        "description": "Lucene index of the MS MARCO V2 augmented passage corpus with doc2query-T5 expansions.",
         "filename": "lucene-index.msmarco-v2-passage-augmented-d2q-t5.20220201.9ea315.tar.gz",
         "readme": "lucene-index.msmarco-v2-passage-augmented-d2q-t5.20220201.9ea315.README.md",
         "urls": [
@@ -517,6 +601,20 @@ TF_INDEX_INFO = {
         ],
         "md5": "f248becbe3ef3fffc39680cff417791d",
         "size compressed (bytes)": 20940452572,
+        "total_terms": 27561177420,
+        "documents": 138364198,
+        "unique_terms": 41176227,
+        "downloaded": False
+    },
+    "msmarco-v2-passage-augmented-d2q-t5-docvectors": {
+        "description": "Lucene index (+docvectors) of the MS MARCO V2 augmented passage corpus with doc2query-T5 expansions.",
+        "filename": "lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        "readme": "lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/pyserini-indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
+        ],
+        "md5": "8fc1cc2b71331772ff7b306cd62794f6",
+        "size compressed (bytes)": 96122355388,
         "total_terms": 27561177420,
         "documents": 138364198,
         "unique_terms": 41176227,

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.README.md
@@ -1,0 +1,16 @@
+# msmarco-v1-doc-d2q-t5-docvectors
+
+Lucene index (+docvectors) of the MS MARCO V1 document corpus, with doc2query-T5 expansions.
+
+This index was generated on 2022/05/25 at Anserini commit [`30c997`](https://github.com/castorini/anserini/commit/30c9974f495a06c94d576d0e9c2c5861515e0e19) on `damiano` with the following command:
+
+```
+target/appassembler/bin/IndexCollection -collection JsonCollection \
+  -generator DefaultLuceneDocumentGenerator -threads 7 \
+  -input /scratch2/collections/msmarco/msmarco-doc-docTTTTTquery/ \
+  -index indexes/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997/ \
+  -storeDocvectors -optimize
+```
+
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.README.md
@@ -12,5 +12,5 @@ target/appassembler/bin/IndexCollection -collection JsonCollection \
   -storeDocvectors -optimize
 ```
 
-Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but not phrase queries.
 The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
@@ -1,0 +1,16 @@
+# msmarco-v1-doc-segmented-d2q-t5-docvectors
+
+Lucene index (+docvectors) of the MS MARCO V1 segmented document corpus, with doc2query-T5 expansions.
+
+This index was generated on 2022/05/25 at Anserini commit [`30c997`](https://github.com/castorini/anserini/commit/30c9974f495a06c94d576d0e9c2c5861515e0e19) on `damiano` with the following command:
+
+```
+target/appassembler/bin/IndexCollection -collection JsonCollection \
+  -generator DefaultLuceneDocumentGenerator -threads 32 \
+  -input /scratch2/collections/msmarco/msmarco-doc-segmented-docTTTTTquery/ \
+  -index indexes/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997/ \
+  -storeDocvectors -optimize
+```
+
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
@@ -12,5 +12,5 @@ target/appassembler/bin/IndexCollection -collection JsonCollection \
   -storeDocvectors -optimize
 ```
 
-Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but not phrase queries.
 The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.README.md
@@ -1,0 +1,16 @@
+# msmarco-v1-passage-d2q-t5-docvectors
+
+Lucene index (+docvectors) of the MS MARCO V1 passage corpus, with doc2query-T5 expansions.
+
+This index was generated on 2022/05/25 at Anserini commit [`30c997`](https://github.com/castorini/anserini/commit/30c9974f495a06c94d576d0e9c2c5861515e0e19) on `damiano` with the following command:
+
+```
+target/appassembler/bin/IndexCollection -collection JsonCollection \
+  -generator DefaultLuceneDocumentGenerator -threads 18 \
+  -input /scratch2/collections/msmarco/msmarco-passage-docTTTTTquery/ \
+  -index indexes/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997/ \
+  -storeDocvectors -optimize
+```
+
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.README.md
@@ -12,5 +12,5 @@ target/appassembler/bin/IndexCollection -collection JsonCollection \
   -storeDocvectors -optimize
 ```
 
-Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but not phrase queries.
 The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.README.md
@@ -1,0 +1,16 @@
+# msmarco-v2-doc-d2q-t5-docvectors
+
+Lucene index (+docvectors) of the MS MARCO V2 document corpus, with doc2query-T5 expansions.
+
+This index was generated on 2022/05/25 at Anserini commit [`30c997`](https://github.com/castorini/anserini/commit/30c9974f495a06c94d576d0e9c2c5861515e0e19) on `damiano` with the following command:
+
+```
+target/appassembler/bin/IndexCollection -collection MsMarcoV2DocCollection \
+  -generator DefaultLuceneDocumentGenerator -threads 24 \
+  -input /scratch2/collections/msmarco/msmarco_v2_doc_d2q-t5/ \
+  -index indexes/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997/ \
+  -storeDocvectors -optimize
+```
+
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.README.md
@@ -12,5 +12,5 @@ target/appassembler/bin/IndexCollection -collection MsMarcoV2DocCollection \
   -storeDocvectors -optimize
 ```
 
-Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but not phrase queries.
 The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
@@ -12,5 +12,5 @@ target/appassembler/bin/IndexCollection -collection MsMarcoV2DocCollection \
   -storeDocvectors -optimize
 ```
 
-Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but not phrase queries.
 The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md
@@ -1,0 +1,16 @@
+# msmarco-v2-doc-segmented-d2q-t5-docvectors
+
+Lucene index (+docvectors) of the MS MARCO V2 segmented document corpus, with doc2query-T5 expansions.
+
+This index was generated on 2022/05/25 at Anserini commit [`30c997`](https://github.com/castorini/anserini/commit/30c9974f495a06c94d576d0e9c2c5861515e0e19) on `damiano` with the following command:
+
+```
+target/appassembler/bin/IndexCollection -collection MsMarcoV2DocCollection \
+  -generator DefaultLuceneDocumentGenerator -threads 24 \
+  -input /scratch2/collections/msmarco/msmarco_v2_doc_segmented_d2q-t5/ \
+  -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997/ \
+  -storeDocvectors -optimize
+```
+
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.README.md
@@ -1,0 +1,16 @@
+# msmarco-v2-passage-augmented-d2q-t5-docvectors
+
+Lucene index (+docvectors) of the MS MARCO V2 augmented passage corpus, with doc2query-T5 expansions.
+
+This index was generated on 2022/05/25 at Anserini commit [`30c997`](https://github.com/castorini/anserini/commit/30c9974f495a06c94d576d0e9c2c5861515e0e19) on `damiano` with the following command:
+
+```
+target/appassembler/bin/IndexCollection -collection MsMarcoV2PassageCollection \
+  -generator DefaultLuceneDocumentGenerator -threads 18 \
+  -input /scratch2/collections/msmarco/msmarco_v2_passage_augmented_d2q-t5/ \
+  -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997/ \
+  -storeDocvectors -optimize
+```
+
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.README.md
@@ -12,5 +12,5 @@ target/appassembler/bin/IndexCollection -collection MsMarcoV2PassageCollection \
   -storeDocvectors -optimize
 ```
 
-Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but not phrase queries.
 The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.README.md
@@ -1,0 +1,16 @@
+# msmarco-v2-passage-d2q-t5-docvectors
+
+Lucene index (+docvectors) of the MS MARCO V2 passage corpus, with doc2query-T5 expansions.
+
+This index was generated on 2022/05/25 at Anserini commit [`30c997`](https://github.com/castorini/anserini/commit/30c9974f495a06c94d576d0e9c2c5861515e0e19) on `damiano` with the following command:
+
+```
+target/appassembler/bin/IndexCollection -collection MsMarcoV2PassageCollection \
+  -generator DefaultLuceneDocumentGenerator -threads 18 \
+  -input /scratch2/collections/msmarco/msmarco_v2_passage_d2q-t5/ \
+  -index indexes/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997/ \
+  -storeDocvectors -optimize
+```
+
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+The raw text is not stored.

--- a/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.README.md
@@ -12,5 +12,5 @@ target/appassembler/bin/IndexCollection -collection MsMarcoV2PassageCollection \
   -storeDocvectors -optimize
 ```
 
-Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but no phrase queries.
+Note that this index stores term frequencies along with the docvectors: bag-of-words queries and relevance feedback are supported, but not phrase queries.
 The raw text is not stored.


### PR DESCRIPTION
This is the missing row in our repro matrix for our SIGIR 2022 paper.