### PR TITLE
Update odqa 2cr for all remaining methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,8 +630,8 @@ python scripts/repro_matrix/run_all_msmarco.py --collection v2-doc
 python scripts/repro_matrix/run_all_beir.py
 python scripts/repro_matrix/run_all_mrtydi.py
 python scripts/repro_matrix/run_all_miracl.py
-python scripts/repro_matrix/run_all_odqa.py --topics naturalquestion
-python scripts/repro_matrix/run_all_odqa.py --topics triviaqa
+python scripts/repro_matrix/run_all_odqa.py --topics nq
+python scripts/repro_matrix/run_all_odqa.py --topics tqa
 ```
 
 And to generate the nicely formatted documentation pages:

--- a/docs/2cr/odqa.html
+++ b/docs/2cr/odqa.html
@@ -187,7 +187,8 @@ pre[class*="prettyprint"] {
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>python -m pyserini.search.lucene --threads 16 \
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
   --batch-size 128 \
   --index wikipedia-dpr \
   --topics dpr-trivia-test \
@@ -218,7 +219,8 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>python -m pyserini.search.lucene --threads 16 \
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
   --batch-size 128 \
   --index wikipedia-dpr \
   --topics nq-test \
@@ -250,14 +252,14 @@ Evaluation commands:
 
 </div></td>
 </tr>
-<!-- Condition: BM25-k1_0.9_b_0.4-RM3 -->
+<!-- Condition: BM25-k1_0.9_b_0.4_dpr-topics -->
 <tr class="accordion-toggle collapsed" id="table1-row2" data-toggle="collapse" data-parent="#table1-row2" href="#table1-collapse2">
 <td class="expand-button" style="padding-right:50px"></td>
-<td nowrap style="padding-right:100px">BM25-k1_0.9_b_0.4-RM3</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
+<td nowrap style="padding-right:100px">BM25-k1_0.9_b_0.4_dpr-topics</td>
+<td>76.41</td>
+<td>83.14</td>
+<td>62.99</td>
+<td>78.23</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -283,19 +285,31 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics dpr-trivia-test \
+  --output runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-trivia-test.hits=100.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-trivia-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-trivia-test.hits=100.txt \
+  --output runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-trivia-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-trivia-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -303,19 +317,31 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics dpr-nq-test \
+  --output runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-nq-test.hits=100.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-nq-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-nq-test.hits=100.txt \
+  --output runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-nq-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.BM25-k1_0.9_b_0.4_dpr-topics.dpr-nq-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -324,14 +350,14 @@ Evaluation commands:
 
 </div></td>
 </tr>
-<!-- Condition: GarT5 -->
+<!-- Condition: GarT5-RRF -->
 <tr class="accordion-toggle collapsed" id="table1-row3" data-toggle="collapse" data-parent="#table1-row3" href="#table1-collapse3">
 <td class="expand-button" style="padding-right:50px"></td>
-<td nowrap style="padding-right:100px">GarT5</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
+<td nowrap style="padding-right:100px">GarT5-RRF</td>
+<td>80.66</td>
+<td>85.95</td>
+<td>77.17</td>
+<td>86.9</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -354,42 +380,126 @@ Evaluation commands:
 <!-- Tabs content -->
 <div class="tab-content" id="table1-row3-content">
   <div class="tab-pane fade show active" id="table1-row3-tab1" role="tabpanel" aria-labelledby="table1-row3-tab1">
-Command to generate run:
+Command to generate runs:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics dpr-trivia-test-gar-t5-answers \
+  --output runs/run.odqa.GarT5-RRF.dpr-trivia-test.answers.hits=1000.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 1000
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics dpr-trivia-test-gar-t5-titles \
+  --output runs/run.odqa.GarT5-RRF.dpr-trivia-test.titles.hits=1000.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 1000
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics dpr-trivia-test-gar-t5-sentences \
+  --output runs/run.odqa.GarT5-RRF.dpr-trivia-test.sentences.hits=1000.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 1000
+</code></pre></blockquote>
+
+Fusing the results using RRF
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.fusion \
+  --runs runs/run.odqa.GarT5-RRF.dpr-trivia-test.answers.hits=1000.txt \
+	 runs/run.odqa.GarT5-RRF.dpr-trivia-test.titles.hits=1000.txt \
+	 runs/run.odqa.GarT5-RRF.dpr-trivia-test.sentences.hits=1000.txt \
+  --output runs/run.odqa.GarT5-RRF.dpr-trivia-test.hits=100.fusion.txt\
+  --k 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-trivia-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.GarT5-RRF.dpr-trivia-test.hits=100.fusion.txt \
+  --output runs/run.odqa.GarT5-RRF.dpr-trivia-test.hits=100.fusion.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.GarT5-RRF.dpr-trivia-test.hits=100.fusion.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
   <div class="tab-pane fade" id="table1-row3-tab2" role="tabpanel" aria-labelledby="table1-row3-tab2">
-Command to generate run:
+Command to generate runs:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics nq-test-gar-t5-answers \
+  --output runs/run.odqa.GarT5-RRF.nq-test.answers.hits=1000.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 1000
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics nq-test-gar-t5-titles \
+  --output runs/run.odqa.GarT5-RRF.nq-test.titles.hits=1000.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 1000
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr \
+  --topics nq-test-gar-t5-sentences \
+  --output runs/run.odqa.GarT5-RRF.nq-test.sentences.hits=1000.txt --bm25 --k1 0.9 --b 0.4 \
+  --hits 1000
+</code></pre></blockquote>
+
+Fusing the results using RRF
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.fusion \
+  --runs runs/run.odqa.GarT5-RRF.nq-test.answers.hits=1000.txt \
+	 runs/run.odqa.GarT5-RRF.nq-test.titles.hits=1000.txt \
+	 runs/run.odqa.GarT5-RRF.nq-test.sentences.hits=1000.txt \
+  --output runs/run.odqa.GarT5-RRF.nq-test.hits=100.fusion.txt \
+  --k 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics nq-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.GarT5-RRF.nq-test.hits=100.fusion.txt \
+  --output runs/run.odqa.GarT5-RRF.nq-test.hits=100.fusion.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.GarT5-RRF.nq-test.hits=100.fusion.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -402,10 +512,10 @@ Evaluation commands:
 <tr class="accordion-toggle collapsed" id="table1-row4" data-toggle="collapse" data-parent="#table1-row4" href="#table1-collapse4">
 <td class="expand-button" style="padding-right:50px"></td>
 <td nowrap style="padding-right:100px">DPR</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
+<td>78.87</td>
+<td>84.79</td>
+<td>80.58</td>
+<td>86.68</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -431,19 +541,32 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.faiss \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr-multi-bf \
+  --encoder facebook/dpr-question_encoder-multiset-base \
+  --topics dpr-trivia-test \
+  --output runs/run.odqa.DPR.dpr-trivia-test.hits=100.txt \
+  --hits 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-trivia-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.DPR.dpr-trivia-test.hits=100.txt \
+  --output runs/run.odqa.DPR.dpr-trivia-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.DPR.dpr-trivia-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -451,19 +574,32 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.faiss \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr-single-nq-bf \
+  --encoder facebook/dpr-question_encoder-single-nq-base \
+  --topics nq-test \
+  --output runs/run.odqa.DPR.nq-test.hits=100.txt \
+  --hits 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics nq-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.DPR.nq-test.hits=100.txt \
+  --output runs/run.odqa.DPR.nq-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.DPR.nq-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -476,10 +612,10 @@ Evaluation commands:
 <tr class="accordion-toggle collapsed" id="table1-row5" data-toggle="collapse" data-parent="#table1-row5" href="#table1-collapse5">
 <td class="expand-button" style="padding-right:50px"></td>
 <td nowrap style="padding-right:100px">DPR-DKRR</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
+<td>83.74</td>
+<td>87.78</td>
+<td>84.27</td>
+<td>89.34</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -505,19 +641,32 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.faiss \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr-dkrr-tqa \
+  --encoder castorini/dkrr-dpr-tqa-retriever \
+  --topics dpr-trivia-test \
+  --output runs/run.odqa.DPR-DKRR.dpr-trivia-test.hits=100.txt --query-prefix question:  \
+  --hits 1000
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-trivia-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.DPR-DKRR.dpr-trivia-test.hits=100.txt \
+  --output runs/run.odqa.DPR-DKRR.dpr-trivia-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.DPR-DKRR.dpr-trivia-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -525,19 +674,32 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.faiss \
+  --threads 72 \
+  --batch-size 128 \
+  --index wikipedia-dpr-dkrr-nq \
+  --encoder castorini/dkrr-dpr-nq-retriever \
+  --topics nq-test \
+  --output runs/run.odqa.DPR-DKRR.nq-test.hits=100.txt --query-prefix question:  \
+  --hits 1000
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics nq-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.DPR-DKRR.nq-test.hits=100.txt \
+  --output runs/run.odqa.DPR-DKRR.nq-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.DPR-DKRR.nq-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -546,14 +708,14 @@ Evaluation commands:
 
 </div></td>
 </tr>
-<!-- Condition: DPR-hybrid -->
+<!-- Condition: DPR-Hybrid -->
 <tr class="accordion-toggle collapsed" id="table1-row6" data-toggle="collapse" data-parent="#table1-row6" href="#table1-collapse6">
 <td class="expand-button" style="padding-right:50px"></td>
-<td nowrap style="padding-right:100px">DPR-hybrid</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
+<td nowrap style="padding-right:100px">DPR-Hybrid</td>
+<td>82.64</td>
+<td>86.55</td>
+<td>83.43</td>
+<td>89.03</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -579,19 +741,34 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.hybrid\
+ dense  --index wikipedia-dpr-multi-bf \
+	--encoder facebook/dpr-question_encoder-multiset-base\
+ sparse --index wikipedia-dpr\
+ fusion --alpha 0.95\
+ run	--topics dpr-trivia-test \
+	--output runs/run.odqa.DPR-Hybrid.dpr-trivia-test.hits=100.txt \
+	--threads 72 \
+	--batch-size 128 \
+	--hits 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-trivia-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.DPR-Hybrid.dpr-trivia-test.hits=100.txt \
+  --output runs/run.odqa.DPR-Hybrid.dpr-trivia-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.DPR-Hybrid.dpr-trivia-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -599,19 +776,34 @@ Evaluation commands:
 Command to generate run:
 
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.search.hybrid\
+ dense  --index wikipedia-dpr-single-nq-bf \
+	--encoder facebook/dpr-question_encoder-single-nq-base\
+ sparse --index wikipedia-dpr\
+ fusion --alpha 1.2\
+ run	--topics nq-test \
+	--output runs/run.odqa.DPR-Hybrid.nq-test.hits=100.txt \
+	--threads 72 \
+	--batch-size 128 \
+	--hits 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics nq-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.DPR-Hybrid.nq-test.hits=100.txt \
+  --output runs/run.odqa.DPR-Hybrid.nq-test.hits=100.json
 </code></pre></blockquote>
 
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.DPR-Hybrid.nq-test.hits=100.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
@@ -620,14 +812,14 @@ Evaluation commands:
 
 </div></td>
 </tr>
-<!-- Condition: RRF -->
+<!-- Condition: GarT5RRF-DKRR-RRF -->
 <tr class="accordion-toggle collapsed" id="table1-row7" data-toggle="collapse" data-parent="#table1-row7" href="#table1-collapse7">
 <td class="expand-button" style="padding-right:50px"></td>
-<td nowrap style="padding-right:100px">RRF</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
-<td>0.0</td>
+<td nowrap style="padding-right:100px">GarT5RRF-DKRR-RRF</td>
+<td>85.02</td>
+<td>88.41</td>
+<td>84.9</td>
+<td>90.86</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -650,42 +842,62 @@ Evaluation commands:
 <!-- Tabs content -->
 <div class="tab-content" id="table1-row7-content">
   <div class="tab-pane fade show active" id="table1-row7-tab1" role="tabpanel" aria-labelledby="table1-row7-tab1">
-Command to generate run:
+Runs can be generated using the commands above.
 
+Fusing the results using RRF
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.fusion \
+  --runs runs/run.odqa.DPR-DKRR.dpr-trivia-test.hits=100.txt \
+	 runs/run.odqa.GarT5-RRF.dpr-trivia-test.hits=100.fusion.txt \
+  --output runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.txt\
+  --k 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-trivia-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.txt \
+  --output runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.json
 </code></pre></blockquote>
-
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>
   <div class="tab-pane fade" id="table1-row7-tab2" role="tabpanel" aria-labelledby="table1-row7-tab2">
-Command to generate run:
+Runs can be generated using the commands above.
 
+Fusing the results using RRF
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.fusion \
+  --runs runs/run.odqa.DPR-DKRR.nq-test.hits=100.txt \
+	 runs/run.odqa.GarT5-RRF.nq-test.hits=100.fusion.txt \
+  --output runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.txt \
+  --k 100
 </code></pre></blockquote>
 
 Converting from trec into json
   <blockquote class="mycode">
-<pre><code>
+<pre><code>python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics nq-test \
+  --index wikipedia-dpr \
+  --input runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.txt \
+  --output runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.json
 </code></pre></blockquote>
-
 
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code></code></pre>
+<pre><code>python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.odqa.GarT5RRF-DKRR-RRF.dpr-trivia-test.json \
+  --topk 20 100</code></pre>
   </blockquote>
 
   </div>

--- a/pyserini/resources/naturalquestion.yaml
+++ b/pyserini/resources/naturalquestion.yaml
@@ -1,16 +1,66 @@
 conditions:
   - model_name: BM25-k1_0.9_b_0.4
-    command: python -m pyserini.search.lucene --threads 16 --batch-size 128 --index wikipedia-dpr --topics nq-test --output $output --bm25 --k1 0.9 --b 0.4
+    command: 
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics nq-test --output $output --bm25 --k1 0.9 --b 0.4
     scores:
       - Top5: 44.82
         Top20: 64.02
         Top100: 79.20
         Top500: 86.59
         Top1000: 88.95
-  # - model_name: BM25-k1_0.9_b_0.4
-  # - model_name: BM25-k1_0.9_b_0.4-RM3
-  # - model_name: GarT5
-  # - model_name: DPR
-  # - model_name: DPR-DKRR
-  # - model_name: DPR-hybrid
-  # - model_name: RRF
+  - model_name: BM25-k1_0.9_b_0.4_dpr-topics
+    command: 
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics dpr-nq-test --output $output --bm25 --k1 0.9 --b 0.4
+    scores:
+      - Top5: 43.77
+        Top20: 62.99
+        Top100: 78.23
+        Top500: 85.60
+        Top1000: 88.01
+  - model_name: GarT5-RRF
+    command: 
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics nq-test-gar-t5-answers --output $output --bm25 --k1 0.9 --b 0.4
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics nq-test-gar-t5-titles --output $output --bm25 --k1 0.9 --b 0.4
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics nq-test-gar-t5-sentences --output $output --bm25 --k1 0.9 --b 0.4
+    scores:
+      - Top5: 64.62
+        Top20: 77.17
+        Top100: 86.90
+        Top500: 91.63
+        Top1000: 92.91
+  - model_name: DPR
+    command: 
+      - python -m pyserini.search.faiss --threads 72 --batch-size 128 --index wikipedia-dpr-single-nq-bf --encoder facebook/dpr-question_encoder-single-nq-base --topics nq-test --output $output
+    scores:
+      - Top5: 68.61
+        Top20: 80.58 
+        Top100: 86.68
+        Top500: 90.91
+        Top1000: 91.83
+  - model_name: DPR-DKRR
+    command: 
+      - 'python -m pyserini.search.faiss --threads 72 --batch-size 128 --index wikipedia-dpr-dkrr-nq --encoder castorini/dkrr-dpr-nq-retriever --topics nq-test --output $output --query-prefix question: '
+    scores:
+      - Top5: 73.80
+        Top20: 84.27
+        Top100: 89.34
+        Top500: 92.24
+        Top1000: 93.43
+  - model_name: DPR-Hybrid
+    command: 
+      - python -m pyserini.search.hybrid dense --index wikipedia-dpr-single-nq-bf --encoder facebook/dpr-question_encoder-single-nq-base sparse --index wikipedia-dpr fusion --alpha 1.2 run --topics nq-test --output $output --threads 72 --batch-size 128 
+    scores:
+      - Top5: 72.52
+        Top20: 83.43
+        Top100: 89.03
+        Top500: 92.16
+        Top1000: 93.19
+  - model_name: GarT5RRF-DKRR-RRF
+    command:
+      - ''
+    scores:
+      - Top5: 74.57
+        Top20: 84.90
+        Top100: 90.86
+        Top500: 93.35
+        Top1000: 94.18

--- a/pyserini/resources/triviaqa.yaml
+++ b/pyserini/resources/triviaqa.yaml
@@ -1,16 +1,66 @@
 conditions:
   - model_name: BM25-k1_0.9_b_0.4
-    command: python -m pyserini.search.lucene --threads 16 --batch-size 128 --index wikipedia-dpr --topics dpr-trivia-test --output $output --bm25 --k1 0.9 --b 0.4
+    command: 
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics dpr-trivia-test --output $output --bm25 --k1 0.9 --b 0.4
     scores:
       - Top5: 66.29
         Top20: 76.41
         Top100: 83.14
         Top500: 87.35
         Top1000: 88.50
-  # - model_name: BM25-k1_0.9_b_0.4
-  # - model_name: BM25-k1_0.9_b_0.4-RM3
-  # - model_name: GarT5
-  # - model_name: DPR
-  # - model_name: DPR-DKRR
-  # - model_name: DPR-hybrid
-  # - model_name: RRF
+  - model_name: BM25-k1_0.9_b_0.4_dpr-topics
+    command: 
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics dpr-trivia-test --output $output --bm25 --k1 0.9 --b 0.4
+    scores:
+      - Top5: 66.29
+        Top20: 76.41
+        Top100: 83.14
+        Top500: 87.35
+        Top1000: 88.50
+  - model_name: GarT5-RRF
+    command: 
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics dpr-trivia-test-gar-t5-answers --output $output --bm25 --k1 0.9 --b 0.4
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics dpr-trivia-test-gar-t5-titles --output $output --bm25 --k1 0.9 --b 0.4
+      - python -m pyserini.search.lucene --threads 72 --batch-size 128 --index wikipedia-dpr --topics dpr-trivia-test-gar-t5-sentences --output $output --bm25 --k1 0.9 --b 0.4
+    scores:
+      - Top5: 72.82
+        Top20: 80.66
+        Top100: 85.95
+        Top500: 89.07
+        Top1000: 90.06
+  - model_name: DPR
+    command: 
+      - python -m pyserini.search.faiss --threads 72 --batch-size 128 --index wikipedia-dpr-multi-bf --encoder facebook/dpr-question_encoder-multiset-base --topics dpr-trivia-test --output $output
+    scores:
+      - Top5: 69.80
+        Top20: 78.87 
+        Top100: 84.79
+        Top500: 88.19
+        Top1000: 89.30
+  - model_name: DPR-DKRR
+    command: 
+      - 'python -m pyserini.search.faiss --threads 72 --batch-size 128 --index wikipedia-dpr-dkrr-tqa --encoder castorini/dkrr-dpr-tqa-retriever --topics dpr-trivia-test --output $output --query-prefix question: '
+    scores:
+      - Top5: 77.23
+        Top20: 83.74
+        Top100: 87.78
+        Top500: 89.87
+        Top1000: 90.63
+  - model_name: DPR-Hybrid
+    command: 
+      - python -m pyserini.search.hybrid dense --index wikipedia-dpr-multi-bf --encoder facebook/dpr-question_encoder-multiset-base sparse --index wikipedia-dpr fusion --alpha 0.95 run --topics dpr-trivia-test --output $output --threads 72 --batch-size 128
+    scores:
+      - Top5: 76.01
+        Top20: 82.64
+        Top100: 86.55
+        Top500: 89.12
+        Top1000: 89.90
+  - model_name: GarT5RRF-DKRR-RRF
+    command:
+      - ''
+    scores:
+      - Top5: 78.63
+        Top20: 85.02
+        Top100: 88.41
+        Top500: 90.29 
+        Top1000: 90.83

--- a/scripts/repro_matrix/defs_odqa.py
+++ b/scripts/repro_matrix/defs_odqa.py
@@ -18,12 +18,12 @@
 models = {
     'models':
     ['BM25-k1_0.9_b_0.4',
-     'BM25-k1_0.9_b_0.4-RM3',
-     'GarT5',
+     'BM25-k1_0.9_b_0.4_dpr-topics',
+     'GarT5-RRF',
      'DPR',
      'DPR-DKRR',
-     'DPR-hybrid',
-     'RRF'
+     'DPR-Hybrid',
+     'GarT5RRF-DKRR-RRF'
      ]
 }
 

--- a/scripts/repro_matrix/generate_html_odqa.py
+++ b/scripts/repro_matrix/generate_html_odqa.py
@@ -20,32 +20,46 @@ import argparse
 
 import yaml
 
-from scripts.repro_matrix.defs_odqa import models
+# from scripts.repro_matrix.defs_odqa import models
+from defs_odqa import models
 
 # global vars
 TQA_TOPICS = 'dpr-trivia-test'
 NQ_TOPICS = 'nq-test'
 PRINT_TQA_TOPICS = 'TriviaQA'
 PRINT_NQ_TOPICS = 'Natural Question'
+TQA_DKRR_RUN = f'runs/run.odqa.DPR-DKRR.{TQA_TOPICS}.hits=100.txt'
+NQ_DKRR_RUN = f'runs/run.odqa.DPR-DKRR.{NQ_TOPICS}.hits=100.txt'
+HITS_1K = set(['GarT5-RRF', 'DPR-DKRR'])
 
 
 def format_run_command(raw):
-    return raw.replace('--encoded-queries', '\\\n  --lang')\
+    return raw.replace('--encoded-queries', '\\\n  --encoded-queries')\
         .replace('--encoder', '\\\n  --encoder')\
         .replace('--topics', '\\\n  --topics')\
         .replace('--index', '\\\n  --index')\
         .replace('--output', '\\\n  --output')\
         .replace('--batch', '\\\n  --batch') \
-        .replace('--threads 12', '--threads 12 \\\n')\
+        .replace('--threads', '\\\n  --threads')\
         .replace('--hits 100', '\\\n  --hits 100')
 
+def format_hybrid_search_command(raw):
+    return raw.replace('--encoder', '\\\n\t--encoder')\
+        .replace(' dense', '\\\n dense ')\
+        .replace(' sparse', '\\\n sparse')\
+        .replace(' fusion', '\\\n fusion')\
+        .replace(' run ', '\\\n run\t')\
+        .replace('--output', '\\\n\t--output')\
+        .replace('--batch', '\\\n\t--batch') \
+        .replace('--threads', '\\\n\t--threads')\
+        .replace('--lang', '\\\n\t--lang')\
+        .replace('--hits 100', '\\\n\t--hits 100')
 
 def format_convert_command(raw):
     return raw.replace('--topics', '\\\n  --topics')\
         .replace('--index', '\\\n  --index')\
         .replace('--input', '\\\n  --input')\
         .replace('--output', '\\\n  --output')\
-
 
 
 def format_eval_command(raw):
@@ -66,22 +80,60 @@ def generate_table_rows(table_id):
     html_rows = []
 
     for model in models['models']:
-        s = Template(row_template)
-        s = s.substitute(table_cnt=table_id,
-                         row_cnt=row_cnt,
-                         model=model,
-                         TQA_Top20=table[model][TQA_TOPICS]["Top20"],
-                         TQA_Top100=table[model][TQA_TOPICS]["Top100"],
-                         NQ_Top20=table[model][NQ_TOPICS]["Top20"],
-                         NQ_Top100=table[model][NQ_TOPICS]["Top100"],
-                         cmd1=f'{commands[model][TQA_TOPICS]}',
-                         cmd2=f'{commands[model][NQ_TOPICS]}',
-                         convert_cmd1=f'{convert_commands[model][TQA_TOPICS]}',
-                         convert_cmd2=f'{convert_commands[model][NQ_TOPICS]}',
-                         eval_cmd1=f'{eval_commands[model][TQA_TOPICS]}',
-                         eval_cmd2=f'{eval_commands[model][NQ_TOPICS]}'
-                         )
-
+        if model == "GarT5-RRF":
+            s = Template(row_template_garrrf)
+            s = s.substitute(table_cnt=table_id,
+                            row_cnt=row_cnt,
+                            model=model,
+                            TQA_Top20=table[model][TQA_TOPICS]["Top20"],
+                            TQA_Top100=table[model][TQA_TOPICS]["Top100"],
+                            NQ_Top20=table[model][NQ_TOPICS]["Top20"],
+                            NQ_Top100=table[model][NQ_TOPICS]["Top100"],
+                            cmd1=f'{commands[model][TQA_TOPICS][0]}',
+                            cmd2=f'{commands[model][TQA_TOPICS][1]}',
+                            cmd3=f'{commands[model][TQA_TOPICS][2]}',
+                            cmd4=f'{commands[model][NQ_TOPICS][0]}',
+                            cmd5=f'{commands[model][NQ_TOPICS][1]}',
+                            cmd6=f'{commands[model][NQ_TOPICS][2]}',
+                            fusion_cmd1=fusion_cmd_tqa[0],                            
+                            fusion_cmd2=fusion_cmd_nq[0],                            
+                            convert_cmd1=f'{convert_commands[model][TQA_TOPICS]}',
+                            convert_cmd2=f'{convert_commands[model][NQ_TOPICS]}',
+                            eval_cmd1=f'{eval_commands[model][TQA_TOPICS]}',
+                            eval_cmd2=f'{eval_commands[model][NQ_TOPICS]}'
+                            )
+        elif model == "GarT5RRF-DKRR-RRF":
+            s = Template(row_template_rrf)
+            s = s.substitute(table_cnt=table_id,
+                            row_cnt=row_cnt,
+                            model=model,
+                            TQA_Top20=table[model][TQA_TOPICS]["Top20"],
+                            TQA_Top100=table[model][TQA_TOPICS]["Top100"],
+                            NQ_Top20=table[model][NQ_TOPICS]["Top20"],
+                            NQ_Top100=table[model][NQ_TOPICS]["Top100"],
+                            fusion_cmd1=fusion_cmd_tqa[1],                            
+                            fusion_cmd2=fusion_cmd_nq[1],                            
+                            convert_cmd1=f'{convert_commands[model][TQA_TOPICS]}',
+                            convert_cmd2=f'{convert_commands[model][NQ_TOPICS]}',
+                            eval_cmd1=f'{eval_commands[model][TQA_TOPICS]}',
+                            eval_cmd2=f'{eval_commands[model][NQ_TOPICS]}'
+                            )
+        else:
+            s = Template(row_template)
+            s = s.substitute(table_cnt=table_id,
+                            row_cnt=row_cnt,
+                            model=model,
+                            TQA_Top20=table[model][TQA_TOPICS]["Top20"],
+                            TQA_Top100=table[model][TQA_TOPICS]["Top100"],
+                            NQ_Top20=table[model][NQ_TOPICS]["Top20"],
+                            NQ_Top100=table[model][NQ_TOPICS]["Top100"],
+                            cmd1=commands[model][TQA_TOPICS][0],
+                            cmd2=commands[model][NQ_TOPICS][0],
+                            convert_cmd1=f'{convert_commands[model][TQA_TOPICS]}',
+                            convert_cmd2=f'{convert_commands[model][NQ_TOPICS]}',
+                            eval_cmd1=f'{eval_commands[model][TQA_TOPICS]}',
+                            eval_cmd2=f'{eval_commands[model][NQ_TOPICS]}'
+                            )
         html_rows.append(s)
         row_cnt += 1
 
@@ -92,17 +144,28 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Generate HTML rendering of regression matrix for MS MARCO corpora.')
     args = parser.parse_args()
+    
     table = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: 0.0)))
-    commands = defaultdict(lambda: defaultdict(lambda: ''))
+    commands = defaultdict(lambda: defaultdict(lambda: []))
     eval_commands = defaultdict(lambda: defaultdict(lambda: ''))
     convert_commands = defaultdict(lambda: defaultdict(lambda: ''))
 
     html_template = read_file('scripts/repro_matrix/odqa_html.template')
     table_template = read_file('scripts/repro_matrix/odqa_html_table.template')
-    row_template = read_file(
-        'scripts/repro_matrix/odqa_html_table_row.template')
+    row_template = read_file('scripts/repro_matrix/odqa_html_table_row.template')
+    row_template_garrrf = read_file('scripts/repro_matrix/odqa_html_table_row_gar-rrf.template')
+    row_template_rrf = read_file('scripts/repro_matrix/odqa_html_table_row_rrf.template')
     tqa_yaml_path = 'pyserini/resources/triviaqa.yaml'
     nq_yaml_path = 'pyserini/resources/naturalquestion.yaml'
+
+    garrrf_ls = ['answers','titles','sentences']
+    prefusion_runfile_tqa = []
+    prefusion_runfile_nq = []
+    fusion_cmd_tqa = []
+    fusion_cmd_nq = []
+    tqa_fused_run = {}
+    nq_fused_run = {}
+
 
     with open(tqa_yaml_path) as f_tqa, open(nq_yaml_path) as f_nq:
         tqa_yaml_data = yaml.safe_load(f_tqa)
@@ -111,30 +174,83 @@ if __name__ == '__main__':
             name = condition_tqa['model_name']
             cmd_template_tqa = condition_tqa['command']
             cmd_template_nq = condition_nq['command']
-            runfile_tqa = f'runs/run.odqa.{name}.{TQA_TOPICS}.hits=100.txt'
-            runfile_nq = f'runs/run.odqa.{name}.{NQ_TOPICS}.hits=100.txt'
-            jsonfile_tqa = runfile_tqa.replace('.txt', '.json')
-            jsonfile_nq = runfile_nq.replace('.txt', '.json')
-            cmd_tqa = Template(cmd_template_tqa).substitute(
-                output=runfile_tqa) + " --hits 100"
-            cmd_nq = Template(cmd_template_nq).substitute(output=runfile_nq) + " --hits 100"
-            commands[name][TQA_TOPICS] = format_run_command(cmd_tqa)
-            commands[name][NQ_TOPICS] = format_run_command(cmd_nq)
+            if 'RRF' in name:
+                if name == 'GarT5-RRF':
+                    runfile_tqa = [f'runs/run.odqa.{name}.{TQA_TOPICS}.{garrrf_ls[i]}.hits=1000.txt' for i in range(len(cmd_template_tqa))]
+                    runfile_nq = [f'runs/run.odqa.{name}.{NQ_TOPICS}.{garrrf_ls[i]}.hits=1000.txt' for i in range(len(cmd_template_nq))]
+                    tqa_fused_run.update({name: runfile_tqa[0].replace('.answers.hits=1000.txt', '.hits=100.fusion.txt')})
+                    nq_fused_run.update({name: runfile_nq[0].replace('.answers.hits=1000.txt', '.hits=100.fusion.txt')})
+                    jsonfile_tqa = tqa_fused_run[name].replace('.txt', '.json').replace('.hits=1000', '')
+                    jsonfile_nq = nq_fused_run[name].replace('.txt', '.json').replace('.hits=1000', '')
+                elif name == 'GarT5RRF-DKRR-RRF':
+                    jsonfile_tqa = f'runs/run.odqa.{name}.{TQA_TOPICS}.json'
+                    jsonfile_nq = f'runs/run.odqa.{name}.{TQA_TOPICS}.json'
+                    tqa_fused_run.update({name: jsonfile_tqa.replace('.json','.txt')})
+                    nq_fused_run.update({name: jsonfile_nq.replace('.json','.txt')})
+                else:
+                    raise NameError('Wrong model name in yaml config')
+            else:
+                if 'dpr-topics' in name:
+                    runfile_nq = [f'runs/run.odqa.{name}.dpr-nq-test.hits=100.txt']
+                else:
+                    runfile_nq = [f'runs/run.odqa.{name}.{NQ_TOPICS}.hits=100.txt']
+                runfile_tqa = [f'runs/run.odqa.{name}.{TQA_TOPICS}.hits=100.txt']   
+                jsonfile_tqa = runfile_tqa[0].replace('.answers', '').replace('.txt', '.json')
+                jsonfile_nq = runfile_nq[0].replace('.answers', '').replace('.txt', '.json')
+            
+            display_runfile_tqa = jsonfile_tqa.replace('.json','.txt')
+            display_runfile_nq = jsonfile_nq.replace('.json','.txt')
+
+            # fusion commands
+            if "RRF" in name:
+                if name == "GarT5RRF-DKRR-RRF":
+                    nq_runs = ' \\\n\t '.join([NQ_DKRR_RUN, nq_fused_run['GarT5-RRF']])
+                    tqa_runs = ' \\\n\t '.join([TQA_DKRR_RUN, tqa_fused_run['GarT5-RRF']])
+                else:
+                    tqa_runs = ' \\\n\t '.join(runfile_tqa)
+                    nq_runs = ' \\\n\t '.join(runfile_nq)
+                
+                fusion_cmd_tqa.append(f'python -m pyserini.fusion \\\n' + \
+                    f'  --runs {tqa_runs} \\\n' + \
+                    f'  --output {tqa_fused_run[name]}\\\n'
+                    f'  --k 100')
+                fusion_cmd_nq.append(f'python -m pyserini.fusion \\\n' + \
+                    f'  --runs {nq_runs} \\\n' + \
+                    f'  --output {nq_fused_run[name]} \\\n' + \
+                    f'  --k 100')
+
+            if name != "GarT5RRF-DKRR-RRF":
+                hits = 100 if name not in HITS_1K else 1000
+                cmd_tqa = [Template(cmd_template_tqa[i]).substitute(
+                    output=runfile_tqa[i]) + f" --hits {hits}" for i in range(len(cmd_template_tqa))]
+                cmd_nq = [Template(cmd_template_nq[i]).substitute(output=runfile_nq[i]) + f" --hits {hits}" for i in range(len(cmd_template_nq))]
+                if name == 'DPR-Hybrid':
+                    commands[name][TQA_TOPICS].extend([format_hybrid_search_command(i) for i in cmd_tqa])
+                    commands[name][NQ_TOPICS].extend([format_hybrid_search_command(i) for i in cmd_nq])
+                else:
+                    commands[name][TQA_TOPICS].extend([format_run_command(i) for i in cmd_tqa])
+                    commands[name][NQ_TOPICS].extend([format_run_command(i) for i in cmd_nq])
+            
+            # convertion commands:
+            if 'dpr-topics' in name:
+                temp_nq_topics = 'dpr-nq-test'
+            else:
+                temp_nq_topics = NQ_TOPICS
+
             convert_cmd_tqa = f'python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run ' + \
                 f'--topics {TQA_TOPICS} ' + \
                 f'--index wikipedia-dpr ' +\
-                f'--input {runfile_tqa} ' + \
+                f'--input {display_runfile_tqa} ' + \
                 f'--output {jsonfile_tqa}'
             convert_cmd_nq = f'python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run ' + \
-                f'--topics {NQ_TOPICS} ' + \
+                f'--topics {temp_nq_topics} ' + \
                 f'--index wikipedia-dpr ' +\
-                f'--input {runfile_nq} ' + \
+                f'--input {display_runfile_nq} ' + \
                 f'--output {jsonfile_nq}'
-            convert_commands[name][TQA_TOPICS] = format_convert_command(
-                convert_cmd_tqa)
-            convert_commands[name][NQ_TOPICS] = format_convert_command(
-                convert_cmd_nq)
+            convert_commands[name][TQA_TOPICS] = format_convert_command(convert_cmd_tqa)
+            convert_commands[name][NQ_TOPICS] = format_convert_command(convert_cmd_nq)
 
+            # eval commands
             eval_cmd_tqa = f'python -m pyserini.eval.evaluate_dpr_retrieval ' + \
                 f'--retrieval {jsonfile_tqa} ' + \
                 f'--topk 20 100'
@@ -151,8 +267,7 @@ if __name__ == '__main__':
 
         html_rows = generate_table_rows(1)
         all_rows = '\n'.join(html_rows)
-        tables_html.append(Template(table_template).substitute(
-            desc='Models', rows=all_rows))
+        tables_html.append(Template(table_template).substitute(desc='Models', rows=all_rows))
 
         print(Template(html_template).substitute(
             title=f'Retrieval for Open-Domain QA Datasets', tables=' '.join(tables_html)))

--- a/scripts/repro_matrix/odqa_html_table_row_gar-rrf.template
+++ b/scripts/repro_matrix/odqa_html_table_row_gar-rrf.template
@@ -1,0 +1,100 @@
+<!-- Condition: $model -->
+<tr class="accordion-toggle collapsed" id="table${table_cnt}-row${row_cnt}" data-toggle="collapse" data-parent="#table${table_cnt}-row${row_cnt}" href="#table${table_cnt}-collapse${row_cnt}">
+<td class="expand-button" style="padding-right:50px"></td>
+<td nowrap style="padding-right:100px">$model</td>
+<td>$TQA_Top20</td>
+<td>$TQA_Top100</td>
+<td>$NQ_Top20</td>
+<td>$NQ_Top100</td>
+</tr>
+<tr class="hide-table-padding">
+<td></td>
+<td></td>
+<td colspan="13" style="max-width: 600px">
+<div id="table${table_cnt}-collapse${row_cnt}" class="collapse in p-3">
+
+<!-- Tabs navs -->
+<ul class="nav nav-tabs mb-3" id="table${table_cnt}-row${row_cnt}-tabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <a class="nav-link active" id="table${table_cnt}-row${row_cnt}-tab1-header" data-mdb-toggle="tab" href="#table${table_cnt}-row${row_cnt}-tab1" role="tab" aria-controls="table${table_cnt}-row${row_cnt}-tab1" aria-selected="true" style="text-transform:none">TriviaQA</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="table${table_cnt}-row${row_cnt}-tab2-header" data-mdb-toggle="tab" href="#table${table_cnt}-row${row_cnt}-tab2" role="tab" aria-controls="table${table_cnt}-row${row_cnt}-tab2" aria-selected="false" style="text-transform:none">Natural Question</a>
+  </li>
+
+</ul>
+<!-- Tabs navs -->
+
+<!-- Tabs content -->
+<div class="tab-content" id="table${table_cnt}-row${row_cnt}-content">
+  <div class="tab-pane fade show active" id="table${table_cnt}-row${row_cnt}-tab1" role="tabpanel" aria-labelledby="table${table_cnt}-row${row_cnt}-tab1">
+Command to generate runs:
+
+  <blockquote class="mycode">
+<pre><code>$cmd1
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>$cmd2
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>$cmd3
+</code></pre></blockquote>
+
+Fusing the results using RRF
+  <blockquote class="mycode">
+<pre><code>$fusion_cmd1
+</code></pre></blockquote>
+
+Converting from trec into json
+  <blockquote class="mycode">
+<pre><code>$convert_cmd1
+</code></pre></blockquote>
+
+
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>$eval_cmd1</code></pre>
+  </blockquote>
+
+  </div>
+  <div class="tab-pane fade" id="table${table_cnt}-row${row_cnt}-tab2" role="tabpanel" aria-labelledby="table${table_cnt}-row${row_cnt}-tab2">
+Command to generate runs:
+
+  <blockquote class="mycode">
+<pre><code>$cmd4
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>$cmd5
+</code></pre></blockquote>
+
+  <blockquote class="mycode">
+<pre><code>$cmd6
+</code></pre></blockquote>
+
+Fusing the results using RRF
+  <blockquote class="mycode">
+<pre><code>$fusion_cmd2
+</code></pre></blockquote>
+
+Converting from trec into json
+  <blockquote class="mycode">
+<pre><code>$convert_cmd2
+</code></pre></blockquote>
+
+
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>$eval_cmd2</code></pre>
+  </blockquote>
+
+  </div>
+</div>
+<!-- Tabs content -->
+
+</div></td>
+</tr>

--- a/scripts/repro_matrix/odqa_html_table_row_rrf.template
+++ b/scripts/repro_matrix/odqa_html_table_row_rrf.template
@@ -1,0 +1,74 @@
+<!-- Condition: $model -->
+<tr class="accordion-toggle collapsed" id="table${table_cnt}-row${row_cnt}" data-toggle="collapse" data-parent="#table${table_cnt}-row${row_cnt}" href="#table${table_cnt}-collapse${row_cnt}">
+<td class="expand-button" style="padding-right:50px"></td>
+<td nowrap style="padding-right:100px">$model</td>
+<td>$TQA_Top20</td>
+<td>$TQA_Top100</td>
+<td>$NQ_Top20</td>
+<td>$NQ_Top100</td>
+</tr>
+<tr class="hide-table-padding">
+<td></td>
+<td></td>
+<td colspan="13" style="max-width: 600px">
+<div id="table${table_cnt}-collapse${row_cnt}" class="collapse in p-3">
+
+<!-- Tabs navs -->
+<ul class="nav nav-tabs mb-3" id="table${table_cnt}-row${row_cnt}-tabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <a class="nav-link active" id="table${table_cnt}-row${row_cnt}-tab1-header" data-mdb-toggle="tab" href="#table${table_cnt}-row${row_cnt}-tab1" role="tab" aria-controls="table${table_cnt}-row${row_cnt}-tab1" aria-selected="true" style="text-transform:none">TriviaQA</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="table${table_cnt}-row${row_cnt}-tab2-header" data-mdb-toggle="tab" href="#table${table_cnt}-row${row_cnt}-tab2" role="tab" aria-controls="table${table_cnt}-row${row_cnt}-tab2" aria-selected="false" style="text-transform:none">Natural Question</a>
+  </li>
+
+</ul>
+<!-- Tabs navs -->
+
+<!-- Tabs content -->
+<div class="tab-content" id="table${table_cnt}-row${row_cnt}-content">
+  <div class="tab-pane fade show active" id="table${table_cnt}-row${row_cnt}-tab1" role="tabpanel" aria-labelledby="table${table_cnt}-row${row_cnt}-tab1">
+Runs can be generated using the commands above.
+
+Fusing the results using RRF
+  <blockquote class="mycode">
+<pre><code>$fusion_cmd1
+</code></pre></blockquote>
+
+Converting from trec into json
+  <blockquote class="mycode">
+<pre><code>$convert_cmd1
+</code></pre></blockquote>
+
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>$eval_cmd1</code></pre>
+  </blockquote>
+
+  </div>
+  <div class="tab-pane fade" id="table${table_cnt}-row${row_cnt}-tab2" role="tabpanel" aria-labelledby="table${table_cnt}-row${row_cnt}-tab2">
+Runs can be generated using the commands above.
+
+Fusing the results using RRF
+  <blockquote class="mycode">
+<pre><code>$fusion_cmd2
+</code></pre></blockquote>
+
+Converting from trec into json
+  <blockquote class="mycode">
+<pre><code>$convert_cmd2
+</code></pre></blockquote>
+
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>$eval_cmd2</code></pre>
+  </blockquote>
+
+  </div>
+</div>
+<!-- Tabs content -->
+
+</div></td>
+</tr>

--- a/scripts/repro_matrix/utils.py
+++ b/scripts/repro_matrix/utils.py
@@ -101,3 +101,18 @@ def convert_trec_run_to_dpr_retrieval_json(topics,index,runfile,output):
     """    
     cmd = f"python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run --topics {topics} --index {index} --input {runfile} --output {output}"
     return os.system(cmd)
+
+def run_fusion(run_ls, output, k):
+    """run fusion command and return status code
+
+    Args:
+        run_ls: a list of runfile paths
+        output: output path
+        k: topk value
+
+    Returns:
+        status code: status code 
+    """
+    run_files = ' '.join(run_ls)
+    cmd = f'python -m pyserini.fusion --runs {run_files} --output {output} --k {k}'
+    return os.system(cmd)


### PR DESCRIPTION
Update:
- Regression test script for all methods
  - tested on ORCA, both TriviaQA and NaturalQuestion passed regression tests
- 2cr webpage updated
  - ground truth changed for DPR-Hybrid (improved performance on NQ using single-nq setting + nq-test instead of multi + dpr-nq-test)
 - `--topics` choices changed from 'naturalquestion' and 'triviaqa' to 'nq' and 'tqa' 