### PR TITLE
Add ability to extract feedback terms

### DIFF
--- a/pyserini/search/lucene/_searcher.py
+++ b/pyserini/search/lucene/_searcher.py
@@ -198,6 +198,26 @@ class LuceneSearcher:
                 results = self.object.batch_search_fields(query_strings, qid_strings, int(k), int(threads), jfields)
         return {r.getKey(): r.getValue() for r in results.entrySet().toArray()}
 
+    def get_feedback_terms(self, q: str) -> Dict[str, float]:
+        """Returns feedback terms and their weights.
+
+        Parameters
+        ----------
+        q : str
+            Query string or the ``JQuery`` objected.
+
+        Returns
+        -------
+        Dict[str, float]
+            Feedback terms and their weights.
+        """
+
+        terms_map = self.object.get_feedback_terms(q)
+        if terms_map:
+            return {r.getKey(): r.getValue() for r in terms_map.entrySet().toArray()}
+        else:
+            return None
+
     def set_analyzer(self, analyzer):
         """Set the Java ``Analyzer`` to use.
 
@@ -212,8 +232,8 @@ class LuceneSearcher:
         """Set language of LuceneSearcher"""
         self.object.set_language(language)
 
-    def set_rm3(self, fb_terms=10, fb_docs=10, original_query_weight=float(0.5), rm3_output_query=False, rm3_filter_terms=True):
-        """Configure RM3 query expansion.
+    def set_rm3(self, fb_terms=10, fb_docs=10, original_query_weight=float(0.5), debug=False, filter_terms=True):
+        """Configure RM3 pseudo-relevance feedback.
 
         Parameters
         ----------
@@ -223,26 +243,27 @@ class LuceneSearcher:
             RM3 parameter for number of expansion documents.
         original_query_weight : float
             RM3 parameter for weight to assign to the original query.
-        rm3_output_query : bool
+        debug : bool
             Print the original and expanded queries as debug output.
-        rm3_filter_terms: bool
+        filter_terms: bool
             Whether to remove non-English terms.
         """
         if self.object.reader.getTermVectors(0):
-            self.object.set_rm3(fb_terms, fb_docs, original_query_weight, rm3_output_query, rm3_filter_terms)
+            self.object.set_rm3(fb_terms, fb_docs, original_query_weight, debug, filter_terms)
         else:
             raise TypeError("RM3 is not supported for indexes without document vectors.")
 
     def unset_rm3(self):
-        """Disable RM3 query expansion."""
+        """Disable RM3 pseudo-relevance feedback."""
         self.object.unset_rm3()
 
     def is_using_rm3(self) -> bool:
-        """Check if RM3 query expansion is being performed."""
+        """Check if RM3 pseudo-relevance feedback is being performed."""
         return self.object.use_rm3()
     
-    def set_rocchio(self, top_fb_terms=10, top_fb_docs=10, bottom_fb_terms=10, bottom_fb_docs=10, alpha=1, beta=0.75, gamma=0, output_query=False, use_negative=False):
-        """Configure Rocchio query expansion.
+    def set_rocchio(self, top_fb_terms=10, top_fb_docs=10, bottom_fb_terms=10, bottom_fb_docs=10,
+                    alpha=1, beta=0.75, gamma=0, debug=False, use_negative=False):
+        """Configure Rocchio pseudo-relevance feedback.
 
         Parameters
         ----------
@@ -254,28 +275,29 @@ class LuceneSearcher:
             Rocchio parameter for number of nonrelevant expansion terms.
         bottom_fb_docs : int
             Rocchio parameter for number of nonrelevant expansion documents.
-        rocchio_alpha : float
+        alpha : float
             Rocchio parameter for weight to assign to the original query.
-        rocchio_beta: float
+        beta: float
             Rocchio parameter for weight to assign to the relevant document vector.
-        rocchio_gamma: float
+        gamma: float
             Rocchio parameter for weight to assign to the nonrelevant document vector.
-        rocchio_output_query : bool
+        debug : bool
             Print the original and expanded queries as debug output.
