### PR TITLE
Add ability to append to existing index

### DIFF
--- a/pyserini/index/lucene/_indexer.py
+++ b/pyserini/index/lucene/_indexer.py
@@ -34,20 +34,20 @@ class LuceneIndexer:
         Path to Lucene index directory.
     args : List[str]
         List of arguments to pass to ``SimpleIndexer``.
+    append : bool
+        Append to existing index.
     """
 
-    def __init__(self, index_dir: str = None, args: List[str] = None):
+    def __init__(self, index_dir: str = None, args: List[str] = None, append: bool = False):
         self.index_dir = index_dir
         self.args = args
         if args:
-            default_args = ["-input", "", "-collection", "JsonCollection"]
-            if not "-threads" in args:
-                default_args.extend(["-threads", "1"])
-            
-            args.extend(default_args)
+            args.extend(['-input', '', '-collection', 'JsonCollection'])
+            if append:
+                args.extend(['-append'])
             self.object = JLuceneIndexer(args)
         else:
-            self.object = JLuceneIndexer(index_dir)
+            self.object = JLuceneIndexer(index_dir, append)
 
     def add(self, doc: str):
         """Add a document to the index.


### PR DESCRIPTION
Python bindings for https://github.com/castorini/anserini/pull/2062

Requested feature: https://github.com/castorini/pyserini/issues/1443

This now works:

```python
>>> from pyserini.index.lucene import LuceneIndexer, IndexReader
>>> indexer = LuceneIndexer('index')
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2023-02-23 15:32:17,020 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:115) - Using DefaultEnglishAnalyzer
2023-02-23 15:32:17,022 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:116) - Stemmer: porter
2023-02-23 15:32:17,022 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:117) - Keep stopwords? false
2023-02-23 15:32:17,023 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:118) - Stopwords file: null
>>> indexer.add('{"id": "0", "contents": "Document 0"}')
>>> indexer.close()
>>> reader = IndexReader("index")
>>> print(reader.stats())
{'total_terms': 2, 'documents': 1, 'non_empty_documents': 1, 'unique_terms': 2}
>>> 
>>> indexer = LuceneIndexer('index', append=True)
2023-02-23 15:32:23,091 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:115) - Using DefaultEnglishAnalyzer
2023-02-23 15:32:23,091 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:116) - Stemmer: porter
2023-02-23 15:32:23,091 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:117) - Keep stopwords? false
2023-02-23 15:32:23,091 INFO  [main] index.SimpleIndexer (SimpleIndexer.java:118) - Stopwords file: null
>>> indexer.add('{"id": "1", "contents": "Document 1"}')
>>> indexer.close()
>>> reader = IndexReader("index")
>>> print(reader.stats())
{'total_terms': 4, 'documents': 2, 'non_empty_documents': 2, 'unique_terms': -1}
```

@theyorubayesian btw, `-threads` is optional now, with a default.