### PR TITLE
Update dense retrieval reproduction logs; minor updates to scores

### DIFF
--- a/docs/experiments-ance.md
+++ b/docs/experiments-ance.md
@@ -169,3 +169,4 @@ Top100	accuracy: 0.8522
 + Results reproduced by [@yuki617](https://github.com/yuki617) on 2021-06-07 (commit [`c7b37d`](https://github.com/castorini/pyserini/commit/c7b37d6073cda62685f64d6d0b99dc46f0718346))
 + Results reproduced by [@ArthurChen189](https://github.com/ArthurChen189) on 2021-07-06 (commit [`c9f44b`](https://github.com/castorini/pyserini/commit/c9f44b2a24103fff4887cade831f9b7c2472b190))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-23 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-bpr.md
+++ b/docs/experiments-bpr.md
@@ -57,3 +57,4 @@ Top100 accuracy: 0.8573
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-09-08 (commit [`d7a7be`](https://github.com/castorini/pyserini/commit/d7a7bededc650dfa87eb89ba92907fd97a10310b))
 + Results reproduced by [@HAKSOAT](https://github.com/HAKSOAT) on 2022-03-11 (commit [`779668`](https://github.com/castorini/pyserini/commit/77966851755163e36489544fb08f73171e98103f))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-24 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-distilbert_kd.md
+++ b/docs/experiments-distilbert_kd.md
@@ -53,3 +53,4 @@ recall_1000             all     0.9553
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-26 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-23 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-distilbert_tasb.md
+++ b/docs/experiments-distilbert_tasb.md
@@ -54,3 +54,4 @@ recall_1000             all     0.9771
  
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-05-28 (commit [`102ed2`](https://github.com/castorini/pyserini/commit/102ed2b2e8770978e4b3e09804913dcffb63c4a7))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-23 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-dkrr.md
+++ b/docs/experiments-dkrr.md
@@ -144,3 +144,4 @@ Running hybrid sparse-dense retrieval with DKKR and [GAR-T5](https://github.com/
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-02-12 (commit [`52a1e7`](https://github.com/castorini/pyserini/commit/52a1e7f241b7b833a3ec1d739e629c08417a324c))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-23 (commit [`90676b`](https://github.com/castorini/pyserini/commit/90676b351b47585084aa8136265d02a67ced3803))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-dpr.md
+++ b/docs/experiments-dpr.md
@@ -27,13 +27,13 @@ Here's how our results stack up against results reported in the paper using the 
 | Dataset     | Method        | Top-20 (orig) | Top-20 (us) | Top-100 (orig) | Top-100 (us) |
 |:------------|:--------------|--------------:|------------:|---------------:|-------------:|
 | NQ          | DPR           |          79.4 |        79.5 |           86.0 |         86.1 |
-| NQ          | BM25          |          59.1 |        62.9 |           73.7 |         78.3 |
+| NQ          | BM25          |          59.1 |        63.0 |           73.7 |         78.2 |
 | NQ          | Hybrid        |          78.0 |        82.6 |           83.9 |         88.6 |
 | TriviaQA    | DPR           |          78.8 |        78.9 |           84.7 |         84.8 |
-| TriviaQA    | BM25          |          66.9 |        76.4 |           76.7 |         83.2 |
-| TriviaQA    | Hybrid        |          79.9 |        82.6 |           84.4 |         86.5 |
-| WQ          | DPR           |          75.0 |        75.0 |           82.9 |         83.0 |
-| WQ          | BM25          |          55.0 |        62.4 |           71.1 |         75.5 |
+| TriviaQA    | BM25          |          66.9 |        76.4 |           76.7 |         83.1 |
+| TriviaQA    | Hybrid        |          79.9 |        82.6 |           84.4 |         86.6 |
+| WQ          | DPR           |          75.0 |        75.1 |           82.9 |         83.0 |
+| WQ          | BM25          |          55.0 |        62.3 |           71.1 |         75.5 |
 | WQ          | Hybrid        |          74.7 |        77.1 |           82.3 |         84.4 |
 | CuratedTREC | DPR           |          89.1 |        88.8 |           93.9 |         93.4 |
 | CuratedTREC | BM25          |          70.9 |        80.7 |           84.1 |         89.9 |
@@ -107,8 +107,8 @@ python -m pyserini.eval.evaluate_dpr_retrieval \
 And the expected results:
 
 ```
-Top20  accuracy: 0.6294
-Top100 accuracy: 0.7825
+Top20  accuracy: 0.6299
+Top100 accuracy: 0.7823
 ```
 
 **Hybrid dense-sparse retrieval** (combining above two approaches):
@@ -210,7 +210,7 @@ And the expected results:
 
 ```
 Top20  accuracy: 0.7641
-Top100 accuracy: 0.8315
+Top100 accuracy: 0.8314
 ```
 
 **Hybrid dense-sparse retrieval** (combining above two approaches):
@@ -311,7 +311,7 @@ python -m pyserini.eval.evaluate_dpr_retrieval \
 And the expected results:
 
 ```
-Top20  accuracy: 0.6240
+Top20  accuracy: 0.6230
 Top100 accuracy: 0.7549
 ```
 
@@ -504,7 +504,6 @@ python -m pyserini.search.lucene \
   --output runs/run.dpr.squad-test.bm25.trec
 ```
 
-
 To evaluate, first convert the TREC output format to DPR's `json` format:
 
 ```bash
@@ -522,8 +521,8 @@ python -m pyserini.eval.evaluate_dpr_retrieval \
 And the expected results:
 
 ```
-Top20  accuracy: 0.7109
-Top100 accuracy: 0.8184
+Top20  accuracy: 0.7107
+Top100 accuracy: 0.8183
 ```
 
 **Hybrid dense-sparse retrieval** (combining above two approaches):
@@ -558,7 +557,7 @@ python -m pyserini.eval.evaluate_dpr_retrieval \
 And the expected results:
 
 ```
-Top20  accuracy: 0.7511
+Top20  accuracy: 0.7514
 Top100 accuracy: 0.8437
 ```
 
@@ -643,3 +642,4 @@ Top100	accuracy: 0.8837
 + Results reproduced by [@vivianliu0](https://github.com/vivianliu0) on 2022-01-20 (commit [`67d0a6`](https://github.com/castorini/pyserini/commit/c38c557faaa3b9ededf1e8504dd67a5be67d0a66))
 + Results reproduced by [@manveertamber](https://github.com/manveertamber) on 2022-01-22 (commit [`ef70c6`](https://github.com/castorini/pyserini/commit/ef70c63efd773e87afd9708338827342f4960540))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-25 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-sbert.md
+++ b/docs/experiments-sbert.md
@@ -72,7 +72,7 @@ $ python -m pyserini.eval.msmarco_passage_eval \
     msmarco-passage-dev-subset runs/run.msmarco-passage.sbert.bf.bm25.tsv
 
 #####################
-MRR @10: 0.3379
+MRR @10: 0.3380
 QueriesRanked: 6980
 #####################
 
@@ -83,7 +83,7 @@ $ python -m pyserini.eval.convert_msmarco_run_to_trec_run \
 $ python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap msmarco-passage-dev-subset \
     runs/run.msmarco-passage.sbert.bf.bm25.trec
 
-map                     all     0.3445
+map                     all     0.3446
 recall_1000             all     0.9659
 ```
 
@@ -92,3 +92,4 @@ recall_1000             all     0.9659
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-02 (commit [`8dcf99`](https://github.com/castorini/pyserini/commit/8dcf99982a7bfd447ce9182ff219a9dad2ddd1f2))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-04-26 (commit [`854c19`](https://github.com/castorini/pyserini/commit/854c1930ba00819245c0a9fbcf2090ce14db4db0))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-23 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-tct_colbert-v2.md
+++ b/docs/experiments-tct_colbert-v2.md
@@ -17,7 +17,7 @@ Summary of results (figures from the paper are in parentheses):
 | TCT_ColBERT-V2 (brute-force index)                            | 0.3440 (0.344) | 0.3509 |      0.9670 |
 | TCT_ColBERT-V2-HN (brute-force index)                         | 0.3543 (0.354) | 0.3608 |      0.9708 |
 | TCT_ColBERT-V2-HN+ (brute-force index)                        | 0.3585 (0.359) | 0.3645 |      0.9695 |
-| TCT_ColBERT-V2-HN+ (brute-force index) + BoW BM25             | 0.3682 (0.369) | 0.3737 |      0.9707 |
+| TCT_ColBERT-V2-HN+ (brute-force index) + BoW BM25             | 0.3683 (0.369) | 0.3737 |      0.9707 |
 | TCT_ColBERT-V2-HN+ (brute-force index) + BM25 w/ doc2query-T5 | 0.3731 (0.375) | 0.3789 |      0.9759 |
 
 The slight differences between the reproduced scores and those reported in the paper can be attributed to TensorFlow implementations in the published paper vs. PyTorch implementations here in this reproduction guide.
@@ -169,7 +169,7 @@ $ python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset \
     runs/run.msmarco-passage.tct_colbert-v2-hnp.bf.bm25.tsv
 
 #####################
-MRR @10: 0.3682
+MRR @10: 0.3683
 QueriesRanked: 6980
 #####################
 
@@ -321,3 +321,4 @@ ndcg_cut_10             all     0.6094
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-07-01 (commit [`b1576a`](https://github.com/castorini/pyserini/commit/b1576a2c3e899349be12e897f92f3ad75ec82d6f))
 + Results reproduced by [@yuki617](https://github.com/yuki617) on 2021-06-30 (commit [`b3f3d9`](https://github.com/castorini/pyserini/commit/b3f3d94f2d2397e684094be7e997c9fe45c6fa76))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-25 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))

--- a/docs/experiments-tct_colbert.md
+++ b/docs/experiments-tct_colbert.md
@@ -194,7 +194,7 @@ Summary of results:
 |:-------------------------------------------------------|--------:|-------:|-----------:|
 | TCT-ColBERT (brute-force index)                        |  0.3323 | 0.3323 |     0.8664 |
 | TCT-ColBERT (brute-force index) + BoW BM25             |  0.3701 | 0.3701 |     0.9020 |
-| TCT-ColBERT (brute-force index) + BM25 w/ doc2query-T5 |  0.3784 | 0.3784 |     0.9081 |
+| TCT-ColBERT (brute-force index) + BM25 w/ doc2query-T5 |  0.3784 | 0.3784 |     0.9083 |
 
 Although this is not described in the paper, we have adapted TCT-ColBERT to the MS MARCO document ranking task in a zero-shot manner.
 Documents in the MS MARCO document collection are first segmented, and each segment is then encoded with the TCT-ColBERT model trained on trained on MS MARCO passages.
@@ -323,7 +323,7 @@ $ python -m pyserini.eval.trec_eval -c -mrecall.100 -mmap msmarco-doc-dev \
     runs/run.msmarco-doc.tct_colbert.bf.doc2queryT5.trec
 
 map                   	all	0.3784
-recall_100            	all	0.9081
+recall_100            	all	0.9083
 ```
 
 ## Reproduction Log[*](reproducibility.md)
@@ -335,3 +335,4 @@ recall_100            	all	0.9081
 + Results reproduced by [@jmmackenzie](https://github.com/jmmackenzie) on 2021-05-17 ([PyPI 0.12.0](https://pypi.org/project/pyserini/0.12.0/))
 + Results reproduced by [@ArthurChen189](https://github.com/ArthurChen189) on 2021-06-12 (commit [`f61411`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-24 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))


### PR DESCRIPTION
During the holidays, I reran a bunch of dense retrieval experiments on `orca`. I noted minor score changes... nothing major.