### PR TITLE
Update requirements.txt - pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython>=0.29.21
 numpy>=1.18.1
-pandas>=1.1.5
+pandas>=1.4.0
 pyjnius>=1.4.0
 scikit-learn>=0.22.1
 scipy>=1.4.1


### PR DESCRIPTION
https://github.com/castorini/pyserini/pull/1419 - latest pre-encoded queries was encoded with pandas 1.5.1 by Xueguang.
Causes backward compatibility issues; works for pandas 1.4.4 (so 1.4.x should work), but fails on 1.3.5.
Solution is to bump up requirements.