-        rocchio_use_negative : bool
+        use_negative : bool
             Rocchio parameter to use negative labels.
         """
         if self.object.reader.getTermVectors(0):
-            self.object.set_rocchio(top_fb_terms, top_fb_docs, bottom_fb_terms, bottom_fb_docs, alpha, beta, gamma, output_query, use_negative)
+            self.object.set_rocchio(top_fb_terms, top_fb_docs, bottom_fb_terms, bottom_fb_docs,
+                                    alpha, beta, gamma, debug, use_negative)
         else:
             raise TypeError("Rocchio is not supported for indexes without document vectors.")
 
     def unset_rocchio(self):
-        """Disable Rocchio query expansion."""
+        """Disable Rocchio pseudo-relevance feedback."""
         self.object.unset_rocchio()
 
     def is_using_rocchio(self) -> bool:
-        """Check if Rocchio query expansion is being performed."""
+        """Check if Rocchio pseudo-relevance feedback is being performed."""
         return self.object.use_rocchio()
 
     def set_qld(self, mu=float(1000)):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -212,12 +212,17 @@ class TestSearch(unittest.TestCase):
         hits = self.searcher.search('information retrieval')
 
         self.assertEqual(hits[0].docid, 'CACM-3134')
-        self.assertAlmostEqual(hits[0].score, 2.18010, places=5)
+        self.assertAlmostEqual(hits[0].score, 2.17350, places=5)
         self.assertEqual(hits[9].docid, 'CACM-2516')
-        self.assertAlmostEqual(hits[9].score, 1.70330, places=5)
+        self.assertAlmostEqual(hits[9].score, 1.70180, places=5)
+
+        feedback_terms = self.searcher.get_feedback_terms('information retrieval')
+        self.assertEqual(len(feedback_terms), 10)
+        self.assertAlmostEqual(feedback_terms['storag'], 0.024701, places=5)
 
         self.searcher.unset_rm3()
         self.assertFalse(self.searcher.is_using_rm3())
+        self.assertIsNone(self.searcher.get_feedback_terms('information retrieval'))
 
         hits = self.searcher.search('information retrieval')
 
@@ -232,9 +237,9 @@ class TestSearch(unittest.TestCase):
         hits = self.searcher.search('information retrieval')
 
         self.assertEqual(hits[0].docid, 'CACM-3134')
-        self.assertAlmostEqual(hits[0].score, 2.17190, places=5)
+        self.assertAlmostEqual(hits[0].score, 2.17150, places=5)
         self.assertEqual(hits[9].docid, 'CACM-1457')
-        self.assertAlmostEqual(hits[9].score, 1.43700, places=5)
+        self.assertAlmostEqual(hits[9].score, 1.45560, places=5)
 
         with self.assertRaises(TypeError):
             self.no_vec_searcher.set_rm3()
@@ -251,8 +256,13 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(hits[9].docid, 'CACM-2140')
         self.assertAlmostEqual(hits[9].score, 5.57970, places=5)
 
+        feedback_terms = self.searcher.get_feedback_terms('information retrieval')
+        self.assertEqual(len(feedback_terms), 10)
+        self.assertAlmostEqual(feedback_terms['storag'], 0.132200, places=5)
+
         self.searcher.unset_rocchio()
         self.assertFalse(self.searcher.is_using_rocchio())
+        self.assertIsNone(self.searcher.get_feedback_terms('information retrieval'))
 
         hits = self.searcher.search('information retrieval')
 
@@ -263,7 +273,7 @@ class TestSearch(unittest.TestCase):
 
         self.searcher.set_rocchio(top_fb_terms=10, top_fb_docs=8, bottom_fb_terms=10,
                                   bottom_fb_docs=8, alpha=0.4, beta=0.5, gamma=0.1,
-                                  output_query=False, use_negative=True)
+                                  debug=False, use_negative=True)
         self.assertTrue(self.searcher.is_using_rocchio())
 
         hits = self.searcher.search('information retrieval')
@@ -275,7 +285,7 @@ class TestSearch(unittest.TestCase):
 
         self.searcher.set_rocchio(top_fb_terms=10, top_fb_docs=8, bottom_fb_terms=10,
                                   bottom_fb_docs=8, alpha=0.4, beta=0.5, gamma=0.1,
-                                  output_query=False, use_negative=False)
+                                  debug=False, use_negative=False)
         self.assertTrue(self.searcher.is_using_rocchio())
 
         hits = self.searcher.search('information retrieval')

--- a/tests/test_search_lucene8.py
+++ b/tests/test_search_lucene8.py
@@ -244,7 +244,7 @@ class TestSearch(unittest.TestCase):
 
         self.searcher.set_rocchio(top_fb_terms=10, top_fb_docs=8, bottom_fb_terms=10,
                                   bottom_fb_docs=8, alpha=0.4, beta=0.5, gamma=0.1,
-                                  output_query=False, use_negative=True)
+                                  debug=False, use_negative=True)
         self.assertTrue(self.searcher.is_using_rocchio())
 
         hits = self.searcher.search('information retrieval')
@@ -256,7 +256,7 @@ class TestSearch(unittest.TestCase):
 
         self.searcher.set_rocchio(top_fb_terms=10, top_fb_docs=8, bottom_fb_terms=10,
                                   bottom_fb_docs=8, alpha=0.4, beta=0.5, gamma=0.1,
-                                  output_query=False, use_negative=False)
+                                  debug=False, use_negative=False)
         self.assertTrue(self.searcher.is_using_rocchio())
 
         hits = self.searcher.search('information retrieval')


### PR DESCRIPTION
Ref https://github.com/castorini/anserini/pull/1979
Exposes hooks from Anserini.

Sample code:

```python
from pyserini.search.lucene import LuceneSearcher

# RM3
searcher = LuceneSearcher.from_prebuilt_index('robust04')
searcher.set_rm3(debug=True)
hits = searcher.search('hubble space telescope')

for i in range(0, 10):
    print(f'{i+1:2} {hits[i].docid:7} {hits[i].score:.5f}')

feedback_terms = searcher.get_feedback_terms('hubble space telescope')

# Rocchio
searcher = LuceneSearcher.from_prebuilt_index('robust04')
searcher.set_rocchio(debug=True)
hits = searcher.search('hubble space telescope')

for i in range(0, 10):
    print(f'{i+1:2} {hits[i].docid:7} {hits[i].score:.5f}')

feedback_terms = searcher.get_feedback_terms('hubble space telescope')
```

cc/  @ola13