### PR TITLE
Integrate new pre-encoded queries for MS MARCO v1 passage conditions into 2CR framework

### DIFF
--- a/docs/2cr/msmarco-v1-passage.html
+++ b/docs/2cr/msmarco-v1-passage.html
@@ -1869,44 +1869,46 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 <!-- Tabs content -->
 <div class="tab-content" id="row17-content">
   <div class="tab-pane fade show active" id="row17-tab1" role="tabpanel" aria-labelledby="row17-tab1">
-    Command to generate run on TREC DL19 queries:
+Command to generate run on TREC 2019 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-ance-bf \
-    --topics dl19-passage --encoded-queries ance-dl19-passage \
-    --output run.msmarco-v1-passage.ance.dl19.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.ance.dl19.txt
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-ance-bf \
+  --topics dl19-passage --encoded-queries ance-dl19-passage \
+  --output run.msmarco-v1-passage.ance.dl19.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.ance.dl19.txt
 python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.ance.dl19.txt
 python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.ance.dl19.txt
-  </code></pre>
-    </blockquote>
+</code></pre>
+  </blockquote>
+
   </div>
   <div class="tab-pane fade" id="row17-tab2" role="tabpanel" aria-labelledby="row17-tab2">
-    Command to generate run on TREC DL20 queries:
+    Command to generate run on TREC 2020 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-ance-bf \
-    --topics dl20 --encoded-queries ance-dl20 \
-    --output run.msmarco-v1-passage.ance.dl20.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.ance.dl20.txt
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-ance-bf \
+  --topics dl20 --encoded-queries ance-dl20 \
+  --output run.msmarco-v1-passage.ance.dl20.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.ance.dl20.txt
 python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.ance.dl20.txt
 python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.ance.dl20.txt
-  </code></pre>
-    </blockquote>
+</code></pre>
+  </blockquote>
+
   </div>
   <div class="tab-pane fade" id="row17-tab3" role="tabpanel" aria-labelledby="row17-tab3">
     Command to generate run on dev queries:
@@ -1971,44 +1973,46 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 <!-- Tabs content -->
 <div class="tab-content" id="row18-content">
   <div class="tab-pane fade show active" id="row18-tab1" role="tabpanel" aria-labelledby="row18-tab1">
-    Command to generate run on TREC DL19 queries:
+Command to generate run on TREC 2019 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-distilbert-dot-margin_mse-T2-bf \
-    --topics dl19-passage --encoded-queries distilbert_kd-dl19-passage \
-    --output run.msmarco-v1-passage.distilbert-kd.dl19.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.distilbert-kd.dl19.txt
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-distilbert-dot-margin_mse-T2-bf \
+  --topics dl19-passage --encoded-queries distilbert_kd-dl19-passage \
+  --output run.msmarco-v1-passage.distilbert-kd.dl19.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.distilbert-kd.dl19.txt
 python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.distilbert-kd.dl19.txt
 python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.distilbert-kd.dl19.txt
-  </code></pre>
-    </blockquote>
+</code></pre>
+  </blockquote>
+
   </div>
   <div class="tab-pane fade" id="row18-tab2" role="tabpanel" aria-labelledby="row18-tab2">
-    Command to generate run on TREC DL20 queries:
+    Command to generate run on TREC 2020 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-distilbert-dot-margin_mse-T2-bf \
-    --topics dl20 --encoded-queries distilbert_kd-dl20 \
-    --output run.msmarco-v1-passage.distilbert-kd.dl20.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.distilbert-kd.dl20.txt
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-distilbert-dot-margin_mse-T2-bf \
+  --topics dl20 --encoded-queries distilbert_kd-dl20 \
+  --output run.msmarco-v1-passage.distilbert-kd.dl20.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.distilbert-kd.dl20.txt
 python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.distilbert-kd.dl20.txt
 python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.distilbert-kd.dl20.txt
-  </code></pre>
-    </blockquote>
+</code></pre>
+  </blockquote>
+
   </div>
   <div class="tab-pane fade" id="row18-tab3" role="tabpanel" aria-labelledby="row18-tab3">
     Command to generate run on dev queries:
@@ -2073,44 +2077,46 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 <!-- Tabs content -->
 <div class="tab-content" id="row19-content">
   <div class="tab-pane fade show active" id="row19-tab1" role="tabpanel" aria-labelledby="row19-tab1">
-    Command to generate run on TREC DL19 queries:
+Command to generate run on TREC 2019 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-distilbert-dot-tas_b-b256-bf \
-    --topics dl19-passage --encoded-queries distilbert_tas_b-dl19-passage \
-    --output run.msmarco-v1-passage.distilbert_tas_b.dl19.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.distilbert_tas_b.dl19.txt
-python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.distilbert_tas_b.dl19.txt
-python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.distilbert_tas_b.dl19.txt
-  </code></pre>
-    </blockquote>
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-distilbert-dot-tas_b-b256-bf \
+  --topics dl19-passage --encoded-queries distilbert_tas_b-dl19-passage \
+  --output run.msmarco-v1-passage.distilbert-kd-tasb.dl19.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.distilbert-kd-tasb.dl19.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.distilbert-kd-tasb.dl19.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.distilbert-kd-tasb.dl19.txt
+</code></pre>
+  </blockquote>
+
   </div>
   <div class="tab-pane fade" id="row19-tab2" role="tabpanel" aria-labelledby="row19-tab2">
