### PR TITLE
Change trec_eval output spacing back to previous alignment

### DIFF
--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -81,7 +81,8 @@ if len(args) > 1:
     for cutoff in cutoffs:
         run_cutoff = run.groupby(0).head(cutoff)
         judged = len(pd.merge(run_cutoff[[0,2]], qrels[[0,2]], on = [0,2])) / len(run_cutoff)
-        judged_result.append(f'judged_{cutoff}\tall\t{judged:.4f}')
+        metric_name = f'judged_{cutoff}'
+        judged_result.append(f'{metric_name:22}\tall\t{judged:.4f}')
     cmd = cmd_prefix + args[1:]
 else:
     cmd = cmd_prefix
@@ -97,11 +98,7 @@ if stderr:
     print(stderr.decode("utf-8"))
 
 print('Results:')
-results = stdout.decode("utf-8")
-# Clean up the formatting of trec_eval output.
-results = results.rstrip()
-results = re.sub(re.compile('[ \\t]+'), '\t', results)
-print(results)
+print(stdout.decode("utf-8").rstrip())
 
 for judged in judged_result:
     print(judged)

--- a/tests/resources/simple_trec_run_unjudged_keep.txt
+++ b/tests/resources/simple_trec_run_unjudged_keep.txt
@@ -1,3 +1,5 @@
 Results:
-ndcg_cut_5	all	0.0848
-ndcg_cut_10	all	0.0550
+ndcg_cut_5            	all	0.0848
+ndcg_cut_10           	all	0.0550
+judged_5              	all	0.5000
+judged_10             	all	0.5000

--- a/tests/resources/simple_trec_run_unjudged_remove.txt
+++ b/tests/resources/simple_trec_run_unjudged_remove.txt
@@ -1,3 +1,5 @@
 Results:
-ndcg_cut_5	all	0.1131
-ndcg_cut_10	all	0.0734
+ndcg_cut_5            	all	0.1131
+ndcg_cut_10           	all	0.0734
+judged_5              	all	1.0000
+judged_10             	all	1.0000

--- a/tests/test_trectools.py
+++ b/tests/test_trectools.py
@@ -83,8 +83,8 @@ class TestTrecTools(unittest.TestCase):
         qrels_path = os.path.join(self.root, 'tools/topics-and-qrels/qrels.covid-round1.txt')
         run_path = os.path.join(self.root, 'tests/resources/simple_trec_run_filter.txt')
         results = subprocess.check_output(
-            f'python -m pyserini.eval.trec_eval -m ndcg_cut.5,10 {qrels_path} {run_path}', shell=True)
-        results = '\n'.join(results.decode('utf-8').split('\n')[-4:])
+            f'python -m pyserini.eval.trec_eval -m ndcg_cut.5,10 -m judged.5,10 {qrels_path} {run_path}', shell=True)
+        results = '\n'.join(results.decode('utf-8').split('\n')[-6:])
         with open(self.output_path, 'w') as writer:
             writer.write(results)
         self.assertTrue(filecmp.cmp(os.path.join(self.root, 'tests/resources/simple_trec_run_unjudged_keep.txt'),
@@ -94,8 +94,8 @@ class TestTrecTools(unittest.TestCase):
         qrels_path = os.path.join(self.root, 'tools/topics-and-qrels/qrels.covid-round1.txt')
         run_path = os.path.join(self.root, 'tests/resources/simple_trec_run_filter.txt')
         results = subprocess.check_output(
-            f'python -m pyserini.eval.trec_eval -m ndcg_cut.5,10 {qrels_path} {run_path} -remove-unjudged', shell=True)
-        results = '\n'.join(results.decode('utf-8').split('\n')[-4:])
+            f'python -m pyserini.eval.trec_eval -m ndcg_cut.5,10 -m judged.5,10 {qrels_path} {run_path} -remove-unjudged', shell=True)
+        results = '\n'.join(results.decode('utf-8').split('\n')[-6:])
         with open(self.output_path, 'w') as writer:
             writer.write(results)
         self.assertTrue(filecmp.cmp(os.path.join(self.root, 'tests/resources/simple_trec_run_unjudged_remove.txt'),


### PR DESCRIPTION
In #1184, I tweaked the spacing of `trec_eval` metrics, but the spacing looks worse now. Reverts back to original format, but makes judged@k metric outputs to look the same.
