### PR TITLE
Quick bug fix with trev_eval

### DIFF
--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -69,6 +69,11 @@ if len(args) > 1:
 
     run = pd.read_csv(args[-1], delim_whitespace=True, header=None)
     qrels = pd.read_csv(args[-2], delim_whitespace=True, header=None)
+    
+    # cast doc_id column as string
+    run[0] = run[0].astype(str)
+    qrels[0] = qrels[0].astype(str)
+
     # Discard non-judged hits
     if judged_docs_only:
         if not temp_file:


### PR DESCRIPTION
Cast the doc_id column as a string to fix the bug below

```
Traceback (most recent call last):
  File "/home/ogundepo/anaconda3/envs/pyserini/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/ogundepo/anaconda3/envs/pyserini/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/ogundepo/anaconda3/envs/pyserini/lib/python3.8/site-packages/pyserini/eval/trec_eval.py", line 83, in <module>
    judged = len(pd.merge(run_cutoff[[0,2]], qrels[[0,2]], on = [0,2])) / len(run_cutoff)
  File "/home/ogundepo/.local/lib/python3.8/site-packages/pandas/core/reshape/merge.py", line 107, in merge
    op = _MergeOperation(
  File "/home/ogundepo/.local/lib/python3.8/site-packages/pandas/core/reshape/merge.py", line 704, in __init__
    self._maybe_coerce_merge_keys()
  File "/home/ogundepo/.local/lib/python3.8/site-packages/pandas/core/reshape/merge.py", line 1257, in _maybe_coerce_merge_keys
    raise ValueError(msg)
ValueError: You are trying to merge on int64 and object columns. If you wish to proceed you should use pd.concat
```