### PR TITLE
fix aggretriever readme with prebuilt index and add encoder test

### DIFF
--- a/docs/experiments-aggretriever.md
+++ b/docs/experiments-aggretriever.md
@@ -24,15 +24,15 @@ Dense retrieval with Aggretriever-DistilBERT, brute-force index:
 
 ```bash
 python -m pyserini.search.faiss \
-  --index /store/scratch/s269lin/experiments/aggretriever/index/aggretriever-distilbert \
+  --index msmarco-passage.aggretriever-distilbert \
   --topics msmarco-passage-dev-subset \
-  --encoded-queries /store/scratch/s269lin/experiments/aggretriever/queries/aggretriever-distilbert \
+  --encoded-queries aggretriever-distilbert-msmarco-passage-dev-subset \
   --output runs/run.msmarco-passage.distilbert-agg.bf.tsv \
   --output-format trec \
   --batch-size 36 --threads 12
 ```
 
-Note that to ensure maximum reproducibility, by default Pyserini uses pre-computed query representations that are automatically downloaded. As an alternative, replace `--encoded-queries /store/scratch/s269lin/experiments/aggretriever/queries/aggretriever-distilbert` with `--encoder /store/scratch/s269lin/experiments/aggretriever/hf_model/aggretriever-distilbert` to perform "on-the-fly" query encoding, i.e., convert text queries into dense vectors as part of the dense retrieval process.
+Note that to ensure maximum reproducibility, by default Pyserini uses pre-computed query representations that are automatically downloaded. As an alternative, replace `--encoded-queries aggretriever-distilbert-msmarco-passage-dev-subset` with `--encoder castorini/aggretriever-distilbert` to perform "on-the-fly" query encoding, i.e., convert text queries into dense vectors as part of the dense retrieval process.
 
 To evaluate:
 
@@ -63,15 +63,15 @@ Dense retrieval with Aggretriever-coCondenser, brute-force index:
 
 ```bash
 python -m pyserini.search.faiss \
-  --index /store/scratch/s269lin/experiments/aggretriever/index/aggretriever-cocondenser \
+  --index msmarco-passage.aggretriever-cocondenser \
   --topics msmarco-passage-dev-subset \
-  --encoded-queries /store/scratch/s269lin/experiments/aggretriever/queries/aggretriever-cocondenser \
+  --encoded-queries aggretriever-cocondenser-msmarco-passage-dev-subset \
   --output runs/run.msmarco-passage.cocondenser-agg.bf.tsv \
   --output-format trec \
   --batch-size 36 --threads 12
 ```
 
-Note that to ensure maximum reproducibility, by default Pyserini uses pre-computed query representations that are automatically downloaded. As an alternative, replace `--encoded-queries /store/scratch/s269lin/experiments/aggretriever/queries/aggretriever-cocondenser` with `--encoder /store/scratch/s269lin/experiments/aggretriever/hf_model/aggretriever-cocondenser` to perform "on-the-fly" query encoding, i.e., convert text queries into dense vectors as part of the dense retrieval process.
+Note that to ensure maximum reproducibility, by default Pyserini uses pre-computed query representations that are automatically downloaded. As an alternative, replace `--encoded-queries aggretriever-cocondenser-msmarco-passage-dev-subset` with `--encoder castorini/aggretriever-cocondenser` to perform "on-the-fly" query encoding, i.e., convert text queries into dense vectors as part of the dense retrieval process.
 
 To evaluate:
 

