### PR TITLE
Improve (multi-threaded) batch indexing capabilities to LuceneIndexer

### DIFF
--- a/pyserini/index/lucene/__init__.py
+++ b/pyserini/index/lucene/__init__.py
@@ -15,6 +15,7 @@
 #
 
 from ._base import Document, Generator, IndexTerm, Posting, IndexReader
-from ._indexer import LuceneIndexer
+from ._indexer import LuceneIndexer, JacksonObjectMapper, JacksonJsonNode
 
-__all__ = ['Document', 'Generator', 'IndexTerm', 'Posting', 'IndexReader', 'LuceneIndexer']
+__all__ = ['Document', 'Generator', 'IndexTerm', 'Posting', 'IndexReader', 'LuceneIndexer',
+           'JacksonObjectMapper', 'JacksonJsonNode']

--- a/pyserini/index/lucene/_indexer.py
+++ b/pyserini/index/lucene/_indexer.py
@@ -42,7 +42,6 @@ class LuceneIndexer:
     threads : int
         Number of indexing threads.
     """
-
     def __init__(self, index_dir: str = None, args: List[str] = None, append: bool = False, threads: int = 8):
         self.index_dir = index_dir
         self.args = args
@@ -57,7 +56,7 @@ class LuceneIndexer:
         self.mapper = JacksonObjectMapper()
 
     def add_doc_raw(self, doc: str):
-        """Add a document to the index.
+        """Add a raw document (in the form of a JSON string) to the index.
 
         Parameters
         ----------
@@ -67,13 +66,27 @@ class LuceneIndexer:
         self.object.addRawDocument(doc)
 
     def add_doc_dict(self, doc: Dict[str, str]):
+        """Add a document (in the form of a Python dictionary) to the index.
+
+        Parameters
+        ----------
+        doc : Dict[str, str]
+            Document to add.
+        """
         self.object.addJsonDocument(JsonCollectionDocument.fromFields(doc['id'], doc['contents']))
 
     def add_doc_json(self, node: JacksonJsonNode):
+        """Add a document (in the form of a Jackson JSON node object) to the index.
+
+        Parameters
+        ----------
+        node : JacksonJsonNode
+            Document to add.
+        """
         self.object.addJsonNode(node)
 
     def add_batch_raw(self, docs: List[str]):
-        """Add a batch of documents to the index.
+        """Add a batch of raw documents (in the form of JSON strings) to the index.
 
         Parameters
         ----------
@@ -83,10 +96,24 @@ class LuceneIndexer:
         self.object.addRawDocuments(docs)
 
     def add_batch_dict(self, docs: List[Dict[str, str]]):
+        """Add a batch of documents (in the form of Python dictionaries) to the index.
+
+        Parameters
+        ----------
+        docs : List[Dict[str, str]]
+            Documents to add.
+        """
         docs = list(map(lambda d: JsonCollectionDocument.fromFields(d['id'], d['contents']), docs))
         self.object.addJsonDocuments(docs)
 
     def add_batch_json(self, nodes: List[JacksonJsonNode]):
+        """Add a batch of documents (in the form of Jackson JSON node objects) to the index.
+
+        Parameters
+        ----------
+        nodes : List[JacksonJsonNode]
+            Documents to add.
+        """
         self.object.addJsonNodes(nodes)
 
     def close(self):

--- a/scripts/msmarco-passage/index_msmarco_passage2.py
+++ b/scripts/msmarco-passage/index_msmarco_passage2.py
@@ -85,4 +85,4 @@ if __name__ == '__main__':
 
     indexer.close()
     end = time.time()
-    print(f'Total {cnt} docs indexed in {end - start:.0f}s, {cnt/(cur - start):.0f} docs/s')
+    print(f'Total {cnt} docs indexed in {end - start:.0f}s, {cnt/(end - start):.0f} docs/s')


### PR DESCRIPTION
Pyserini counterpart to https://github.com/castorini/anserini/pull/2065

Clarifies three six different methods to add documents to index:
+ add string JSON, Python dict, and Jackson JSON node
+ add single doc/add batch