-    Command to generate run on TREC DL20 queries:
+    Command to generate run on TREC 2020 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-distilbert-dot-tas_b-b256-bf \
-    --topics dl20 --encoded-queries distilbert_tas_b-dl20 \
-    --output run.msmarco-v1-passage.distilbert_tas_b.dl20.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.distilbert_tas_b.dl20.txt
-python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.distilbert_tas_b.dl20.txt
-python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.distilbert_tas_b.dl20.txt
-  </code></pre>
-    </blockquote>
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-distilbert-dot-tas_b-b256-bf \
+  --topics dl20 --encoded-queries distilbert_tas_b-dl20 \
+  --output run.msmarco-v1-passage.distilbert-kd-tasb.dl20.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.distilbert-kd-tasb.dl20.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.distilbert-kd-tasb.dl20.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.distilbert-kd-tasb.dl20.txt
+</code></pre>
+  </blockquote>
+
   </div>
   <div class="tab-pane fade" id="row19-tab3" role="tabpanel" aria-labelledby="row19-tab3">
     Command to generate run on dev queries:
@@ -2120,7 +2126,7 @@ python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarc
   --threads 16 --batch-size 512 \
   --index msmarco-passage-distilbert-dot-tas_b-b256-bf \
   --topics msmarco-passage-dev-subset --encoded-queries distilbert_tas_b-msmarco-passage-dev-subset \
-  --output run.msmarco-v1-passage.distilbert-kd-tasb.dev.txt
+  --output run.msmarco-v1-passage.distilbert-kd-tasb.dev.txt \
  
 </code></pre></blockquote>
 Evaluation commands:
@@ -2175,45 +2181,46 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 <!-- Tabs content -->
 <div class="tab-content" id="row20-content">
   <div class="tab-pane fade show active" id="row20-tab1" role="tabpanel" aria-labelledby="row20-tab1">
-    Command to generate run on TREC DL19 queries:
+Command to generate run on TREC 2019 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-tct_colbert-v2-hnp-bf \
-    --topics dl19-passage --encoded-queries tct_colbert-v2-hnp-dl19-passage \
-    --output run.msmarco-v1-passage.tct_colbert-v2-hnp.dl19.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl19.txt
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-tct_colbert-v2-hnp-bf \
+  --topics dl19-passage --encoded-queries tct_colbert-v2-hnp-dl19-passage \
+  --output run.msmarco-v1-passage.tct_colbert-v2-hnp.dl19.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl19.txt
 python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl19.txt
 python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl19.txt
-  </code></pre>
-    </blockquote>
+</code></pre>
+  </blockquote>
+
   </div>
-
   <div class="tab-pane fade" id="row20-tab2" role="tabpanel" aria-labelledby="row20-tab2">
-    Command to generate run on TREC DL20 queries:
+    Command to generate run on TREC 2020 queries:
 
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.search.faiss \
-    --threads 16 --batch-size 512 \
-    --index msmarco-passage-tct_colbert-v2-hnp-bf \
-    --topics dl20 --encoded-queries tct_colbert-v2-hnp-dl20 \
-    --output run.msmarco-v1-passage.tct_colbert-v2-hnp.dl20.txt
-   
-  </code></pre></blockquote>
-  Evaluation commands:
-  
-    <blockquote class="mycode">
-  <pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl20.txt
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 512 \
+  --index msmarco-passage-tct_colbert-v2-hnp-bf \
+  --topics dl20 --encoded-queries tct_colbert-v2-hnp-dl20 \
+  --output run.msmarco-v1-passage.tct_colbert-v2-hnp.dl20.txt \
+ 
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl20.txt
 python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl20.txt
 python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.tct_colbert-v2-hnp.dl20.txt
-  </code></pre>
-    </blockquote>
+</code></pre>
+  </blockquote>
+
   </div>
   <div class="tab-pane fade" id="row20-tab3" role="tabpanel" aria-labelledby="row20-tab3">
     Command to generate run on dev queries:
@@ -2286,7 +2293,7 @@ Command to generate run on TREC 2019 queries:
   --threads 16 --batch-size 512 \
   --index msmarco-passage-ance-bf \
   --topics dl19-passage --encoder castorini/ance-msmarco-passage \
-  --output run.msmarco-v1-passage.ance-otf.dl19.txt
+  --output run.msmarco-v1-passage.ance-otf.dl19.txt \
  
 </code></pre></blockquote>
 Evaluation commands:
@@ -2307,7 +2314,7 @@ python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarc
   --threads 16 --batch-size 512 \
   --index msmarco-passage-ance-bf \
   --topics dl20 --encoder castorini/ance-msmarco-passage \
-  --output run.msmarco-v1-passage.ance-otf.dl20.txt
+  --output run.msmarco-v1-passage.ance-otf.dl20.txt \
  
 </code></pre></blockquote>
 Evaluation commands:

