### PR TITLE
Update code for fetching a document in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ A sparse (Lucene) index can be configured to include the raw document text, in w
 from pyserini.search.lucene import LuceneSearcher
 
 searcher = LuceneSearcher.from_prebuilt_index('msmarco-v1-passage')
-doc = searcher.doc('7157715')
+doc = searcher.doc('doc7157715')
 ```
 
 <details>


### PR DESCRIPTION
The original code for fetching a document in the readme did not work properly, as it returned NoneType instead of the expected document. So I modified it to improve its functionality. Specifically, I changed the code from doc = searcher.doc('7157715') to doc = searcher.doc('doc7157715').

I apologize for the extra files that were created in my previous PR. I'm not sure what caused the creation of multiple extra files in the contributors/ directory during my previous PR submission. I hope it wouldn't happen again, but if it happend, please tell me how to fixed it.

Thank you for considering my contribution.