### PR TITLE
Validate pre-built indexes on intialization

### DIFF
--- a/pyserini/search/lucene/_searcher.py
+++ b/pyserini/search/lucene/_searcher.py
@@ -76,11 +76,10 @@ class LuceneSearcher:
             print(str(e))
             return None
 
-        # Currently, there is no way to validate stats is to create a separate IndexReader.
-        # see: https://github.com/castorini/anserini/issues/2013
+        # Currently, the only way to validate stats is to create a separate IndexReader, because there is no method
+        # to obtain the underlying reader of a SimpleSearcher; see https://github.com/castorini/anserini/issues/2013
         index_reader = IndexReader(index_dir)
-        # So, this is a bit janky as we're created a separate IndexReader for the sole purpose of validating
-        # index stats.
+        # This is janky as we're created a separate IndexReader for the sole purpose of validating index stats.
         index_reader.validate(prebuilt_index_name, verbose=verbose)
 
         if verbose:

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -228,7 +228,8 @@ def download_prebuilt_index(index_name, force=False, verbose=True, mirror=None):
     for url in target_index['urls']:
         local_filename = target_index['filename'] if 'filename' in target_index else None
         try:
-            return download_and_unpack_index(url, local_filename=local_filename, prebuilt=True, md5=index_md5)
+            return download_and_unpack_index(url, local_filename=local_filename,
+                                             prebuilt=True, md5=index_md5, verbose=verbose)
         except (HTTPError, URLError) as e:
             print(f'Unable to download pre-built index at {url}, trying next URL...')
     raise ValueError(f'Unable to download pre-built index at any known URLs.')

--- a/scripts/validate_prebuilt_indexes.py
+++ b/scripts/validate_prebuilt_indexes.py
@@ -22,7 +22,7 @@ from pyserini.search.faiss import FaissSearcher, QueryEncoder, BinaryDenseSearch
 def check_sparse(index):
     for entry in index:
         print(f'# Validating "{entry}"...')
-        IndexReader.validate_prebuilt_index(entry)
+        IndexReader.from_prebuilt_index(entry, verbose=True)
         print('\n')
 
 


### PR DESCRIPTION
Closes #1334

+ Perform consistency checks when initializing pre-built indexes for `IndexReader` and `LuceneSearcher`.
+ Reduce verbosity of debug information during initialization