--- a/pyserini/encoded_query_info.py
+++ b/pyserini/encoded_query_info.py
@@ -15,6 +15,26 @@
 #
 
 QUERY_INFO = {
+    "aggretriever-cocondenser-msmarco-passage-dev-subset": {
+        "description": "MS MARCO passage dev set queries encoded by aggretriever-cocondenser",
+        "urls": [
+            "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-aggretriever-cocondenser-msmarco-passage-dev-subset-20230407-f627ef.tar.gz"
+        ],
+        "md5": "c30ad20c7b101e3034f41597f0fc1f67",
+        "size (bytes)": 20859862,
+        "total_queries": 6980,
+        "downloaded": False
+    },
+    "aggretriever-distilbert-msmarco-passage-dev-subset": {
+        "description": "MS MARCO passage dev set queries encoded by aggretriever-distilbert",
+        "urls": [
+            "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-aggretriever-distilbert-msmarco-passage-dev-subset-20230407-f627ef.tar.gz"
+        ],
+        "md5": "a6ee094bd681b08e5657ce69185eee82",
+        "size (bytes)": 20771767,
+        "total_queries": 6980,
+        "downloaded": False
+    },
     "tct_colbert-msmarco-passage-dev-subset": {
         "description": "MS MARCO passage dev set queries encoded by TCT-ColBERT",
         "urls": [

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -5194,6 +5194,31 @@ IMPACT_INDEX_INFO_DEPRECATED = {
 IMPACT_INDEX_INFO = {**IMPACT_INDEX_INFO_CURRENT, **IMPACT_INDEX_INFO_DEPRECATED}
 
 FAISS_INDEX_INFO = {
+    # Aggretriever indexes
+    "msmarco-passage.aggretriever-cocondenser": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by aggretriever-cocondenser encoder.",
+        "filename": "faiss.msmarco-passage.aggretriever-cocondenser.20230407.f627ef.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-passage.aggretriever-cocondenser.20230407.f627ef.tar.gz"
+        ],
+        "md5": "7d5f33b1b350f6cac6a02f3d1c4670ca",
+        "size compressed (bytes)": 26053474787,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+     "msmarco-passage.aggretriever-distilbert": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by aggretriever-distilbert encoder.",
+        "filename": "faiss.msmarco-passage.aggretriever-distilbert.20230407.f627ef.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-passage.aggretriever-distilbert.20230407.f627ef.tar.gz"
+        ],
+        "md5": "e9c48c36d1c2a7b3da0ab39f58e10ffc",
+        "size compressed (bytes)": 25963140897,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
     # BEIR (v1.0.0) contriever indexes
     "beir-v1.0.0-trec-covid.contriever": {
         "description": "Faiss index for BEIR v1.0.0 (TREC-COVID) corpus encoded by Contriever encoder.",

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -144,6 +144,68 @@ class TestSearch(unittest.TestCase):
         for index_dir in cleanup_list:
             shutil.rmtree(index_dir)
 
+    def test_aggretriever_distilbert_encoder_cmd(self):
+        index_dir = 'temp_index'
+        cmd = f'python -m pyserini.encode \
+                  input   --corpus {self.test_file} \
+                          --fields text \
+                  output  --embeddings {index_dir} \
+                  encoder --encoder castorini/aggretriever-distilbert \
+                          --fields text \
+                          --batch 1 \
+                          --device cpu'
+        status = os.system(cmd)
+        self.assertEqual(status, 0)
+
+        embedding_json_fn = os.path.join(index_dir, 'embeddings.jsonl')
+        self.assertIsFile(embedding_json_fn)
+
+        with open(embedding_json_fn) as f:
+            embeddings = [json.loads(line) for line in f]
+
+        self.assertListEqual([entry["id"] for entry in embeddings], self.docids)
+        self.assertListEqual(
+            [entry["contents"] for entry in embeddings], 
+            [entry.strip() for entry in self.texts],
+        )
+        self.assertAlmostEqual(embeddings[0]['vector'][0], 0.14203716814517975, places=4)
+        self.assertAlmostEqual(embeddings[0]['vector'][-1], -0.011851579882204533, places=4)
+        self.assertAlmostEqual(embeddings[2]['vector'][0], 0.4780103862285614, places=4)
+        self.assertAlmostEqual(embeddings[2]['vector'][-1], 0.0017992404755204916, places=4)
+
+        shutil.rmtree(index_dir)
+    
+    def test_aggretriever_cocondenser_encoder_cmd(self):
+        index_dir = 'temp_index'
+        cmd = f'python -m pyserini.encode \
+                  input   --corpus {self.test_file} \
+                          --fields text \
+                  output  --embeddings {index_dir} \
+                  encoder --encoder castorini/aggretriever-cocondenser \
+                          --fields text \
+                          --batch 1 \
+                          --device cpu'
+        status = os.system(cmd)
+        self.assertEqual(status, 0)
+
+        embedding_json_fn = os.path.join(index_dir, 'embeddings.jsonl')
+        self.assertIsFile(embedding_json_fn)
+
+        with open(embedding_json_fn) as f:
+            embeddings = [json.loads(line) for line in f]
+
+        self.assertListEqual([entry["id"] for entry in embeddings], self.docids)
+        self.assertListEqual(
+            [entry["contents"] for entry in embeddings], 
+            [entry.strip() for entry in self.texts],
+        )
+        self.assertAlmostEqual(embeddings[0]['vector'][0], 0.4865410327911377, places=4)
+        self.assertAlmostEqual(embeddings[0]['vector'][-1], 0.006781343836337328, places=4)
+        self.assertAlmostEqual(embeddings[2]['vector'][0], 0.32751473784446716, places=4)
+        self.assertAlmostEqual(embeddings[2]['vector'][-1], 0.0014184381579980254, places=4)
+
+        shutil.rmtree(index_dir)
+
 
 class TestJsonlCollectionIterator(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
In this PR, we add 1. prebuilt index, query embedding and huggingface model path into readme 2. add test_aggretriever_distilbert_encoder_cmd() and test_aggretriever_cocondenser_encoder_cmd() to tests.test_encoder