### PR TITLE
MIRACL BM25 scores fix

### DIFF
--- a/docs/2cr/miracl.html
+++ b/docs/2cr/miracl.html
@@ -137,7 +137,7 @@ pre[class*="prettyprint"] {
     <thead>
       <tr>
         <th scope="col"></th>
-        <th scope="col">nDCG, dev queries</th>
+        <th scope="col">nDCG@10, dev queries</th>
         <th scope="col">ar</th>
         <th scope="col">bn</th>
         <th scope="col">en</th>
@@ -164,24 +164,24 @@ pre[class*="prettyprint"] {
 <tr class="accordion-toggle collapsed" id="table1-row1" data-toggle="collapse" data-parent="#table1-row1" href="#table1-collapse1">
 <td class="expand-button"></td>
 <td>BM25</td>
-<td>0.553</td>
-<td>0.577</td>
+<td>0.481</td>
+<td>0.508</td>
+<td>0.351</td>
+<td>0.319</td>
+<td>0.333</td>
+<td>0.551</td>
+<td>0.183</td>
 <td>0.458</td>
-<td>0.434</td>
-<td>0.408</td>
-<td>0.609</td>
-<td>0.280</td>
-<td>0.533</td>
-<td>0.571</td>
-<td>0.450</td>
-<td>0.504</td>
-<td>0.410</td>
-<td>0.436</td>
-<td>0.529</td>
-<td>0.528</td>
-<td>0.260</td>
+<td>0.449</td>
+<td>0.369</td>
+<td>0.419</td>
+<td>0.334</td>
+<td>0.383</td>
+<td>0.494</td>
+<td>0.484</td>
+<td>0.180</td>
 <td></td>
-<td>0.471</td>
+<td>0.393</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -259,7 +259,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-ar-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-ar-dev.tsv \
   run.miracl.bm25.ar.dev.txt</code></pre>
   </blockquote>
 
@@ -279,7 +279,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-bn-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-bn-dev.tsv \
   run.miracl.bm25.bn.dev.txt</code></pre>
   </blockquote>
 
@@ -299,7 +299,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-en-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-en-dev.tsv \
   run.miracl.bm25.en.dev.txt</code></pre>
   </blockquote>
 
@@ -319,7 +319,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-es-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-es-dev.tsv \
   run.miracl.bm25.es.dev.txt</code></pre>
   </blockquote>
 
@@ -339,7 +339,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-fa-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-fa-dev.tsv \
   run.miracl.bm25.fa.dev.txt</code></pre>
   </blockquote>
 
@@ -359,7 +359,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-fi-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-fi-dev.tsv \
   run.miracl.bm25.fi.dev.txt</code></pre>
   </blockquote>
 
@@ -379,7 +379,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-fr-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-fr-dev.tsv \
   run.miracl.bm25.fr.dev.txt</code></pre>
   </blockquote>
 
@@ -399,7 +399,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-hi-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-hi-dev.tsv \
   run.miracl.bm25.hi.dev.txt</code></pre>
   </blockquote>
 
@@ -419,7 +419,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-id-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-id-dev.tsv \
   run.miracl.bm25.id.dev.txt</code></pre>
   </blockquote>
 
@@ -439,7 +439,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-ja-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-ja-dev.tsv \
   run.miracl.bm25.ja.dev.txt</code></pre>
   </blockquote>
 
@@ -459,7 +459,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-ko-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-ko-dev.tsv \
   run.miracl.bm25.ko.dev.txt</code></pre>
   </blockquote>
 
@@ -479,7 +479,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-ru-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-ru-dev.tsv \
   run.miracl.bm25.ru.dev.txt</code></pre>
   </blockquote>
 
@@ -499,7 +499,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-sw-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-sw-dev.tsv \
   run.miracl.bm25.sw.dev.txt</code></pre>
   </blockquote>
 
@@ -520,7 +520,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-te-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-te-dev.tsv \
   run.miracl.bm25.te.dev.txt</code></pre>
   </blockquote>
 
@@ -541,7 +541,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-th-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-th-dev.tsv \
   run.miracl.bm25.th.dev.txt</code></pre>
   </blockquote>
 
@@ -562,7 +562,7 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>python -m pyserini.eval.trec_eval \
-  -c -M 100 -m ndcg_cut.100 tools/topics-and-qrels/qrels.miracl-v1.0-zh-dev.tsv \
+  -c -M 100 -m ndcg_cut.10 tools/topics-and-qrels/qrels.miracl-v1.0-zh-dev.tsv \
   run.miracl.bm25.zh.dev.txt</code></pre>
   </blockquote>
 
@@ -616,16 +616,16 @@ Evaluation commands:
 <td>0.891</td>
 <td>0.653</td>
 <td>0.868</td>
-<td>0.921</td>
+<td>0.904</td>
 <td>0.805</td>
 <td>0.783</td>
 <td>0.661</td>
 <td>0.701</td>
 <td>0.831</td>
-<td>0.842</td>
-<td>0.555</td>
+<td>0.887</td>
+<td>0.560</td>
 <td></td>
-<td>0.785</td>
+<td>0.787</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>

--- a/docs/2cr/miracl.html
+++ b/docs/2cr/miracl.html
@@ -185,8 +185,7 @@ pre[class*="prettyprint"] {
 </tr>
 <tr class="hide-table-padding">
 <td></td>
-<td></td>
-<td colspan="8" style="max-width: 600px">
+<td colspan="17" >
 <div id="table1-collapse1" class="collapse in p-3">
 
 <!-- Tabs navs -->
@@ -573,6 +572,7 @@ Evaluation commands:
 </div></td>
 </tr>
 
+
     </tbody>
   </table>
 </div>
@@ -629,8 +629,7 @@ Evaluation commands:
 </tr>
 <tr class="hide-table-padding">
 <td></td>
-<td></td>
-<td colspan="8" style="max-width: 600px">
+<td colspan="17" >
 <div id="table2-collapse1" class="collapse in p-3">
 
 <!-- Tabs navs -->
@@ -1016,6 +1015,7 @@ Evaluation commands:
 
 </div></td>
 </tr>
+
 
     </tbody>
   </table>

--- a/pyserini/resources/miracl.yaml
+++ b/pyserini/resources/miracl.yaml
@@ -186,9 +186,10 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG@10: 0.1990
-            R@100: 0.5476
+          - nDCG@10: 0.2018
+            R@100: 0.5541
       - split: dev
         scores:
-          - nDCG@10: 0.1775
-            R@100: 0.5551
+          - nDCG@10: 0.1801
+            R@100: 0.5599
+

--- a/pyserini/resources/miracl.yaml
+++ b/pyserini/resources/miracl.yaml
@@ -6,11 +6,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.5112
+          - nDCG@10: 0.4434
             R@100: 0.8562
       - split: dev
         scores:
-          - nDCG: 0.5529
+          - nDCG@10: 0.4809
             R@100: 0.8885
   - name: bm25.bn
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-bn
@@ -18,11 +18,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.5839
+          - nDCG@10: 0.5122
             R@100: 0.8934
       - split: dev
         scores:
-          - nDCG: 0.5765
+          - nDCG@10: 0.5079
             R@100: 0.9088
   - name: bm25.en
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-en
@@ -30,11 +30,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.4409
+          - nDCG@10: 0.3415
             R@100: 0.7928
       - split: dev
         scores:
-          - nDCG: 0.4581
+          - nDCG@10: 0.3506
             R@100: 0.8190
   - name: bm25.es
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-es
@@ -42,11 +42,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.4215
+          - nDCG@10: 0.3030
             R@100: 0.7020
       - split: dev
         scores:
-          - nDCG: 0.4345
+          - nDCG@10: 0.3193
             R@100: 0.7018
   - name: bm25.fa
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-fa
@@ -54,11 +54,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.3965
+          - nDCG@10: 0.3270
             R@100: 0.7139
       - split: dev
         scores:
-          - nDCG: 0.4084
+          - nDCG@10: 0.3334
             R@100: 0.7306
   - name: bm25.fi
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-fi
@@ -66,11 +66,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.5606
+          - nDCG@10: 0.5106
             R@100: 0.8471
       - split: dev
         scores:
-          - nDCG: 0.6085
+          - nDCG@10: 0.5513
             R@100: 0.8910
   - name: bm25.fr
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-fr
@@ -78,11 +78,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.3017
+          - nDCG@10: 0.2152
             R@100: 0.6601
       - split: dev
         scores:
-          - nDCG: 0.2802
+          - nDCG@10: 0.1832
             R@100: 0.6528
   - name: bm25.hi
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-hi
@@ -90,11 +90,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.5488
+          - nDCG@10: 0.4745
             R@100: 0.9016
       - split: dev
         scores:
-          - nDCG: 0.5327
+          - nDCG@10: 0.4578
             R@100: 0.8679
   - name: bm25.id
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-id
@@ -102,23 +102,23 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.5938
-            R@100: 0.9387
+          - nDCG@10: 0.4844
+            R@100: 0.9234
       - split: dev
         scores:
-          - nDCG: 0.5707
-            R@100: 0.9214
+          - nDCG@10: 0.4486
+            R@100: 0.9041
   - name: bm25.ja
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-ja
     command: python -m pyserini.search.lucene --language ja --topics tools/topics-and-qrels/topics.miracl-v1.0-ja-${split}.tsv --index miracl-v1.0-ja --output $output --batch 128 --threads 16 --bm25 --hits 100
     splits:
       - split: train
         scores:
-          - nDCG: 0.4591
+          - nDCG@10: 0.3796
             R@100: 0.8225
       - split: dev
         scores:
-          - nDCG: 0.4495
+          - nDCG@10: 0.3689
             R@100: 0.8048
   - name: bm25.ko
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-ko
@@ -126,11 +126,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.4960
+          - nDCG@10: 0.4279
             R@100: 0.7572
       - split: dev
         scores:
-          - nDCG: 0.5042
+          - nDCG@10: 0.4190
             R@100: 0.7831
   - name: bm25.ru
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-ru
@@ -138,11 +138,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.3812
+          - nDCG@10: 0.3153
             R@100: 0.6464
       - split: dev
         scores:
-          - nDCG: 0.4104
+          - nDCG@10: 0.3342
             R@100: 0.6614
   - name: bm25.sw
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-sw
@@ -150,11 +150,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.3792
+          - nDCG@10: 0.3356
             R@100: 0.6499
       - split: dev
         scores:
-          - nDCG: 0.4357
+          - nDCG@10: 0.3826
             R@100: 0.7008
   - name: bm25.te
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-te
@@ -162,11 +162,11 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.5191
+          - nDCG@10: 0.4814
             R@100: 0.8077
       - split: dev
         scores:
-          - nDCG: 0.5292
+          - nDCG@10: 0.4942
             R@100: 0.8307
   - name: bm25.th
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-th
@@ -174,21 +174,21 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG: 0.5081
-            R@100: 0.8357
+          - nDCG@10: 0.4629
+            R@100: 0.8768
       - split: dev
         scores:
-          - nDCG: 0.5279
-            R@100: 0.8424
+          - nDCG@10: 0.4838
+            R@100: 0.8874
   - name: bm25.zh
     eval_key: tools/topics-and-qrels/qrels.miracl-v1.0-zh
     command: python -m pyserini.search.lucene --language zh --topics tools/topics-and-qrels/topics.miracl-v1.0-zh-${split}.tsv --index miracl-v1.0-zh --output $output --batch 128 --threads 16 --bm25 --hits 100
     splits:
       - split: train
         scores:
-          - nDCG: 0.2723
+          - nDCG@10: 0.1990
             R@100: 0.5476
       - split: dev
         scores:
-          - nDCG: 0.2595
+          - nDCG@10: 0.1775
             R@100: 0.5551

--- a/scripts/repro_matrix/defs_miracl.py
+++ b/scripts/repro_matrix/defs_miracl.py
@@ -44,6 +44,6 @@ html_display = {
 }
 
 trec_eval_metric_definitions = {
-    'nDCG': '-c -M 100 -m ndcg_cut.100',
+    'nDCG@10': '-c -M 100 -m ndcg_cut.10',
     'R@100': '-c -m recall.100',
 }

--- a/scripts/repro_matrix/generate_html_miracl.py
+++ b/scripts/repro_matrix/generate_html_miracl.py
@@ -170,9 +170,9 @@ if __name__ == '__main__':
         split = 'dev'
 
         # Build the table for MRR@100, test queries
-        html_rows = generate_table_rows(1, split, 'nDCG')
+        html_rows = generate_table_rows(1, split, 'nDCG@10')
         all_rows = '\n'.join(html_rows)
-        tables_html.append(Template(table_template).substitute(desc=f'nDCG, {split} queries', rows=all_rows))
+        tables_html.append(Template(table_template).substitute(desc=f'nDCG@10, {split} queries', rows=all_rows))
 
         # Build the table for R@100, test queries
         html_rows = generate_table_rows(2, split, 'R@100')

--- a/scripts/repro_matrix/miracl_html_table_row.template
+++ b/scripts/repro_matrix/miracl_html_table_row.template
@@ -23,8 +23,7 @@
 </tr>
 <tr class="hide-table-padding">
 <td></td>
-<td></td>
-<td colspan="8" style="max-width: 600px">
+<td colspan="17" >
 <div id="table${table_cnt}-collapse${row_cnt}" class="collapse in p-3">
 
 <!-- Tabs navs -->

--- a/scripts/repro_matrix/run_all_miracl.py
+++ b/scripts/repro_matrix/run_all_miracl.py
@@ -42,7 +42,7 @@ def print_results(metric, split):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Generate regression matrix for Mr.TyDi.')
+    parser = argparse.ArgumentParser(description='Generate regression matrix for MIRACL.')
     parser.add_argument('--skip-eval', action='store_true', default=False, help='Skip running trec_eval.')
     args = parser.parse_args()
 
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
                 print(f'  - split: {split}')
 
-                runfile = f'runs/run.mrtydi.{name}.{split}.txt'
+                runfile = f'runs/run.miracl.{name}.{split}.txt'
                 cmd = Template(cmd_template).substitute(split=split, output=runfile)
 
                 if not os.path.exists(runfile):

--- a/scripts/repro_matrix/run_all_miracl.py
+++ b/scripts/repro_matrix/run_all_miracl.py
@@ -93,6 +93,6 @@ if __name__ == '__main__':
 
             print('')
 
-    for metric in ['nDCG', 'R@100']:
+    for metric in ['nDCG@10', 'R@100']:
         for split in ['dev', 'train']:
             print_results(metric, split)


### PR DESCRIPTION
1. fix scores: ndcg -> ndcg@10
2. fix scores for `id` and `th`, whose qrels was a bit off (hgf is up-to-date now)
3. fix css format of `miracl.html` as previous slack discussion

Currently the webpage looks like this:
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/31640436/196252005-8232fb60-f243-45e8-b72b-28fba6bb7f3c.png">