--- a/pyserini/resources/msmarco-v1-passage.yaml
+++ b/pyserini/resources/msmarco-v1-passage.yaml
@@ -114,13 +114,25 @@ conditions:
     display: "DistilBERT KD TASB: pre-encoded"
     display-html: "DistilBERT KD TASB: pre-encoded queries"
     display-row: "[4]"
-    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-distilbert-dot-tas_b-b256-bf --topics $topics --encoded-queries distilbert_tas_b-msmarco-passage-dev-subset --output $output
+    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-distilbert-dot-tas_b-b256-bf --topics $topics --encoded-queries distilbert_tas_b-$topics --output $output
     topics:
       - topic_key: msmarco-passage-dev-subset
         eval_key: msmarco-passage-dev-subset
         scores:
           - MRR@10: 0.3444
             R@1K: 0.9771
+      - topic_key: dl19-passage
+        eval_key: dl19-passage
+        scores:
+          - MAP: 0.4590
+            nDCG@10: 0.7210
+            R@1K: 0.8406
+      - topic_key: dl20
+        eval_key: dl20-passage
+        scores:
+          - MAP: 0.4698
+            nDCG@10: 0.6854
+            R@1K: 0.8727
   - name: distilbert-kd-otf
     display: "DistilBERT KD: otf"
     display-html: "DistilBERT KD: on-the-fly query inference"
@@ -148,13 +160,25 @@ conditions:
     display: "DistilBERT KD: pre-encoded"
     display-html: "DistilBERT KD: pre-encoded queries"
     display-row: "[3]"
-    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-distilbert-dot-margin_mse-T2-bf --topics $topics --encoded-queries distilbert_kd-msmarco-passage-dev-subset --output $output
+    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-distilbert-dot-margin_mse-T2-bf --topics $topics --encoded-queries distilbert_kd-$topics --output $output
     topics:
       - topic_key: msmarco-passage-dev-subset
         eval_key: msmarco-passage-dev-subset
         scores:
           - MRR@10: 0.3251
             R@1K: 0.9553
+      - topic_key: dl19-passage
+        eval_key: dl19-passage
+        scores:
+          - MAP: 0.4053
+            nDCG@10: 0.6994
+            R@1K: 0.7653
+      - topic_key: dl20
+        eval_key: dl20-passage
+        scores:
+          - MAP: 0.4159
+            nDCG@10: 0.6447
+            R@1K: 0.7953
   - name: ance-otf
     display: "ANCE: otf"
     display-html: "ANCE: on-the-fly query inference"
@@ -182,13 +206,25 @@ conditions:
     display: "ANCE: pre-encoded"
     display-html: "ANCE: pre-encoded queries"
     display-row: "[2]"
-    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-ance-bf --topics $topics --encoded-queries ance-msmarco-passage-dev-subset --output $output
+    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-ance-bf --topics $topics --encoded-queries ance-$topics --output $output
     topics:
       - topic_key: msmarco-passage-dev-subset
         eval_key: msmarco-passage-dev-subset
         scores:
           - MRR@10: 0.3302
             R@1K: 0.9584
+      - topic_key: dl19-passage
+        eval_key: dl19-passage
+        scores:
+          - MAP: 0.3710
+            nDCG@10: 0.6452
+            R@1K: 0.7554
+      - topic_key: dl20
+        eval_key: dl20-passage
+        scores:
+          - MAP: 0.4076
+            nDCG@10: 0.6458
+            R@1K: 0.7764
   - name: bm25-tuned
     display: BM25 (k1=0.82, b=0.68)
     display-html: BM25 (<i>k<sub><small>1</small></sub></i>=0.82, <i>b</i>=0.68)
@@ -486,11 +522,22 @@ conditions:
     display: "TCT_ColBERT-V2-HN+: pre-encoded"
     display-html: "TCT_ColBERT-V2-HN+: pre-encoded queries"
     display-row: "[5]"
-    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-tct_colbert-v2-hnp-bf --topics $topics --encoded-queries tct_colbert-v2-hnp-msmarco-passage-dev-subset --output $output
+    command: python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-passage-tct_colbert-v2-hnp-bf --topics $topics --encoded-queries tct_colbert-v2-hnp-$topics --output $output
     topics:
       - topic_key: msmarco-passage-dev-subset
         eval_key: msmarco-passage-dev-subset
         scores:
           - MRR@10: 0.3584
             R@1K: 0.9695
-      # TODO: We don't have DL19 an DL20 queries pre-encoded
+      - topic_key: dl19-passage
+        eval_key: dl19-passage
+        scores:
+          - MAP: 0.4469
+            nDCG@10: 0.7204
+            R@1K: 0.8261
+      - topic_key: dl20
+        eval_key: dl20-passage
+        scores:
+          - MAP: 0.4754
+            nDCG@10: 0.6882
+            R@1K: 0.8429


### PR DESCRIPTION
Generate docs automatically:

```
python scripts/repro_matrix/generate_html_msmarco.py \
  --collection v1-passage > docs/2cr/msmarco-v1-passage.html
```