### PR TITLE
Update Lucene Indexer to match SimpleIndexer in Anserini

### DIFF
--- a/pyserini/index/lucene/_indexer.py
+++ b/pyserini/index/lucene/_indexer.py
@@ -15,6 +15,7 @@
 #
 
 import logging
+from typing import List
 
 from pyserini.pyclass import autoclass
 
@@ -33,9 +34,14 @@ class LuceneIndexer:
         Path to Lucene index directory.
     """
 
-    def __init__(self, index_dir: str):
+    def __init__(self, index_dir: str = None, args: List[str] = None):
         self.index_dir = index_dir
-        self.object = JLuceneIndexer(index_dir)
+        self.args = args
+        if args:
+            # `-input` is required by `IndexCollection.Args` but not by `SimpleIndexer`
+            self.object = JLuceneIndexer(args)
+        else:
+            self.object = JLuceneIndexer(index_dir)
 
     def add(self, doc: str):
         """Add a document to the index.

--- a/pyserini/index/lucene/_indexer.py
+++ b/pyserini/index/lucene/_indexer.py
@@ -32,13 +32,19 @@ class LuceneIndexer:
     ----------
     index_dir : str
         Path to Lucene index directory.
+    args : List[str]
+        List of arguments to pass to ``SimpleIndexer``.
     """
 
     def __init__(self, index_dir: str = None, args: List[str] = None):
         self.index_dir = index_dir
         self.args = args
         if args:
-            # `-input` is required by `IndexCollection.Args` but not by `SimpleIndexer`
+            default_args = ["-input", "", "-collection", "JsonCollection"]
+            if not "-threads" in args:
+                default_args.extend(["-threads", "1"])
+            
+            args.extend(default_args)
             self.object = JLuceneIndexer(args)
         else:
             self.object = JLuceneIndexer(index_dir)

--- a/tests/test_index_otf.py
+++ b/tests/test_index_otf.py
@@ -55,5 +55,29 @@ class TestSearch(unittest.TestCase):
         self.assertEqual('CACM-2274', hits[0].docid)
         self.assertAlmostEqual(1.53650, hits[0].score, places=5)
 
+    def test_indexer_with_args(self):
+        indexer = LuceneIndexer(args=[
+            "-input", "", "-index", self.tmp_dir,
+            "-collection", "JsonCollection"
+            , "-threads", "1", "-pretokenized"
+        ])
+
+        with open(self.test_file) as f:
+            for doc in f:
+                indexer.add(doc)
+
+        indexer.close()
+
+        searcher = LuceneSearcher(self.tmp_dir)
+        self.assertEqual(3, searcher.num_docs)
+
+        hits = searcher.search('semantic networks')
+
+        self.assertTrue(isinstance(hits, List))
+        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertEqual(1, len(hits))
+        self.assertEqual('CACM-2274', hits[0].docid)
+        self.assertAlmostEqual(0.62610, hits[0].score, places=5)
+
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)

--- a/tests/test_index_otf.py
+++ b/tests/test_index_otf.py
@@ -56,11 +56,7 @@ class TestSearch(unittest.TestCase):
         self.assertAlmostEqual(1.53650, hits[0].score, places=5)
 
     def test_indexer_with_args(self):
-        indexer = LuceneIndexer(args=[
-            "-input", "", "-index", self.tmp_dir,
-            "-collection", "JsonCollection"
-            , "-threads", "1", "-pretokenized"
-        ])
+        indexer = LuceneIndexer(args=["-index", self.tmp_dir, "-pretokenized"])
 
         with open(self.test_file) as f:
             for doc in f:


### PR DESCRIPTION
This allows us to pass additional arguments as discussed here [#2061](https://github.com/castorini/anserini/pull/2061).

Arguments marked as required by `IndexCollection.Args` but not required by the `SimpleIndexer` (e.g. `collection`) are handled appropriately so no need to pass these parameters when using the class with Args. 