### PR TITLE
Reorganize info for pre-built indexes into Python dictionaries

### DIFF
--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -14,33 +14,7 @@
 # limitations under the License.
 #
 
-TF_INDEX_INFO_CURRENT = {
-    "cacm": {
-        "description": "Lucene index of the CACM corpus. (Lucene 9)",
-        "filename": "lucene-index.cacm.tar.gz",
-        "urls": [
-            "https://github.com/castorini/anserini-data/raw/master/CACM/lucene-index.cacm.20221005.252b5e.tar.gz",
-        ],
-        "md5": "cfe14d543c6a27f4d742fb2d0099b8e0",
-        "size compressed (bytes)": 2347197,
-        "total_terms": 320968,
-        "documents": 3204,
-        "unique_terms": 14363,
-    },
-    "robust04": {
-        "description": "Lucene index of TREC Disks 4 & 5 (minus Congressional Records), used in the TREC 2004 Robust Track. (Lucene 9)",
-        "filename": "lucene-index.robust04.20221005.252b5e.tar.gz",
-        "readme": "lucene-index.robust04.20221005.252b5e.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.robust04.20221005.252b5e.tar.gz",
-        ],
-        "md5": "a1abd5437394956b7ec8bea4699b5e46",
-        "size compressed (bytes)": 1806776535,
-        "total_terms": 174540872,
-        "documents": 528030,
-        "unique_terms": 923436,
-    },
-
+TF_INDEX_INFO_MSMARCO = {
     # MS MARCO V1 document corpus, three indexes with different amounts of information (and sizes).
     "msmarco-v1-doc": {
         "description": "Lucene index of the MS MARCO V1 document corpus. (Lucene 9)",
@@ -601,476 +575,10 @@ TF_INDEX_INFO_CURRENT = {
         "documents": 138364198,
         "unique_terms": 41177061,
         "downloaded": False
-    },
+    }
+}
 
-    "enwiki-paragraphs": {
-        "description": "Lucene index of English Wikipedia for BERTserini",
-        "filename": "lucene-index.enwiki-20180701-paragraphs.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.enwiki-20180701-paragraphs.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/WHKMSCbwQfDXyHt/download"
-        ],
-        "md5": "77d1cd530579905dad2ee3c2bda1b73d",
-        "size compressed (bytes)": 17725958785,
-        "total_terms": 1498980668,
-        "documents": 39880064,
-        "unique_terms": -1,
-        "downloaded": False
-    },
-    "zhwiki-paragraphs": {
-        "description": "Lucene index of Chinese Wikipedia for BERTserini",
-        "filename": "lucene-index.zhwiki-20181201-paragraphs.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.zhwiki-20181201-paragraphs.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/6kEjQZaRYtnb8A6/download"
-        ],
-        "md5": "c005af4036296972831288c894918a92",
-        "size compressed (bytes)": 3284531213,
-        "total_terms": 320776789,
-        "documents": 4170312,
-        "unique_terms": -1,
-        "downloaded": False
-    },
-    "trec-covid-r5-abstract": {
-        "description": "Lucene index for TREC-COVID Round 5: abstract index",
-        "filename": "lucene-index-cord19-abstract-2020-07-16.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-07-16/lucene-index-cord19-abstract-2020-07-16.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/c37JxKYQ7Hogs72/download"
-        ],
-        "md5": "c883571ccc78b4c2ce05b41eb07f5405",
-        "size compressed (bytes)": 2796524,
-        "total_terms": 22100404,
-        "documents": 192459,
-        "unique_terms": 195875,
-        "downloaded": False
-    },
-    "trec-covid-r5-full-text": {
-        "description": "Lucene index for TREC-COVID Round 5: full-text index",
-        "filename": "lucene-index-cord19-full-text-2020-07-16.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-07-16/lucene-index-cord19-full-text-2020-07-16.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/c7CcxRbFWfiFnFq/download"
-        ],
-        "md5": "23cfad89b4c206d66125f5736f60248f",
-        "size compressed (bytes)": 5351744,
-        "total_terms": 275238847,
-        "documents": 192460,
-        "unique_terms": 1843368,
-        "downloaded": False
-    },
-    "trec-covid-r5-paragraph": {
-        "description": "Lucene index for TREC-COVID Round 5: paragraph index",
-        "filename": "lucene-index-cord19-paragraph-2020-07-16.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-07-16/lucene-index-cord19-paragraph-2020-07-16.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/HXigraF5KJL3xS8/download"
-        ],
-        "md5": "c2c6ac832f8a1fcb767d2356d2b1e1df",
-        "size compressed (bytes)": 11352968,
-        "total_terms": 627083574,
-        "documents": 3010497,
-        "unique_terms": 1843368,
-        "downloaded": False
-    },
-    "trec-covid-r4-abstract": {
-        "description": "Lucene index for TREC-COVID Round 4: abstract index",
-        "filename": "lucene-index-cord19-abstract-2020-06-19.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-06-19/lucene-index-cord19-abstract-2020-06-19.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/fBta6sAt4MdaHQX/download"
-        ],
-        "md5": "029bd55daba8800fbae2be9e5fcd7b33",
-        "size compressed (bytes)": 2584264,
-        "total_terms": 18724353,
-        "documents": 158226,
-        "unique_terms": 179937,
-        "downloaded": False
-    },
-    "trec-covid-r4-full-text": {
-        "description": "Lucene index for TREC-COVID Round 4: full-text index",
-        "filename": "lucene-index-cord19-full-text-2020-06-19.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-06-19/lucene-index-cord19-full-text-2020-06-19.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/yErSHZHD38jcDSY/download"
-        ],
-        "md5": "3d0eb12094a24cff9bcacd1f17c3ea1c",
-        "size compressed (bytes)": 4983900,
-        "total_terms": 254810123,
-        "documents": 158227,
-        "unique_terms": 1783089,
-        "downloaded": False
-    },
-    "trec-covid-r4-paragraph": {
-        "description": "Lucene index for TREC-COVID Round 4: paragraph index",
-        "filename": "lucene-index-cord19-paragraph-2020-06-19.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-06-19/lucene-index-cord19-paragraph-2020-06-19.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/7md4kwNNgy3oxiH/download"
-        ],
-        "md5": "5cd8cd6998177bed7a3e0057ef8b3595",
-        "size compressed (bytes)": 10382704,
-        "total_terms": 567579834,
-        "documents": 2781172,
-        "unique_terms": 1783089,
-        "downloaded": False
-    },
-    "trec-covid-r3-abstract": {
-        "description": "Lucene index for TREC-COVID Round 3: abstract index",
-        "filename": "lucene-index-cord19-abstract-2020-05-19.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-19/lucene-index-cord19-abstract-2020-05-19.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Zg9p2D5tJgiTGx2/download"
-        ],
-        "md5": "37bb97d0c41d650ba8e135fd75ae8fd8",
-        "size compressed (bytes)": 2190328,
-        "total_terms": 16278419,
-        "documents": 128465,
-        "unique_terms": 168291,
-        "downloaded": False
-    },
-    "trec-covid-r3-full-text": {
-        "description": "Lucene index for TREC-COVID Round 3: full-text index",
-        "filename": "lucene-index-cord19-full-text-2020-05-19.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-19/lucene-index-cord19-full-text-2020-05-19.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/BTzaQgZ55898dXM/download"
-        ],
-        "md5": "f5711915a66cd2b511e0fb8d03e4c325",
-        "size compressed (bytes)": 4233300,
-        "total_terms": 215806519,
-        "documents": 128465,
-        "unique_terms": 1620335,
-        "downloaded": False
-    },
-    "trec-covid-r3-paragraph": {
-        "description": "Lucene index for TREC-COVID Round 3: paragraph index",
-        "filename": "lucene-index-cord19-paragraph-2020-05-19.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-19/lucene-index-cord19-paragraph-2020-05-19.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/nPyMYTys6NkmEdN/download"
-        ],
-        "md5": "012ab1f804382b2275c433a74d7d31f2",
-        "size compressed (bytes)": 9053524,
-        "total_terms": 485309568,
-        "documents": 2297201,
-        "unique_terms": 1620335,
-        "downloaded": False
-    },
-    "trec-covid-r2-abstract": {
-        "description": "Lucene index for TREC-COVID Round 2: abstract index",
-        "filename": "lucene-index-cord19-abstract-2020-05-01.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-abstract-2020-05-01.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/3YZE65FSypwfnQQ/download"
-        ],
-        "md5": "a06e71a98a68d31148cb0e97e70a2ee1",
-        "size compressed (bytes)": 1575804,
-        "total_terms": 7651125,
-        "documents": 59873,
-        "unique_terms": 109750,
-        "downloaded": False
-    },
-    "trec-covid-r2-full-text": {
-        "description": "Lucene index for TREC-COVID Round 2: full-text index",
-        "filename": "lucene-index-cord19-full-text-2020-05-01.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-full-text-2020-05-01.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/NdPEB7swXeZnq3o/download"
-        ],
-        "md5": "e7eca1b976cdf2cd80e908c9ac2263cb",
-        "size compressed (bytes)": 3088540,
-        "total_terms": 154736295,
-        "documents": 59876,
-        "unique_terms": 1214374,
-        "downloaded": False
-    },
-    "trec-covid-r2-paragraph": {
-        "description": "Lucene index for TREC-COVID Round 2: paragraph index",
-        "filename": "lucene-index-cord19-paragraph-2020-05-01.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-paragraph-2020-05-01.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Mz7n5FAt7rmnYCY/download"
-        ],
-        "md5": "8f9321757a03985ac1c1952b2fff2c7d",
-        "size compressed (bytes)": 6881696,
-        "total_terms": 360119048,
-        "documents": 1758168,
-        "unique_terms": 1214374,
-        "downloaded": False
-    },
-    "trec-covid-r1-abstract": {
-        "description": "Lucene index for TREC-COVID Round 1: abstract index",
-        "filename": "lucene-index-covid-2020-04-10.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-04-10/lucene-index-covid-2020-04-10.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Rz8AEmsFo9NWGP6/download"
-        ],
-        "md5": "ec239d56498c0e7b74e3b41e1ce5d42a",
-        "size compressed (bytes)": 1621440,
-        "total_terms": 6672525,
-        "documents": 51069,
-        "unique_terms": 104595,
-        "downloaded": False
-    },
-    "trec-covid-r1-full-text": {
-        "description": "Lucene index for TREC-COVID Round 1: full-text index",
-        "filename": "lucene-index-covid-full-text-2020-04-10.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-04-10/lucene-index-covid-full-text-2020-04-10.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/oQzSoxrT3grGmBe/download"
-        ],
-        "md5": "401a6f5583b0f05340c73fbbeb3279c8",
-        "size compressed (bytes)": 4471820,
-        "total_terms": 315624154,
-        "documents": 51071,
-        "unique_terms": 1812522,
-        "downloaded": False
-    },
-    "trec-covid-r1-paragraph": {
-        "description": "Lucene index for TREC-COVID Round 1: paragraph index",
-        "filename": "lucene-index-covid-paragraph-2020-04-10.tar.gz",
-        "urls": [
-            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-04-10/lucene-index-covid-paragraph-2020-04-10.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/HDtb5Ys7MYBkePC/download"
-        ],
-        "md5": "8b87a2c55bc0a15b87f11e796860216a",
-        "size compressed (bytes)": 5994192,
-        "total_terms": 330715243,
-        "documents": 1412648,
-        "unique_terms": 944574,
-        "downloaded": False
-    },
-    "cast2019": {
-        "description": "Lucene index for TREC 2019 CaST",
-        "filename": "index-cast2019.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-cast2019.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/56LcDcRPopdQc4d/download"
-        ],
-        "md5": "36e604d7f5a4e08ade54e446be2f6345",
-        "size compressed (bytes)": 21266884884,
-        "total_terms": 1593628213,
-        "documents": 38429835,
-        "unique_terms": -1,
-        "downloaded": False
-    },
-    "wikipedia-dpr": {
-        "description": "Lucene index of Wikipedia with DPR 100-word splits",
-        "filename": "index-wikipedia-dpr-20210120-d1b9e6.tar.gz",
-        "readme": "index-wikipedia-dpr-20210120-d1b9e6-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-wikipedia-dpr-20210120-d1b9e6.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/t6tDJmpoxPw9tH8/download"
-        ],
-        "md5": "c28f3a56b2dfcef25bf3bf755c264d04",
-        "size compressed (bytes)": 9177942656,
-        "total_terms": 1512973270,
-        "documents": 21015324,
-        "unique_terms": 5345463,
-        "downloaded": False
-    },
-    "wikipedia-dpr-slim": {
-        "description": "Lucene index of Wikipedia with DPR 100-word splits (slim version, document text not stored)",
-        "filename": "index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz",
-        "readme": "index-wikipedia-dpr-slim-20210120-d1b9e6-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Gk2sfTyJCyaTrYH/download"
-        ],
-        "md5": "7d40604a824b5df37a1ae9d25ea38071",
-        "size compressed (bytes)": 1810342390,
-        "total_terms": 1512973270,
-        "documents": 21015324,
-        "unique_terms": 5345463,
-        "downloaded": False
-    },
-    "wikipedia-kilt-doc": {
-        "description": "Lucene index of Wikipedia snapshot used as KILT's knowledge source.",
-        "filename": "index-wikipedia-kilt-doc-20210421-f29307.tar.gz",
-        "readme": "index-wikipedia-kilt-doc-20210421-f29307-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-wikipedia-kilt-doc-20210421-f29307.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/RqtLg3CZT38k32c/download"
-        ],
-        "md5": "b8ec8feb654f7aaa86f9901dc6c804a8",
-        "size compressed (bytes)": 10901127209,
-        "total_terms": 1915061164,
-        "documents": 5903530,
-        "unique_terms": 8722502,
-        "downloaded": False
-    },
-    "wiki-all-6-3-tamber": {
-        "description": "Lucene index of wiki-all-6-3-tamber from castorini/odqa-wiki-corpora",
-        "filename": "lucene-index.wiki-all-6-3-tamber.20230111.40277a.tar.gz",
-        "readme": "lucene-index-wiki-all-6-3-tamber-20230111-40277a.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.wiki-all-6-3-tamber.20230111.40277a.tar.gz",
-        ],
-        "md5": "018b45ee8c6278a879caa3145b2dc05d",
-        "size compressed (bytes)": 26240661946,
-        "total_terms": 5064706668,
-        "documents": 76680040,
-        "unique_terms": 14604922,
-        "downloaded": False
-    },
-
-    # Mr.TyDi indexes
-    "mrtydi-v1.1-arabic": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Arabic).",
-        "filename": "lucene-index.mrtydi-v1.1-arabic.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-arabic.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-arabic.20220928.b5ecc5.tar.gz",
-        ],
-        "md5": "efff40a2548f759eb8b0e47e0622685b",
-        "size compressed (bytes)": 1420441600,
-        "total_terms": 92529032,
-        "documents": 2106586,
-        "unique_terms": 1284748,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-bengali": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Bengali).",
-        "filename": "lucene-index.mrtydi-v1.1-bengali.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-bengali.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-bengali.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "6ed844c8f17b2f041fba7c5676d3fb42",
-        "size compressed (bytes)": 294942720,
-        "total_terms": 15236599,
-        "documents": 304059,
-        "unique_terms": 520699,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-english": {
-        "description": "Lucene index for Mr.TyDi v1.1 (English).",
-        "filename": "lucene-index.mrtydi-v1.1-english.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-english.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-english.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "e6b0a2531d958c3d1a65634dc315b0ab",
-        "size compressed (bytes)": 20566118400,
-        "total_terms": 1507060932,
-        "documents": 32907100,
-        "unique_terms": -1,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-finnish": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Finnish).",
-        "filename": "lucene-index.mrtydi-v1.1-finnish.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-finnish.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-finnish.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "0f464c022447eed5431157f0b2feb0b3",
-        "size compressed (bytes)": 1116272640,
-        "total_terms": 69416543,
-        "documents": 1908757,
-        "unique_terms": 1715076,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-indonesian": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Indonesian).",
-        "filename": "lucene-index.mrtydi-v1.1-indonesian.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-indonesian.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-indonesian.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "345d43a2443786a3394a93a6f7ef77b7",
-        "size compressed (bytes)": 698388480,
-        "total_terms": 52493134,
-        "documents": 1469399,
-        "unique_terms": 942552,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-japanese": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Japanese).",
-        "filename": "lucene-index.mrtydi-v1.1-japanese.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-japanese.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-japanese.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "5f0802c1257c325a3e25c58523dba841",
-        "size compressed (bytes)": 4333844480,
-        "total_terms": 300761975,
-        "documents": 7000027,
-        "unique_terms": 1588879,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-korean": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Korean).",
-        "filename": "lucene-index.mrtydi-v1.1-korean.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-korean.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-korean.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "4277f406b138c46edf7c17e4248f3b2e",
-        "size compressed (bytes)": 1349109760,
-        "total_terms": 122217295,
-        "documents": 1496126,
-        "unique_terms": 1517179,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-russian": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Russian).",
-        "filename": "lucene-index.mrtydi-v1.1-russian.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-russian.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-russian.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "d5837fee29c60c7a3a24cfd598056038",
-        "size compressed (bytes)": 6864660480,
-        "total_terms": 346329117,
-        "documents": 9597504,
-        "unique_terms": 3034240,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-swahili": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Swahili).",
-        "filename": "lucene-index.mrtydi-v1.1-swahili.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-swahili.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-swahili.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "bebff76ec6dfe76c904604f8ed1bcd3e",
-        "size compressed (bytes)": 59607040,
-        "total_terms": 4937051,
-        "documents": 136689,
-        "unique_terms": 385711,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-telugu": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Telugu).",
-        "filename": "lucene-index.mrtydi-v1.1-telugu.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-telugu.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-telugu.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "89f8b280cacbdc27e90bb1ea40029c21",
-        "size compressed (bytes)": 519157760,
-        "total_terms": 26812052,
-        "documents": 548224,
-        "unique_terms": 1157217,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-thai": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Thai).",
-        "filename": "lucene-index.mrtydi-v1.1-thai.20220928.b5ecc5.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-thai.20220928.b5ecc5.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-thai.20220928.b5ecc5.tar.gz"
-        ],
-        "md5": "047152fc6bc1b5c5d945f38b23de971e",
-        "size compressed (bytes)": 546201600,
-        "total_terms": 31550936,
-        "documents": 568855,
-        "unique_terms": 663628,
-        "downloaded": False
-    },
-
+TF_INDEX_INFO_BEIR = {
     # BEIR (v1.0.0) flat indexes
     "beir-v1.0.0-trec-covid.flat": {
         "description": "Lucene flat index of BEIR (v1.0.0): TREC-COVID",
@@ -1885,135 +1393,167 @@ TF_INDEX_INFO_CURRENT = {
         "documents": 5183,
         "unique_terms": 28581,
         "downloaded": False
-    },
+    }
+}
 
-    "hc4-v1.0-fa": {
-        "description": "Lucene index for HC4 v1.0 (Persian). (Lucene 9)",
-        "filename": "lucene-index.hc4-v1.0-fa.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.hc4-v1.0.20221025.c4a8d0.README.md",
+TF_INDEX_INFO_MRTYDI = {
+    "mrtydi-v1.1-arabic": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Arabic).",
+        "filename": "lucene-index.mrtydi-v1.1-arabic.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-arabic.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-fa.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-arabic.20220928.b5ecc5.tar.gz",
         ],
-        "md5": "80735c01b2f2cf82288381370adf1d66",
-        "size compressed (bytes)": 1652960750,
-        "total_terms": 112225896,
-        "documents": 486486,
-        "unique_terms": 617109,
+        "md5": "efff40a2548f759eb8b0e47e0622685b",
+        "size compressed (bytes)": 1420441600,
+        "total_terms": 92529032,
+        "documents": 2106586,
+        "unique_terms": 1284748,
         "downloaded": False
     },
-    "hc4-v1.0-ru": {
-        "description": "Lucene index for HC4 v1.0 (Russian). (Lucene 9)",
-        "filename": "lucene-index.hc4-v1.0-ru.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.hc4-v1.0.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-bengali": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Bengali).",
+        "filename": "lucene-index.mrtydi-v1.1-bengali.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-bengali.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-ru.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-bengali.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "40259ba9ca993f850c960a172debe33e",
-        "size compressed (bytes)": 13292705599,
-        "total_terms": 764996714,
-        "documents": 4721064,
-        "unique_terms": 2625222,
+        "md5": "6ed844c8f17b2f041fba7c5676d3fb42",
+        "size compressed (bytes)": 294942720,
+        "total_terms": 15236599,
+        "documents": 304059,
+        "unique_terms": 520699,
         "downloaded": False
     },
-    "hc4-v1.0-zh": {
-        "description": "Lucene index for HC4 v1.0 (Chinese). (Lucene 9)",
-        "filename": "lucene-index.hc4-v1.0-zh.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.hc4-v1.0.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-english": {
+        "description": "Lucene index for Mr.TyDi v1.1 (English).",
+        "filename": "lucene-index.mrtydi-v1.1-english.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-english.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-zh.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-english.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "2ea8885b8ec6c637971c8df0706b623e",
-        "size compressed (bytes)": 2899033342,
-        "total_terms": 304468580,
-        "documents": 646302,
-        "unique_terms": 4380932,
+        "md5": "e6b0a2531d958c3d1a65634dc315b0ab",
+        "size compressed (bytes)": 20566118400,
+        "total_terms": 1507060932,
+        "documents": 32907100,
+        "unique_terms": -1,
         "downloaded": False
     },
-    "neuclir22-fa": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (Persian). (Lucene 9)",
-        "filename": "lucene-index.neuclir22-fa.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.neuclir22.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-finnish": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Finnish).",
+        "filename": "lucene-index.mrtydi-v1.1-finnish.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-finnish.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-fa.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-finnish.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "d423fb72bcd5bf2dea6e4a19743dcb95",
-        "size compressed (bytes)": 7565790180,
-        "total_terms": 514262091,
-        "documents": 2232016,
-        "unique_terms": 1479443,
+        "md5": "0f464c022447eed5431157f0b2feb0b3",
+        "size compressed (bytes)": 1116272640,
+        "total_terms": 69416543,
+        "documents": 1908757,
+        "unique_terms": 1715076,
         "downloaded": False
     },
-    "neuclir22-ru": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (Russian). (Lucene 9)",
-        "filename": "lucene-index.neuclir22-ru.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.neuclir22.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-indonesian": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Indonesian).",
+        "filename": "lucene-index.mrtydi-v1.1-indonesian.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-indonesian.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-ru.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-indonesian.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "2d04bbc880d535c1c4ab172c2c2d8ffe",
-        "size compressed (bytes)": 14202967387,
-        "total_terms": 830006658,
-        "documents": 4627541,
-        "unique_terms": 3396095,
+        "md5": "345d43a2443786a3394a93a6f7ef77b7",
+        "size compressed (bytes)": 698388480,
+        "total_terms": 52493134,
+        "documents": 1469399,
+        "unique_terms": 942552,
         "downloaded": False
     },
-    "neuclir22-zh": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (Chinese). (Lucene 9)",
-        "filename": "lucene-index.neuclir22-zh.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.neuclir22.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-japanese": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Japanese).",
+        "filename": "lucene-index.mrtydi-v1.1-japanese.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-japanese.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-zh.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-japanese.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "46fe989676ff510b997af24f6398199f",
-        "size compressed (bytes)": 15733809682,
-        "total_terms": 1654090507,
-        "documents": 3179206,
-        "unique_terms": 8213058,
+        "md5": "5f0802c1257c325a3e25c58523dba841",
+        "size compressed (bytes)": 4333844480,
+        "total_terms": 300761975,
+        "documents": 7000027,
+        "unique_terms": 1588879,
         "downloaded": False
     },
-    "neuclir22-fa-en": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (official English translation from Persian). (Lucene 9)",
-        "filename": "lucene-index.neuclir22-fa-en.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.neuclir22-en.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-korean": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Korean).",
+        "filename": "lucene-index.mrtydi-v1.1-korean.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-korean.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-fa-en.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-korean.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "35363339b7f0527f27403b848fe01b04",
-        "size compressed (bytes)": 6172239242,
-        "total_terms": 554848215,
-        "documents": 2232016,
-        "unique_terms": 1033260,
+        "md5": "4277f406b138c46edf7c17e4248f3b2e",
+        "size compressed (bytes)": 1349109760,
+        "total_terms": 122217295,
+        "documents": 1496126,
+        "unique_terms": 1517179,
         "downloaded": False
     },
-    "neuclir22-ru-en": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (official English translation from Russian). (Lucene 9)",
-        "filename": "lucene-index.neuclir22-ru-en.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.neuclir22-en.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-russian": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Russian).",
+        "filename": "lucene-index.mrtydi-v1.1-russian.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-russian.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-ru-en.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-russian.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "b0b98803260665eeae97163d2361838e",
-        "size compressed (bytes)": 10513242212,
-        "total_terms": 911886830,
-        "documents": 4627541,
-        "unique_terms": 2794257,
+        "md5": "d5837fee29c60c7a3a24cfd598056038",
+        "size compressed (bytes)": 6864660480,
+        "total_terms": 346329117,
+        "documents": 9597504,
+        "unique_terms": 3034240,
         "downloaded": False
     },
-    "neuclir22-zh-en": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (official English translation from Chinese). (Lucene 9)",
-        "filename": "lucene-index.neuclir22-zh-en.20221025.c4a8d0.tar.gz",
-        "readme": "lucene-index.neuclir22-en.20221025.c4a8d0.README.md",
+    "mrtydi-v1.1-swahili": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Swahili).",
+        "filename": "lucene-index.mrtydi-v1.1-swahili.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-swahili.20220928.b5ecc5.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-zh-en.20221025.c4a8d0.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-swahili.20220928.b5ecc5.tar.gz"
         ],
-        "md5": "d44ca9c7b634cf56e8cfd5892a3d3427",
-        "size compressed (bytes)": 8470981318,
-        "total_terms": 803227160,
-        "documents": 3179206,
-        "unique_terms": 1616532,
+        "md5": "bebff76ec6dfe76c904604f8ed1bcd3e",
+        "size compressed (bytes)": 59607040,
+        "total_terms": 4937051,
+        "documents": 136689,
+        "unique_terms": 385711,
         "downloaded": False
     },
+    "mrtydi-v1.1-telugu": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Telugu).",
+        "filename": "lucene-index.mrtydi-v1.1-telugu.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-telugu.20220928.b5ecc5.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-telugu.20220928.b5ecc5.tar.gz"
+        ],
+        "md5": "89f8b280cacbdc27e90bb1ea40029c21",
+        "size compressed (bytes)": 519157760,
+        "total_terms": 26812052,
+        "documents": 548224,
+        "unique_terms": 1157217,
+        "downloaded": False
+    },
+    "mrtydi-v1.1-thai": {
+        "description": "Lucene index for Mr.TyDi v1.1 (Thai).",
+        "filename": "lucene-index.mrtydi-v1.1-thai.20220928.b5ecc5.tar.gz",
+        "readme": "lucene-index.mrtydi-v1.1-thai.20220928.b5ecc5.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-thai.20220928.b5ecc5.tar.gz"
+        ],
+        "md5": "047152fc6bc1b5c5d945f38b23de971e",
+        "size compressed (bytes)": 546201600,
+        "total_terms": 31550936,
+        "documents": 568855,
+        "unique_terms": 663628,
+        "downloaded": False
+    }
+}
 
+TF_INDEX_INFO_MIRACL = {
     "miracl-v1.0-ar": {
         "description": "Lucene index for MIRACL v1.0 (Arabic).",
         "filename": "lucene-index.miracl-v1.0-ar.20221004.2b2856.tar.gz",
@@ -2265,1758 +1805,486 @@ TF_INDEX_INFO_CURRENT = {
         "documents": 49043,
         "unique_terms": 174539,
         "downloaded": False
-    },
+    }
 }
 
-TF_INDEX_INFO_DEPRECATED = {
-    "hc4-v1.0-zh-lucene8": {
-        "description": "Lucene index for HC4 v1.0 (Chinese). (Lucene 8; deprecated)",
-        "filename": "lucene-index.hc4-v1.0-zh.20220719.71c120.tar.gz",
-        "readme": "lucene-index.hc4-v1.0-zh.20220719.71c120.README.md",
+TF_INDEX_INFO_OTHER = {
+    "cacm": {
+        "description": "Lucene index of the CACM corpus. (Lucene 9)",
+        "filename": "lucene-index.cacm.tar.gz",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-zh.20220719.71c120.tar.gz"
+            "https://github.com/castorini/anserini-data/raw/master/CACM/lucene-index.cacm.20221005.252b5e.tar.gz",
         ],
-        "md5": "7351794f4b570c387a12527cf46a7956",
-        "size compressed (bytes)": 2904147388,
-        "total_terms": 304468573,
-        "documents": 646302,
-        "unique_terms": 4380931,
+        "md5": "cfe14d543c6a27f4d742fb2d0099b8e0",
+        "size compressed (bytes)": 2347197,
+        "total_terms": 320968,
+        "documents": 3204,
+        "unique_terms": 14363,
+    },
+    "robust04": {
+        "description": "Lucene index of TREC Disks 4 & 5 (minus Congressional Records), used in the TREC 2004 Robust Track. (Lucene 9)",
+        "filename": "lucene-index.robust04.20221005.252b5e.tar.gz",
+        "readme": "lucene-index.robust04.20221005.252b5e.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.robust04.20221005.252b5e.tar.gz",
+        ],
+        "md5": "a1abd5437394956b7ec8bea4699b5e46",
+        "size compressed (bytes)": 1806776535,
+        "total_terms": 174540872,
+        "documents": 528030,
+        "unique_terms": 923436,
+    },
+
+    "enwiki-paragraphs": {
+        "description": "Lucene index of English Wikipedia for BERTserini",
+        "filename": "lucene-index.enwiki-20180701-paragraphs.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.enwiki-20180701-paragraphs.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/WHKMSCbwQfDXyHt/download"
+        ],
+        "md5": "77d1cd530579905dad2ee3c2bda1b73d",
+        "size compressed (bytes)": 17725958785,
+        "total_terms": 1498980668,
+        "documents": 39880064,
+        "unique_terms": -1,
         "downloaded": False
     },
-    "hc4-v1.0-fa-lucene8": {
-        "description": "Lucene index for HC4 v1.0 (Persian). (Lucene 8; deprecated)",
-        "filename": "lucene-index.hc4-v1.0-fa.20220719.71c120.tar.gz",
-        "readme": "lucene-index.hc4-v1.0-fa.20220719.71c120.README.md",
+    "zhwiki-paragraphs": {
+        "description": "Lucene index of Chinese Wikipedia for BERTserini",
+        "filename": "lucene-index.zhwiki-20181201-paragraphs.tar.gz",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-fa.20220719.71c120.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.zhwiki-20181201-paragraphs.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/6kEjQZaRYtnb8A6/download"
         ],
-        "md5": "fd838abb94864f22cb4d94cd33660b24",
-        "size compressed (bytes)": 1656366266,
-        "total_terms": 112225895,
+        "md5": "c005af4036296972831288c894918a92",
+        "size compressed (bytes)": 3284531213,
+        "total_terms": 320776789,
+        "documents": 4170312,
+        "unique_terms": -1,
+        "downloaded": False
+    },
+
+    "trec-covid-r5-abstract": {
+        "description": "Lucene index for TREC-COVID Round 5: abstract index",
+        "filename": "lucene-index-cord19-abstract-2020-07-16.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-07-16/lucene-index-cord19-abstract-2020-07-16.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/c37JxKYQ7Hogs72/download"
+        ],
+        "md5": "c883571ccc78b4c2ce05b41eb07f5405",
+        "size compressed (bytes)": 2796524,
+        "total_terms": 22100404,
+        "documents": 192459,
+        "unique_terms": 195875,
+        "downloaded": False
+    },
+    "trec-covid-r5-full-text": {
+        "description": "Lucene index for TREC-COVID Round 5: full-text index",
+        "filename": "lucene-index-cord19-full-text-2020-07-16.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-07-16/lucene-index-cord19-full-text-2020-07-16.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/c7CcxRbFWfiFnFq/download"
+        ],
+        "md5": "23cfad89b4c206d66125f5736f60248f",
+        "size compressed (bytes)": 5351744,
+        "total_terms": 275238847,
+        "documents": 192460,
+        "unique_terms": 1843368,
+        "downloaded": False
+    },
+    "trec-covid-r5-paragraph": {
+        "description": "Lucene index for TREC-COVID Round 5: paragraph index",
+        "filename": "lucene-index-cord19-paragraph-2020-07-16.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-07-16/lucene-index-cord19-paragraph-2020-07-16.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/HXigraF5KJL3xS8/download"
+        ],
+        "md5": "c2c6ac832f8a1fcb767d2356d2b1e1df",
+        "size compressed (bytes)": 11352968,
+        "total_terms": 627083574,
+        "documents": 3010497,
+        "unique_terms": 1843368,
+        "downloaded": False
+    },
+    "trec-covid-r4-abstract": {
+        "description": "Lucene index for TREC-COVID Round 4: abstract index",
+        "filename": "lucene-index-cord19-abstract-2020-06-19.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-06-19/lucene-index-cord19-abstract-2020-06-19.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/fBta6sAt4MdaHQX/download"
+        ],
+        "md5": "029bd55daba8800fbae2be9e5fcd7b33",
+        "size compressed (bytes)": 2584264,
+        "total_terms": 18724353,
+        "documents": 158226,
+        "unique_terms": 179937,
+        "downloaded": False
+    },
+    "trec-covid-r4-full-text": {
+        "description": "Lucene index for TREC-COVID Round 4: full-text index",
+        "filename": "lucene-index-cord19-full-text-2020-06-19.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-06-19/lucene-index-cord19-full-text-2020-06-19.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/yErSHZHD38jcDSY/download"
+        ],
+        "md5": "3d0eb12094a24cff9bcacd1f17c3ea1c",
+        "size compressed (bytes)": 4983900,
+        "total_terms": 254810123,
+        "documents": 158227,
+        "unique_terms": 1783089,
+        "downloaded": False
+    },
+    "trec-covid-r4-paragraph": {
+        "description": "Lucene index for TREC-COVID Round 4: paragraph index",
+        "filename": "lucene-index-cord19-paragraph-2020-06-19.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-06-19/lucene-index-cord19-paragraph-2020-06-19.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/7md4kwNNgy3oxiH/download"
+        ],
+        "md5": "5cd8cd6998177bed7a3e0057ef8b3595",
+        "size compressed (bytes)": 10382704,
+        "total_terms": 567579834,
+        "documents": 2781172,
+        "unique_terms": 1783089,
+        "downloaded": False
+    },
+    "trec-covid-r3-abstract": {
+        "description": "Lucene index for TREC-COVID Round 3: abstract index",
+        "filename": "lucene-index-cord19-abstract-2020-05-19.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-19/lucene-index-cord19-abstract-2020-05-19.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/Zg9p2D5tJgiTGx2/download"
+        ],
+        "md5": "37bb97d0c41d650ba8e135fd75ae8fd8",
+        "size compressed (bytes)": 2190328,
+        "total_terms": 16278419,
+        "documents": 128465,
+        "unique_terms": 168291,
+        "downloaded": False
+    },
+    "trec-covid-r3-full-text": {
+        "description": "Lucene index for TREC-COVID Round 3: full-text index",
+        "filename": "lucene-index-cord19-full-text-2020-05-19.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-19/lucene-index-cord19-full-text-2020-05-19.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/BTzaQgZ55898dXM/download"
+        ],
+        "md5": "f5711915a66cd2b511e0fb8d03e4c325",
+        "size compressed (bytes)": 4233300,
+        "total_terms": 215806519,
+        "documents": 128465,
+        "unique_terms": 1620335,
+        "downloaded": False
+    },
+    "trec-covid-r3-paragraph": {
+        "description": "Lucene index for TREC-COVID Round 3: paragraph index",
+        "filename": "lucene-index-cord19-paragraph-2020-05-19.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-19/lucene-index-cord19-paragraph-2020-05-19.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/nPyMYTys6NkmEdN/download"
+        ],
+        "md5": "012ab1f804382b2275c433a74d7d31f2",
+        "size compressed (bytes)": 9053524,
+        "total_terms": 485309568,
+        "documents": 2297201,
+        "unique_terms": 1620335,
+        "downloaded": False
+    },
+    "trec-covid-r2-abstract": {
+        "description": "Lucene index for TREC-COVID Round 2: abstract index",
+        "filename": "lucene-index-cord19-abstract-2020-05-01.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-abstract-2020-05-01.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/3YZE65FSypwfnQQ/download"
+        ],
+        "md5": "a06e71a98a68d31148cb0e97e70a2ee1",
+        "size compressed (bytes)": 1575804,
+        "total_terms": 7651125,
+        "documents": 59873,
+        "unique_terms": 109750,
+        "downloaded": False
+    },
+    "trec-covid-r2-full-text": {
+        "description": "Lucene index for TREC-COVID Round 2: full-text index",
+        "filename": "lucene-index-cord19-full-text-2020-05-01.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-full-text-2020-05-01.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/NdPEB7swXeZnq3o/download"
+        ],
+        "md5": "e7eca1b976cdf2cd80e908c9ac2263cb",
+        "size compressed (bytes)": 3088540,
+        "total_terms": 154736295,
+        "documents": 59876,
+        "unique_terms": 1214374,
+        "downloaded": False
+    },
+    "trec-covid-r2-paragraph": {
+        "description": "Lucene index for TREC-COVID Round 2: paragraph index",
+        "filename": "lucene-index-cord19-paragraph-2020-05-01.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-05-01/lucene-index-cord19-paragraph-2020-05-01.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/Mz7n5FAt7rmnYCY/download"
+        ],
+        "md5": "8f9321757a03985ac1c1952b2fff2c7d",
+        "size compressed (bytes)": 6881696,
+        "total_terms": 360119048,
+        "documents": 1758168,
+        "unique_terms": 1214374,
+        "downloaded": False
+    },
+    "trec-covid-r1-abstract": {
+        "description": "Lucene index for TREC-COVID Round 1: abstract index",
+        "filename": "lucene-index-covid-2020-04-10.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-04-10/lucene-index-covid-2020-04-10.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/Rz8AEmsFo9NWGP6/download"
+        ],
+        "md5": "ec239d56498c0e7b74e3b41e1ce5d42a",
+        "size compressed (bytes)": 1621440,
+        "total_terms": 6672525,
+        "documents": 51069,
+        "unique_terms": 104595,
+        "downloaded": False
+    },
+    "trec-covid-r1-full-text": {
+        "description": "Lucene index for TREC-COVID Round 1: full-text index",
+        "filename": "lucene-index-covid-full-text-2020-04-10.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-04-10/lucene-index-covid-full-text-2020-04-10.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/oQzSoxrT3grGmBe/download"
+        ],
+        "md5": "401a6f5583b0f05340c73fbbeb3279c8",
+        "size compressed (bytes)": 4471820,
+        "total_terms": 315624154,
+        "documents": 51071,
+        "unique_terms": 1812522,
+        "downloaded": False
+    },
+    "trec-covid-r1-paragraph": {
+        "description": "Lucene index for TREC-COVID Round 1: paragraph index",
+        "filename": "lucene-index-covid-paragraph-2020-04-10.tar.gz",
+        "urls": [
+            "https://git.uwaterloo.ca/jimmylin/cord19-indexes/raw/master/2020-04-10/lucene-index-covid-paragraph-2020-04-10.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/HDtb5Ys7MYBkePC/download"
+        ],
+        "md5": "8b87a2c55bc0a15b87f11e796860216a",
+        "size compressed (bytes)": 5994192,
+        "total_terms": 330715243,
+        "documents": 1412648,
+        "unique_terms": 944574,
+        "downloaded": False
+    },
+
+    "cast2019": {
+        "description": "Lucene index for TREC 2019 CaST",
+        "filename": "index-cast2019.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-cast2019.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/56LcDcRPopdQc4d/download"
+        ],
+        "md5": "36e604d7f5a4e08ade54e446be2f6345",
+        "size compressed (bytes)": 21266884884,
+        "total_terms": 1593628213,
+        "documents": 38429835,
+        "unique_terms": -1,
+        "downloaded": False
+    },
+
+    "wikipedia-dpr": {
+        "description": "Lucene index of Wikipedia with DPR 100-word splits",
+        "filename": "index-wikipedia-dpr-20210120-d1b9e6.tar.gz",
+        "readme": "index-wikipedia-dpr-20210120-d1b9e6-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-wikipedia-dpr-20210120-d1b9e6.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/t6tDJmpoxPw9tH8/download"
+        ],
+        "md5": "c28f3a56b2dfcef25bf3bf755c264d04",
+        "size compressed (bytes)": 9177942656,
+        "total_terms": 1512973270,
+        "documents": 21015324,
+        "unique_terms": 5345463,
+        "downloaded": False
+    },
+    "wikipedia-dpr-slim": {
+        "description": "Lucene index of Wikipedia with DPR 100-word splits (slim version, document text not stored)",
+        "filename": "index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz",
+        "readme": "index-wikipedia-dpr-slim-20210120-d1b9e6-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-wikipedia-dpr-slim-20210120-d1b9e6.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/Gk2sfTyJCyaTrYH/download"
+        ],
+        "md5": "7d40604a824b5df37a1ae9d25ea38071",
+        "size compressed (bytes)": 1810342390,
+        "total_terms": 1512973270,
+        "documents": 21015324,
+        "unique_terms": 5345463,
+        "downloaded": False
+    },
+    "wikipedia-kilt-doc": {
+        "description": "Lucene index of Wikipedia snapshot used as KILT's knowledge source.",
+        "filename": "index-wikipedia-kilt-doc-20210421-f29307.tar.gz",
+        "readme": "index-wikipedia-kilt-doc-20210421-f29307-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-wikipedia-kilt-doc-20210421-f29307.tar.gz",
+            "https://vault.cs.uwaterloo.ca/s/RqtLg3CZT38k32c/download"
+        ],
+        "md5": "b8ec8feb654f7aaa86f9901dc6c804a8",
+        "size compressed (bytes)": 10901127209,
+        "total_terms": 1915061164,
+        "documents": 5903530,
+        "unique_terms": 8722502,
+        "downloaded": False
+    },
+    "wiki-all-6-3-tamber": {
+        "description": "Lucene index of wiki-all-6-3-tamber from castorini/odqa-wiki-corpora",
+        "filename": "lucene-index.wiki-all-6-3-tamber.20230111.40277a.tar.gz",
+        "readme": "lucene-index-wiki-all-6-3-tamber-20230111-40277a.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.wiki-all-6-3-tamber.20230111.40277a.tar.gz",
+        ],
+        "md5": "018b45ee8c6278a879caa3145b2dc05d",
+        "size compressed (bytes)": 26240661946,
+        "total_terms": 5064706668,
+        "documents": 76680040,
+        "unique_terms": 14604922,
+        "downloaded": False
+    },
+
+    "hc4-v1.0-fa": {
+        "description": "Lucene index for HC4 v1.0 (Persian). (Lucene 9)",
+        "filename": "lucene-index.hc4-v1.0-fa.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.hc4-v1.0.20221025.c4a8d0.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-fa.20221025.c4a8d0.tar.gz"
+        ],
+        "md5": "80735c01b2f2cf82288381370adf1d66",
+        "size compressed (bytes)": 1652960750,
+        "total_terms": 112225896,
         "documents": 486486,
-        "unique_terms": 617107,
+        "unique_terms": 617109,
         "downloaded": False
     },
-    "hc4-v1.0-ru-lucene8": {
-        "description": "Lucene index for HC4 v1.0 (Russian). (Lucene 8; deprecated)",
-        "filename": "lucene-index.hc4-v1.0-ru.20220719.71c120.tar.gz",
-        "readme": "lucene-index.hc4-v1.0-ru.20220719.71c120.README.md",
+    "hc4-v1.0-ru": {
+        "description": "Lucene index for HC4 v1.0 (Russian). (Lucene 9)",
+        "filename": "lucene-index.hc4-v1.0-ru.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.hc4-v1.0.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-ru.20220719.71c120.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-ru.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "3f15b30d1238d2d0a6f720f06c7c442c",
-        "size compressed (bytes)": 13323791981,
-        "total_terms": 764996697,
+        "md5": "40259ba9ca993f850c960a172debe33e",
+        "size compressed (bytes)": 13292705599,
+        "total_terms": 764996714,
         "documents": 4721064,
-        "unique_terms": 2640439,
+        "unique_terms": 2625222,
         "downloaded": False
     },
-    "neuclir22-zh-lucene8": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (Chinese). (Lucene 8; deprecated)",
-        "filename": "lucene-index.neuclir22-zh.20220719.71c120.tar.gz",
-        "readme": "lucene-index.neuclir22-zh.20220719.71c120.README.md",
+    "hc4-v1.0-zh": {
+        "description": "Lucene index for HC4 v1.0 (Chinese). (Lucene 9)",
+        "filename": "lucene-index.hc4-v1.0-zh.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.hc4-v1.0.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-zh.20220719.71c120.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.hc4-v1.0-zh.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "edca109c2f39464f73cf9d12af776b73",
-        "size compressed (bytes)": 15744742868,
-        "total_terms": 1654090468,
-        "documents": 3179206,
-        "unique_terms": 8213049,
+        "md5": "2ea8885b8ec6c637971c8df0706b623e",
+        "size compressed (bytes)": 2899033342,
+        "total_terms": 304468580,
+        "documents": 646302,
+        "unique_terms": 4380932,
         "downloaded": False
     },
-    "neuclir22-fa-lucene8": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (Persian). (Lucene 8; deprecated)",
-        "filename": "lucene-index.neuclir22-fa.20220719.71c120.tar.gz",
-        "readme": "lucene-index.neuclir22-fa.20220719.71c120.README.md",
+    "neuclir22-fa": {
+        "description": "Lucene index for NeuCLIR 2022 corpus (Persian). (Lucene 9)",
+        "filename": "lucene-index.neuclir22-fa.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.neuclir22.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-fa.20220719.71c120.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-fa.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "ff3a6ac9a4c428d3aa42e1ae3c007147",
-        "size compressed (bytes)": 7577718950,
+        "md5": "d423fb72bcd5bf2dea6e4a19743dcb95",
+        "size compressed (bytes)": 7565790180,
         "total_terms": 514262091,
         "documents": 2232016,
-        "unique_terms": 1479422,
+        "unique_terms": 1479443,
         "downloaded": False
     },
-    "neuclir22-ru-lucene8": {
-        "description": "Lucene index for NeuCLIR 2022 corpus (Russian). (Lucene 8; deprecated)",
-        "filename": "lucene-index.neuclir22-ru.20220719.71c120.tar.gz",
-        "readme": "lucene-index.neuclir22-ru.20220719.71c120.README.md",
+    "neuclir22-ru": {
+        "description": "Lucene index for NeuCLIR 2022 corpus (Russian). (Lucene 9)",
+        "filename": "lucene-index.neuclir22-ru.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.neuclir22.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-ru.20220719.71c120.tar.gz"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-ru.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "dd483e258fddde98cd059fd5f4f0fe1e",
-        "size compressed (bytes)": 14237631658,
-        "total_terms": 830006488,
+        "md5": "2d04bbc880d535c1c4ab172c2c2d8ffe",
+        "size compressed (bytes)": 14202967387,
+        "total_terms": 830006658,
         "documents": 4627541,
-        "unique_terms": 3412268,
+        "unique_terms": 3396095,
         "downloaded": False
     },
-
-    "mrtydi-v1.1-arabic-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Arabic). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-arabic.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-arabic.20220108.6fcb89.README.md",
+    "neuclir22-zh": {
+        "description": "Lucene index for NeuCLIR 2022 corpus (Chinese). (Lucene 9)",
+        "filename": "lucene-index.neuclir22-zh.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.neuclir22.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-arabic.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/7oDFnq8FmTazf2a/download"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-zh.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "0129b01cc88524e13a9ff3e398e988a5",
-        "size compressed (bytes)": 1172153418,
-        "total_terms": 92529014,
-        "documents": 2106586,
-        "unique_terms": 1284712,
+        "md5": "46fe989676ff510b997af24f6398199f",
+        "size compressed (bytes)": 15733809682,
+        "total_terms": 1654090507,
+        "documents": 3179206,
+        "unique_terms": 8213058,
         "downloaded": False
     },
-    "mrtydi-v1.1-bengali-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Bengali). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-bengali.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-bengali.20220108.6fcb89.README.md",
+    "neuclir22-fa-en": {
+        "description": "Lucene index for NeuCLIR 2022 corpus (official English translation from Persian). (Lucene 9)",
+        "filename": "lucene-index.neuclir22-fa-en.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.neuclir22-en.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-bengali.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/HaPaz2wFbRMP2LK/download"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-fa-en.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "756a686cc5723791eb5ab5357271be10",
-        "size compressed (bytes)": 240371052,
-        "total_terms": 15236598,
-        "documents": 304059,
-        "unique_terms": 520694,
+        "md5": "35363339b7f0527f27403b848fe01b04",
+        "size compressed (bytes)": 6172239242,
+        "total_terms": 554848215,
+        "documents": 2232016,
+        "unique_terms": 1033260,
         "downloaded": False
     },
-    "mrtydi-v1.1-english-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (English). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-english.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-english.20220108.6fcb89.README.md",
+    "neuclir22-ru-en": {
+        "description": "Lucene index for NeuCLIR 2022 corpus (official English translation from Russian). (Lucene 9)",
+        "filename": "lucene-index.neuclir22-ru-en.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.neuclir22-en.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-english.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/w4ccMwH5BLnXQ3j/download"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-ru-en.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "804c7626b5a36f06f75e0a04c6ec4fe1",
-        "size compressed (bytes)": 16772744114,
-        "total_terms": 1507060955,
-        "documents": 32907100,
-        "unique_terms": 6189349,
+        "md5": "b0b98803260665eeae97163d2361838e",
+        "size compressed (bytes)": 10513242212,
+        "total_terms": 911886830,
+        "documents": 4627541,
+        "unique_terms": 2794257,
         "downloaded": False
     },
-    "mrtydi-v1.1-finnish-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Finnish). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-finnish.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-finnish.20220108.6fcb89.README.md",
+    "neuclir22-zh-en": {
+        "description": "Lucene index for NeuCLIR 2022 corpus (official English translation from Chinese). (Lucene 9)",
+        "filename": "lucene-index.neuclir22-zh-en.20221025.c4a8d0.tar.gz",
+        "readme": "lucene-index.neuclir22-en.20221025.c4a8d0.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-finnish.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Pgd3mqjy77a6FR8/download"
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.neuclir22-zh-en.20221025.c4a8d0.tar.gz"
         ],
-        "md5": "65361258d1a318447f364ccae90c293a",
-        "size compressed (bytes)": 908904453,
-        "total_terms": 69431615,
-        "documents": 1908757,
-        "unique_terms": 1709590,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-indonesian-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Indonesian). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-indonesian.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-indonesian.20220108.6fcb89.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-indonesian.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/tF8NE7pWZ2xGix7/download"
-        ],
-        "md5": "ca62d690401b84a493c70693ee2626c3",
-        "size compressed (bytes)": 564741230,
-        "total_terms": 52493134,
-        "documents": 1469399,
-        "unique_terms": 942550,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-japanese-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Japanese). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-japanese.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-japanese.20220108.6fcb89.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-japanese.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/ema8i83zqJr7n48/download"
-        ],
-        "md5": "d05aefed5f79bfc151a9f4815d3693d8",
-        "size compressed (bytes)": 3670762373,
-        "total_terms": 303640353,
-        "documents": 7000027,
-        "unique_terms": 1708155,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-korean-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Korean). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-korean.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-korean.20220108.6fcb89.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-korean.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/igmEHCTjTwNi3de/download"
-        ],
-        "md5": "4ecc408de4c749f25865859ea97278bd",
-        "size compressed (bytes)": 1141503582,
-        "total_terms": 122217290,
-        "documents": 1496126,
-        "unique_terms": 1517175,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-russian-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Russian). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-russian.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-russian.20220108.6fcb89.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-russian.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Pbi9xrD7jSYaxnX/download"
-        ],
-        "md5": "9e229b33f4ddea411477d2f00c25be72",
-        "size compressed (bytes)": 5672456411,
-        "total_terms": 346329152,
-        "documents": 9597504,
-        "unique_terms": 3059773,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-swahili-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Swahili). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-swahili.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-swahili.20220108.6fcb89.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-swahili.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/SWqajDQgq8wppf6/download"
-        ],
-        "md5": "ec88a5b39c2506b8cd61e6e47b8044e7",
-        "size compressed (bytes)": 47689785,
-        "total_terms": 4937051,
-        "documents": 136689,
-        "unique_terms": 385711,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-telugu-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Telugu). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-telugu.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-telugu.20220108.6fcb89.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-telugu.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/DAB6ba5ZF98awH6/download"
-        ],
-        "md5": "2704b725c0418905037a45b6301e8666",
-        "size compressed (bytes)": 452906283,
-        "total_terms": 27173644,
-        "documents": 548224,
-        "unique_terms": 1892900,
-        "downloaded": False
-    },
-    "mrtydi-v1.1-thai-lucene8": {
-        "description": "Lucene index for Mr.TyDi v1.1 (Thai). (Lucene 8; deprecated)",
-        "filename": "lucene-index.mrtydi-v1.1-thai.20220108.6fcb89.tar.gz",
-        "readme": "lucene-index.mrtydi-v1.1-thai.20220108.6fcb89.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.mrtydi-v1.1-thai.20220108.6fcb89.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/2Ady6AwBwNbYLpg/download"
-        ],
-        "md5": "9756502f1aeeee035c37975202787538",
-        "size compressed (bytes)": 452244053,
-        "total_terms": 31550936,
-        "documents": 568855,
-        "unique_terms": 663628,
-        "downloaded": False
-    },
-
-    # Deprecated: MS MARCO V1 document corpus, three indexes with different amounts of information (and sizes).
-    "msmarco-v1-doc-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 document corpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/aDRAfyZytQsQ9T3/download"
-        ],
-        "md5": "43b60b3fc75324c648a02375772e7fe8",
-        "size compressed (bytes)": 13757573401,
-        "total_terms": 2742209690,
-        "documents": 3213835,
-        "unique_terms": 29820456,
-        "downloaded": False
-    },
-    "msmarco-v1-doc-slim-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 document corpus ('slim' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-slim.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-slim.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-slim.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/iCnysqnaG9SL9pA/download"
-        ],
-        "md5": "17a7b079e9d527492904c7697a9cae59",
-        "size compressed (bytes)": 1811599007,
-        "total_terms": 2742209690,
-        "documents": 3213835,
-        "unique_terms": 29820456,
-        "downloaded": False
-    },
-    "msmarco-v1-doc-full-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 document corpus ('full' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-full.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-full.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-full.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/KsqZ2AwkSrTM8yS/download"
-        ],
-        "md5": "ef60d7f8afa3919cdeedc6fea89aa3f7",
-        "size compressed (bytes)": 25548064269,
-        "total_terms": 2742209690,
-        "documents": 3213835,
-        "unique_terms": 29820456,
-        "downloaded": False
-    },
-
-    # Deprecated: MS MARCO V1 document corpus, doc2query-T5 expansions.
-    "msmarco-v1-doc-d2q-t5-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-d2q-t5.20220201.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-d2q-t5.20220201.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-d2q-t5.20220201.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/jWb3La4NYorwSCp/download"
-        ],
-        "md5": "37c639c9c26a34d2612ea6549fb866df",
-        "size compressed (bytes)": 1904879520,
-        "total_terms": 3748333319,
-        "documents": 3213835,
-        "unique_terms": 30627687,
-        "downloaded": False
-    },
-    "msmarco-v1-doc-d2q-t5-docvectors-lucene8": {
-        "description": "Lucene index (+docvectors) of the MS MARCO V1 document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        ],
-        "md5": "987088270d4df2d51bcdffb1588f6915",
-        "size compressed (bytes)": 11169880136,
-        "total_terms": 3748333319,
-        "documents": 3213835,
-        "unique_terms": 30627687,
-        "downloaded": False
-    },
-
-    # Deprecated: MS MARCO V1 segmented document corpus, three indexes with different amounts of information (and sizes).
-    "msmarco-v1-doc-segmented-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 segmented document corpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-segmented.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/FKniAWGJjZHy3TF/download"
-        ],
-        "md5": "611bb83e043c0d6febe0fa3508d1d7f9",
-        "size compressed (bytes)": 17091132803,
-        "total_terms": 3200515914,
-        "documents": 20545677,
-        "unique_terms": 21190687,
-        "downloaded": False
-    },
-    "msmarco-v1-doc-segmented-slim-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 segmented document corpus ('slim' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-segmented-slim.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-segmented-slim.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-segmented-slim.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/QNYpaAcLXERr74y/download"
-        ],
-        "md5": "d42113cfeeea862b51765329795948ad",
-        "size compressed (bytes)": 3408754542,
-        "total_terms": 3200515914,
-        "documents": 20545677,
-        "unique_terms": 21190687,
-        "downloaded": False
-    },
-    "msmarco-v1-doc-segmented-full-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 segmented document corpus ('full' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-segmented-full.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-segmented-full.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-segmented-full.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/RzRBC6xkmaTsmX9/download"
-        ],
-        "md5": "2ed7457c8804d2d6370a1a7f604eb360",
-        "size compressed (bytes)": 30771630666,
-        "total_terms": 3200515914,
-        "documents": 20545677,
-        "unique_terms": 21190687,
-        "downloaded": False
-    },
-
-    # Deprecated: MS MARCO V1 segmented document corpus, doc2query-T5 expansions.
-    "msmarco-v1-doc-segmented-d2q-t5-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 segmented document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-segmented-d2q-t5.20220201.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-segmented-d2q-t5.20220201.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-segmented-d2q-t5.20220201.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/gJmL8iiWWztnYmH/download"
-        ],
-        "md5": "6c1f86ee4f7175eed4d3a7acc3d567b8",
-        "size compressed (bytes)": 3638703522,
-        "total_terms": 4206639543,
-        "documents": 20545677,
-        "unique_terms": 22054207,
-        "downloaded": False
-    },
-    "msmarco-v1-doc-segmented-d2q-t5-docvectors-lucene8": {
-        "description": "Lucene index (+docvectors) of the MS MARCO V1 segmented document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        "readme": "lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        ],
-        "md5": "a67e6854187f084a8a3eee11dd30bc31",
-        "size compressed (bytes)": 16627681594,
-        "total_terms": 4206639543,
-        "documents": 20545677,
-        "unique_terms": 22054207,
-        "downloaded": False
-    },
-
-    # Deprecated: MS MARCO V1 passage corpus, three indexes with different amounts of information (and sizes).
-    "msmarco-v1-passage-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 passage corpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-passage.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-passage.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-passage.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/L7yNfCXpqK5yf8e/download"
-        ],
-        "md5": "4d8fdbdcd119c1f47a4cc5d01a45dad3",
-        "size compressed (bytes)": 2178557129,
-        "total_terms": 352316036,
-        "documents": 8841823,
-        "unique_terms": 2660824,
-        "downloaded": False
-    },
-    "msmarco-v1-passage-slim-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 passage corpus ('slim' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-passage-slim.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-passage-slim.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-passage-slim.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/swtPDQAGg6oHD8m/download"
-        ],
-        "md5": "2f1e50d60a0df32a50111a986159de51",
-        "size compressed (bytes)": 498355616,
-        "total_terms": 352316036,
-        "documents": 8841823,
-        "unique_terms": 2660824,
-        "downloaded": False
-    },
-    "msmarco-v1-passage-full-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 passage corpus ('full' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-passage-full.20220131.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-passage-full.20220131.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-passage-full.20220131.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/wzGLFMQyKAc2TTC/download"
-        ],
-        "md5": "3283069c6e8451659c8ea83e2140d739",
-        "size compressed (bytes)": 3781721749,
-        "total_terms": 352316036,
-        "documents": 8841823,
-        "unique_terms": 2660824,
-        "downloaded": False
-    },
-
-    # Deprecated: MS MARCO V1 passage corpus, doc2query-T5 expansions.
-    "msmarco-v1-passage-d2q-t5-lucene8": {
-        "description": "Lucene index of the MS MARCO V1 passage corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-passage-d2q-t5.20220201.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v1-passage-d2q-t5.20220201.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-passage-d2q-t5.20220201.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/P7Lt234kyZP87nB/download"
-        ],
-        "md5": "136205f35bd895077c0874eaa063376c",
-        "size compressed (bytes)": 819441969,
-        "total_terms": 1986612263,
-        "documents": 8841823,
-        "unique_terms": 3929111,
-        "downloaded": False
-    },
-    "msmarco-v1-passage-d2q-t5-docvectors-lucene8": {
-        "description": "Lucene index (+docvectors) of the MS MARCO V1 passage corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        "readme": "lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v1-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        ],
-        "md5": "5eb8178e48a4a9b85714be156d85b2d1",
-        "size compressed (bytes)": 4433982542,
-        "total_terms": 1986612263,
-        "documents": 8841823,
-        "unique_terms": 3929111,
-        "downloaded": False
-    },
-
-    # These MS MARCO V1 indexes are deprecated, but keeping around for archival reasons
-    "msmarco-passage": {
-        "description": "Lucene index of the MS MARCO passage corpus (deprecated; use msmarco-v1-passage instead). (Lucene 8)",
-        "filename": "index-msmarco-passage-20201117-f87c94.tar.gz",
-        "readme": "index-msmarco-passage-20201117-f87c94-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-passage-20201117-f87c94.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/QQsZMFG8MpF4P8M/download"
-        ],
-        "md5": "1efad4f1ae6a77e235042eff4be1612d",
-        "size compressed (bytes)": 2218470796,
-        "total_terms": 352316036,
-        "documents": 8841823,
-        "unique_terms": 2660824,
-        "downloaded": False
-    },
-    "msmarco-passage-slim": {
-        "description": "Lucene index of the MS MARCO passage corpus (slim version, document text not stored) (deprecated; use msmarco-v1-passage-slim instead). (Lucene 8)",
-        "filename": "index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
-        "readme": "index-msmarco-passage-slim-20201202-ab6e28-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-passage-slim-20201202-ab6e28.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/Kx6K9NJFmwnaAP8/download"
-        ],
-        "md5": "5e11da4cebd2e8dda2e73c589ffb0b4c",
-        "size compressed (bytes)": 513566686,
-        "total_terms": 352316036,
-        "documents": 8841823,
-        "unique_terms": 2660824,
-        "downloaded": False
-    },
-    "msmarco-doc": {
-        "description": "Lucene index of the MS MARCO document corpus (deprecated; use msmarco-v1-doc instead). (Lucene 8)",
-        "filename": "index-msmarco-doc-20201117-f87c94.tar.gz",
-        "readme": "index-msmarco-doc-20201117-f87c94-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-doc-20201117-f87c94.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/5NC7A2wAL7opJKH/download"
-        ],
-        "md5": "ac747860e7a37aed37cc30ed3990f273",
-        "size compressed (bytes)": 13642330935,
-        "total_terms": 2748636047,
-        "documents": 3213835,
-        "unique_terms": 29823078,
-        "downloaded": False
-    },
-    "msmarco-doc-slim": {
-        "description": "Lucene index of the MS MARCO document corpus (slim version, document text not stored) (deprecated; use msmarco-v1-doc-slim instead). (Lucene 8)",
-        "filename": "index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
-        "readme": "index-msmarco-doc-slim-20201202-ab6e28-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-doc-slim-20201202-ab6e28.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/BMZ6oYBoEPgTFqs/download"
-        ],
-        "md5": "c56e752f7992bf6149761097641d515a",
-        "size compressed (bytes)": 1874471867,
-        "total_terms": 2748636047,
-        "documents": 3213835,
-        "unique_terms": 29823078,
-        "downloaded": False
-    },
-    "msmarco-doc-per-passage": {
-        "description": "Lucene index of the MS MARCO document corpus segmented into passages (deprecated; use msmarco-v1-doc-segmented instead). (Lucene 8)",
-        "filename": "index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
-        "readme": "index-msmarco-doc-per-passage-20201204-f50dcc-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-doc-per-passage-20201204-f50dcc.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/q6sAxE6q57q2TBo/download"
-        ],
-        "md5": "797367406a7542b649cefa6b41cf4c33",
-        "size compressed (bytes)": 11602951258,
-        "total_terms": 3197886407,
-        "documents": 20544550,
-        "unique_terms": 21173582,
-        "downloaded": False
-    },
-    "msmarco-doc-per-passage-slim": {
-        "description": "Lucene index of the MS MARCO document corpus segmented into passages (slim version, document text not stored) (deprecated; use msmarco-v1-doc-segmented-slim instead). (Lucene 8)",
-        "filename": "index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
-        "readme": "index-msmarco-doc-per-passage-slim-20201204-f50dcc-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-doc-per-passage-slim-20201204-f50dcc.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/mKTjbTKMwWF9kY3/download"
-        ],
-        "md5": "77c2409943a8c9faffabf57cb6adca69",
-        "size compressed (bytes)": 2834865200,
-        "total_terms": 3197886407,
-        "documents": 20544550,
-        "unique_terms": 21173582,
-        "downloaded": False
-    },
-
-    # These MS MARCO V1 doc2query expansion indexes are deprecated, but keeping around for archival reasons
-    "msmarco-passage-expanded": {
-        "description": "Lucene index of the MS MARCO passage corpus with docTTTTTquery expansions (deprecated; use msmarco-v1-passage-d2q-t5 instead). (Lucene 8)",
-        "filename": "index-msmarco-passage-expanded-20201121-e127fb.tar.gz",
-        "readme": "index-msmarco-passage-expanded-20201121-e127fb-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-passage-expanded-20201121-e127fb.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/pm7cisJtRxiAMHd/download"
-        ],
-        "md5": "e5762e9e065b6fe5000f9c18da778565",
-        "size compressed (bytes)": 816438546,
-        "total_terms": 1986612263,
-        "documents": 8841823,
-        "unique_terms": 3929111,
-        "downloaded": False
-    },
-    "msmarco-doc-expanded-per-doc": {
-        "description": "Lucene index of the MS MARCO document corpus with per-doc docTTTTTquery expansions (deprecated; use msmarco-v1-doc-d2q-t5 instead). (Lucene 8)",
-        "filename": "index-msmarco-doc-expanded-per-doc-20201126-1b4d0a.tar.gz",
-        "readme": "index-msmarco-doc-expanded-per-doc-20201126-1b4d0a-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-doc-expanded-per-doc-20201126-1b4d0a.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/3BQz6ZAXAxtfne8/download"
-        ],
-        "md5": "f7056191842ab77a01829cff68004782",
-        "size compressed (bytes)": 1978837253,
-        "total_terms": 3748333319,
-        "documents": 3213835,
-        "unique_terms": 30627687,
-        "downloaded": False
-    },
-    "msmarco-doc-expanded-per-passage": {
-        "description": "Lucene index of the MS MARCO document corpus with per-passage docTTTTTquery expansions (deprecated; use msmarco-v1-doc-segmented-d2q-t5 instead). (Lucene 8)",
-        "filename": "index-msmarco-doc-expanded-per-passage-20201126-1b4d0a.tar.gz",
-        "readme": "index-msmarco-doc-expanded-per-passage-20201126-1b4d0a-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/index-msmarco-doc-expanded-per-passage-20201126-1b4d0a.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/eZLbPWcnB7LzKnQ/download"
-        ],
-        "md5": "54ea30c64515edf3c3741291b785be53",
-        "size compressed (bytes)": 3069280946,
-        "total_terms": 4203956960,
-        "documents": 20544550,
-        "unique_terms": 22037213,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 document corpus, three indexes with different amounts of information (and sizes).
-    "msmarco-v2-doc-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 document corpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc.20220111.06fb4f.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/BC7CXiRrTfg9FbD/download"
-        ],
-        "md5": "3ca8b924f00f11e51e337c5421e55d96",
-        "size compressed (bytes)": 63719115316,
-        "total_terms": 14165661202,
-        "documents": 11959635,
-        "unique_terms": 44855557,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-slim-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 document corpus ('slim' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-slim.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-slim.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-slim.20220111.06fb4f.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/eAjtprNt2fwjQ7F/download"
-        ],
-        "md5": "502c4c96ecd95e4113a7a26a06065ecf",
-        "size compressed (bytes)": 7306072104,
-        "total_terms": 14165661202,
-        "documents": 11959635,
-        "unique_terms": 44855557,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-full-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 document corpus ('full' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-full.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-full.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-full.20220111.06fb4f.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/ZqEx5bbznxc9ekd/download"
-        ],
-        "md5": "cdb600adceccd327cb97c4277f910150",
-        "size compressed (bytes)": 119577632837,
-        "total_terms": 14165661202,
-        "documents": 11959635,
-        "unique_terms": 44855557,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 document corpus, doc2query-T5 expansions.
-    "msmarco-v2-doc-d2q-t5-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-d2q-t5.20220201.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-d2q-t5.20220201.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-d2q-t5.20220201.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/MeTFfBnwffS7gLd/download"
-        ],
-        "md5": "431391554854c51f347ba38c5e07ef94",
-        "size compressed (bytes)": 8254297093,
-        "total_terms": 19760777295,
-        "documents": 11959635,
-        "unique_terms": 54143053,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-d2q-t5-docvectors-lucene8": {
-        "description": "Lucene index (+docvectors) of the MS MARCO V2 document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        ],
-        "md5": "200176909cd31d750919f38410f20b8a",
-        "size compressed (bytes)": 54511069668,
-        "total_terms": 19760777295,
-        "documents": 11959635,
-        "unique_terms": 54143053,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 segmented document corpus, three indexes with different amounts of information (and sizes).
-    "msmarco-v2-doc-segmented-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 segmented document corpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "cb37211851bd0053227b8db1dd0a3853",
-        "size compressed (bytes)": 105646039864,
-        "total_terms": 24780915974,
-        "documents": 124131414,
-        "unique_terms": 29263590,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-segmented-slim-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 segmented document corpus ('slim' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-slim.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-slim.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-slim.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "448c1e0e49c38364abbc4d880e865ee5",
-        "size compressed (bytes)": 21004046043,
-        "total_terms": 24780915974,
-        "documents": 124131414,
-        "unique_terms": 29263590,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-segmented-full-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 segmented document corpus ('full' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-full.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-full.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-full.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "bb597b3d03eba00653387ffab8c01998",
-        "size compressed (bytes)": 186377654091,
-        "total_terms": 24780915974,
-        "documents": 124131414,
-        "unique_terms": 29263590,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 segmented document corpus, doc2query-T5 expansions.
-    "msmarco-v2-doc-segmented-d2q-t5-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 segmented document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-d2q-t5.20220201.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-d2q-t5.20220201.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5.20220201.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/m4DRWpeGW9Dawd7/download"
-        ],
-        "md5": "3ce9eaca885e1e8a79466bee5e6a4084",
-        "size compressed (bytes)": 24125355549,
-        "total_terms": 30376032067,
-        "documents": 124131414,
-        "unique_terms": 38930475,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-segmented-d2q-t5-docvectors-lucene8": {
-        "description": "Lucene index (+docvectors) of the MS MARCO V2 segmented document corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        ],
-        "md5": "d7fd3d9fbca6ca0b5ffeb8b824db0cd7",
-        "size compressed (bytes)": 114312032964,
-        "total_terms": 30376032067,
-        "documents": 124131414,
-        "unique_terms": 38930475,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 passage corpus, three indexes with different amounts of information (and sizes).
-    "msmarco-v2-passage-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 passage corpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "5990b4938dfdd092888ce9c9dfb6a90c",
-        "size compressed (bytes)": 38013278576,
-        "total_terms": 4673266762,
-        "documents": 138364198,
-        "unique_terms": 11885026,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-slim-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 passage corpus ('slim' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-slim.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-slim.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-slim.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "b9a6fdf88775b0b546907d4cd84c4a58",
-        "size compressed (bytes)": 8174630082,
-        "total_terms": 4673266762,
-        "documents": 138364198,
-        "unique_terms": 11885026,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-full-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 passage corpus ('full' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-full.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-full.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-full.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "a233873bef304dd87adef35f54c7a436",
-        "size compressed (bytes)": 59658189636,
-        "total_terms": 4673266762,
-        "documents": 138364198,
-        "unique_terms": 11885026,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 passage corpus, doc2query-T5 expansions.
-    "msmarco-v2-passage-d2q-t5-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 passage corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-d2q-t5.20220201.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-d2q-t5.20220201.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-d2q-t5.20220201.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/EiPESdXiikAcbFF/download"
-        ],
-        "md5": "72f3f0f56b9c7a1bdff836419f2f30bd",
-        "size compressed (bytes)": 14431987438,
-        "total_terms": 16961479226,
-        "documents": 138364198,
-        "unique_terms": 36650715,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-d2q-t5-docvectors-lucene8": {
-        "description": "Lucene index (+docvectors) of the MS MARCO V2 passage corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        ],
-        "md5": "e0ed749284f67db1f0890cb709ecb690",
-        "size compressed (bytes)": 59320157969,
-        "total_terms": 16961479226,
-        "documents": 138364198,
-        "unique_terms": 36650715,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 augmented passage corpus, three indexes with different amounts of information (and sizes).
-    "msmarco-v2-passage-augmented-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 augmented passage corpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-augmented.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-augmented.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-augmented.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "975f6be8d49238fe1d47e2895d26f99e",
-        "size compressed (bytes)": 65574361728,
-        "total_terms": 15272964956,
-        "documents": 138364198,
-        "unique_terms": 16579071,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-augmented-slim-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 augmented passage corpus ('slim' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-augmented-slim.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-augmented-slim.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-augmented-slim.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "af893e56d050a98b6646ce2ca063d3f4",
-        "size compressed (bytes)": 117322378611,
-        "total_terms": 15272964956,
-        "documents": 138364198,
-        "unique_terms": 16579071,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-augmented-full-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 augmented passage corpus ('full' version). (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-augmented-full.20220111.06fb4f.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-augmented-full.20220111.06fb4f.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-augmented-full.20220111.06fb4f.tar.gz"
-        ],
-        "md5": "e99f99503b9e030424546d59239f0cb5",
-        "size compressed (bytes)": 14819003760,
-        "total_terms": 15272964956,
-        "documents": 138364198,
-        "unique_terms": 16579071,
-        "downloaded": False
-    },
-
-    # MS MARCO V2 augmented passage corpus, doc2query-T5 expansions.
-    "msmarco-v2-passage-augmented-d2q-t5-lucene8": {
-        "description": "Lucene index of the MS MARCO V2 augmented passage corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-augmented-d2q-t5.20220201.9ea315.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-augmented-d2q-t5.20220201.9ea315.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5.20220201.9ea315.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/44EDc5a9aCbHZNW/download"
-        ],
-        "md5": "f248becbe3ef3fffc39680cff417791d",
-        "size compressed (bytes)": 20940452572,
-        "total_terms": 27561177420,
-        "documents": 138364198,
-        "unique_terms": 41176227,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-augmented-d2q-t5-docvectors-lucene8": {
-        "description": "Lucene index (+docvectors) of the MS MARCO V2 augmented passage corpus with doc2query-T5 expansions. (Lucene 8; deprecated)",
-        "filename": "lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5-docvectors.20220525.30c997.tar.gz",
-        ],
-        "md5": "8fc1cc2b71331772ff7b306cd62794f6",
-        "size compressed (bytes)": 96122355388,
-        "total_terms": 27561177420,
-        "documents": 138364198,
-        "unique_terms": 41176227,
-        "downloaded": False
-    },
-
-    # BEIR (v1.0.0) flat indexes (Lucene 8; deprecated)
-    "beir-v1.0.0-trec-covid-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): TREC-COVID. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-trec-covid-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-trec-covid-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-trec-covid-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "d8574b8263df5dc337b443c4c35d384f",
-        "size compressed (bytes)": 226745226,
-        "total_terms": 20822810,
-        "documents": 171331,
-        "unique_terms": 202643,
-        "downloaded": False
-    },
-    "beir-v1.0.0-bioasq-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): BioASQ. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-bioasq-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-bioasq-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-bioasq-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "ab4823b0b59dbb59ae72c2689b73133c",
-        "size compressed (bytes)": 24861183683,
-        "total_terms": 2257541768,
-        "documents": 14914603,
-        "unique_terms": 4959999,
-        "downloaded": False
-    },
-    "beir-v1.0.0-nfcorpus-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): NFCorpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-nfcorpus-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-nfcorpus-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-nfcorpus-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "b52e0f918eb3a5517289980850dec55c",
-        "size compressed (bytes)": 6508815,
-        "total_terms": 637485,
-        "documents": 3633,
-        "unique_terms": 22111,
-        "downloaded": False
-    },
-    "beir-v1.0.0-nq-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): NQ. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-nq-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-nq-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-nq-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "71c35db0343ba9800c6b34510acbfb4f",
-        "size compressed (bytes)": 1650195223,
-        "total_terms": 151249287,
-        "documents": 2681468,
-        "unique_terms": 997009,
-        "downloaded": False
-    },
-    "beir-v1.0.0-hotpotqa-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): HotpotQA. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-hotpotqa-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-hotpotqa-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-hotpotqa-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "431995b33471f183272bb84d9499d8f6",
-        "size compressed (bytes)": 2027634934,
-        "total_terms": 172477063,
-        "documents": 5233329,
-        "unique_terms": 2644887,
-        "downloaded": False
-    },
-    "beir-v1.0.0-fiqa-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): FiQA-2018. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-fiqa-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-fiqa-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-fiqa-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "332ec18504778b03e330847a006541d4",
-        "size compressed (bytes)": 56101137,
-        "total_terms": 5288635,
-        "documents": 57600,
-        "unique_terms": 66977,
-        "downloaded": False
-    },
-    "beir-v1.0.0-signal1m-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): Signal-1M. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-signal1m-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-signal1m-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-signal1m-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "95b279bbd4533b631967540647f18476",
-        "size compressed (bytes)": 499183897,
-        "total_terms": 32240067,
-        "documents": 2866315,
-        "unique_terms": 796646,
-        "downloaded": False
-    },
-    "beir-v1.0.0-trec-news-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): TREC-NEWS. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-trec-news-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-trec-news-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-trec-news-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "9f78f049ffdcac5f6f55cd118e008bdb",
-        "size compressed (bytes)": 2630489172,
-        "total_terms": 275651967,
-        "documents": 594589,
-        "unique_terms": 729872,
-        "downloaded": False
-    },
-    "beir-v1.0.0-robust04-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): Robust04. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-robust04-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-robust04-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-robust04-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "a9340eeedb444a303afbf974ba1872d5",
-        "size compressed (bytes)": 1731243578,
-        "total_terms": 174384263,
-        "documents": 528036,
-        "unique_terms": 923466,
-        "downloaded": False
-    },
-    "beir-v1.0.0-arguana-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): ArguAna. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-arguana-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-arguana-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-arguana-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "62ba65fa619e7f1c9e48850974ab242d",
-        "size compressed (bytes)": 10563170,
-        "total_terms": 969528,
-        "documents": 8674,
-        "unique_terms": 23895,
-        "downloaded": False
-    },
-    "beir-v1.0.0-webis-touche2020-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): Webis-Touche2020. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-webis-touche2020-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-webis-touche2020-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-webis-touche2020-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "9e43abfd1de98da6671df90bba8486a1",
-        "size compressed (bytes)": 751902399,
-        "total_terms": 76082209,
-        "documents": 382545,
-        "unique_terms": 525540,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-android-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-android. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-android-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-android-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-android-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "870b2ddfd59abb96a74c00515122b9e1",
-        "size compressed (bytes)": 17466940,
-        "total_terms": 1760761,
-        "documents": 22998,
-        "unique_terms": 41455,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-english-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-english. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-english-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-english-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-english-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "bdcfe2cb5798b79405cba1185ad4ad38",
-        "size compressed (bytes)": 24992357,
-        "total_terms": 2236655,
-        "documents": 40221,
-        "unique_terms": 62517,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-gaming-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-gaming. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-gaming-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-gaming-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-gaming-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "92fc7435b1ee64783c4a97eea9d2c4a4",
-        "size compressed (bytes)": 29224430,
-        "total_terms": 2827717,
-        "documents": 45301,
-        "unique_terms": 60070,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-gis-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-gis. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-gis-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-gis-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-gis-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "80c3dcc4b3fd39a1125537b587f27436",
-        "size compressed (bytes)": 43466795,
-        "total_terms": 4048584,
-        "documents": 37637,
-        "unique_terms": 184133,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-mathematica-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-mathematica. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-mathematica-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-mathematica-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-mathematica-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "359c577e5a4f9a48e7b61fbd70447121",
-        "size compressed (bytes)": 21621544,
-        "total_terms": 2332642,
-        "documents": 16705,
-        "unique_terms": 111611,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-physics-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-physics. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-physics-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-physics-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-physics-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "3f4a0c885463a50038893c5169374e56",
-        "size compressed (bytes)": 38016173,
-        "total_terms": 3785483,
-        "documents": 38316,
-        "unique_terms": 55950,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-programmers-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-programmers. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-programmers-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-programmers-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-programmers-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "2b0be6fc6d9623201540cbcb2f4881ab",
-        "size compressed (bytes)": 40373220,
-        "total_terms": 3905694,
-        "documents": 32176,
-        "unique_terms": 74195,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-stats-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-stats. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-stats-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-stats-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-stats-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "ce64d853969bde0fecea2228c1258944",
-        "size compressed (bytes)": 52283784,
-        "total_terms": 5356042,
-        "documents": 42269,
-        "unique_terms": 183358,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-tex-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-tex. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-tex-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-tex-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-tex-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "558efcfba599b0e8e7a95a41df4dc5f2",
-        "size compressed (bytes)": 91968319,
-        "total_terms": 9556422,
-        "documents": 68184,
-        "unique_terms": 288087,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-unix-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-unix. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-unix-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-unix-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-unix-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "a3c6cbfc1e81d98abc6cc4380a8f19d2",
-        "size compressed (bytes)": 53892386,
-        "total_terms": 5767374,
-        "documents": 47382,
-        "unique_terms": 206323,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-webmasters-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-webmasters. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-webmasters-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-webmasters-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-webmasters-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "fa35ece230cb4d85a5e4ad5de0fd9240",
-        "size compressed (bytes)": 15204463,
-        "total_terms": 1482585,
-        "documents": 17405,
-        "unique_terms": 40547,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-wordpress-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): CQADupStack-wordpress. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-wordpress-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-wordpress-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-wordpress-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "5a3591b6ff9ce5a97d1600f8a8cd63e8",
-        "size compressed (bytes)": 54895441,
-        "total_terms": 5463472,
-        "documents": 48605,
-        "unique_terms": 125727,
-        "downloaded": False
-    },
-    "beir-v1.0.0-quora-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): Quora. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-quora-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-quora-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-quora-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "dde92b4610b08282d11e7a4465b29181",
-        "size compressed (bytes)": 52750359,
-        "total_terms": 4390852,
-        "documents": 522931,
-        "unique_terms": 69597,
-        "downloaded": False
-    },
-    "beir-v1.0.0-dbpedia-entity-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): DBPedia. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-dbpedia-entity-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-dbpedia-entity-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-dbpedia-entity-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "0d38ea1abf89644bb7d39e74cc4dd2d9",
-        "size compressed (bytes)": 2079898414,
-        "total_terms": 164794987,
-        "documents": 4635922,
-        "unique_terms": 3351449,
-        "downloaded": False
-    },
-    "beir-v1.0.0-scidocs-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): SCIDOCS. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-scidocs-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-scidocs-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-scidocs-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "09a0ea1853445be14da2afb0bc47335e",
-        "size compressed (bytes)": 186605163,
-        "total_terms": 3266767,
-        "documents": 25657,
-        "unique_terms": 63604,
-        "downloaded": False
-    },
-    "beir-v1.0.0-fever-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): FEVER. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-fever-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-fever-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-fever-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "63cd5f369b5952386f138efe45571d41",
-        "size compressed (bytes)": 3878535207,
-        "total_terms": 325179170,
-        "documents": 5416568,
-        "unique_terms": 3293639,
-        "downloaded": False
-    },
-    "beir-v1.0.0-climate-fever-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): Climate-FEVER. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-climate-fever-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-climate-fever-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-climate-fever-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "9af959cf58139d086d52121917913a02",
-        "size compressed (bytes)": 3878606250,
-        "total_terms": 325185077,
-        "documents": 5416593,
-        "unique_terms": 3293621,
-        "downloaded": False
-    },
-    "beir-v1.0.0-scifact-flat-lucene8": {
-        "description": "Lucene flat index of BEIR (v1.0.0): SciFact. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-scifact-flat.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-scifact-flat.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-scifact-flat.20220501.1842ee.tar.gz"
-        ],
-        "md5": "8c79300afd78acb95f127c58682fc881",
-        "size compressed (bytes)": 8851845,
-        "total_terms": 838128,
-        "documents": 5183,
-        "unique_terms": 28865,
-        "downloaded": False
-    },
-
-    # BEIR (v1.0.0) multifield indexes (Lucene 8; deprecated)
-    "beir-v1.0.0-trec-covid-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): TREC-COVID. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-trec-covid-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-trec-covid-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-trec-covid-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "2dabcca159c157215ae59b1899c495a8",
-        "size compressed (bytes)": 223251753,
-        "total_terms": 19060111,
-        "documents": 129192,
-        "unique_terms": 193846,
-        "downloaded": False
-    },
-    "beir-v1.0.0-bioasq-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): BioASQ. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-bioasq-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-bioasq-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-bioasq-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "723dcc48c961a9faef23e41cc0f372b0",
-        "size compressed (bytes)": 25390117017,
-        "total_terms": 2099554317,
-        "documents": 14914602,
-        "unique_terms": 4889048,
-        "downloaded": False
-    },
-    "beir-v1.0.0-nfcorpus-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): NFCorpus. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-nfcorpus-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-nfcorpus-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-nfcorpus-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "7c6a63153cca484bd85510d9ffc7c62e",
-        "size compressed (bytes)": 6644821,
-        "total_terms": 601950,
-        "documents": 3633,
-        "unique_terms": 21819,
-        "downloaded": False
-    },
-    "beir-v1.0.0-nq-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): NQ. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-nq-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-nq-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-nq-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "3642ab8879de1c37993347d164694885",
-        "size compressed (bytes)": 1647410313,
-        "total_terms": 144050884,
-        "documents": 2680961,
-        "unique_terms": 996635,
-        "downloaded": False
-    },
-    "beir-v1.0.0-hotpotqa-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): HotpotQA. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-hotpotqa-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-hotpotqa-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-hotpotqa-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "fa80379866ff06ad905d70ba1d4d55e3",
-        "size compressed (bytes)": 2092477199,
-        "total_terms": 158180689,
-        "documents": 5233235,
-        "unique_terms": 2627634,
-        "downloaded": False
-    },
-    "beir-v1.0.0-fiqa-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): FiQA-2018. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-fiqa-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-fiqa-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-fiqa-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "2cc96d72349f5f864235a88303af5da9",
-        "size compressed (bytes)": 56101140,
-        "total_terms": 5288635,
-        "documents": 57600,
-        "unique_terms": 66977,
-        "downloaded": False
-    },
-    "beir-v1.0.0-signal1m-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): Signal-1M. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-signal1m-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-signal1m-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-signal1m-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "16a8c34363c69afc820af20ec6ec0848",
-        "size compressed (bytes)": 499183933,
-        "total_terms": 32240067,
-        "documents": 2866315,
-        "unique_terms": 796646,
-        "downloaded": False
-    },
-    "beir-v1.0.0-trec-news-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): TREC-NEWS. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-trec-news-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-trec-news-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-trec-news-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "91390f9e059ba04479f3550cca166a65",
-        "size compressed (bytes)": 2640469722,
-        "total_terms": 270886723,
-        "documents": 578605,
-        "unique_terms": 727856,
-        "downloaded": False
-    },
-    "beir-v1.0.0-robust04-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): Robust04. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-robust04-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-robust04-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-robust04-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "f9821cef4dc903772dec283cc8c9e0f5",
-        "size compressed (bytes)": 1731243641,
-        "total_terms": 174384263,
-        "documents": 528036,
-        "unique_terms": 923466,
-        "downloaded": False
-    },
-    "beir-v1.0.0-arguana-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): ArguAna. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-arguana-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-arguana-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-arguana-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "d22aa6b4247535dedb78b3f876d958e7",
-        "size compressed (bytes)": 10523627,
-        "total_terms": 944123,
-        "documents": 8674,
-        "unique_terms": 23867,
-        "downloaded": False
-    },
-    "beir-v1.0.0-webis-touche2020-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): Webis-Touche2020. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-webis-touche2020-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-webis-touche2020-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-webis-touche2020-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "f9d1601b76bdbafef6bfa335bf1d1595",
-        "size compressed (bytes)": 752116420,
-        "total_terms": 74066724,
-        "documents": 382545,
-        "unique_terms": 524665,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-android-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-android. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-android-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-android-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-android-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "05801b35a25af7c16172255512b4ce36",
-        "size compressed (bytes)": 17931810,
-        "total_terms": 1591284,
-        "documents": 22998,
-        "unique_terms": 40823,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-english-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-english. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-english-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-english-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-english-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "bf9eef1c5fd10b66b6816f272e7872e1",
-        "size compressed (bytes)": 25605309,
-        "total_terms": 2006983,
-        "documents": 40221,
-        "unique_terms": 61530,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-gaming-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-gaming. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-gaming-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-gaming-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-gaming-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "3393426ddc796ce263ffb318a6d2bfed",
-        "size compressed (bytes)": 30065920,
-        "total_terms": 2510477,
-        "documents": 45300,
-        "unique_terms": 59113,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-gis-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-gis. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-gis-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-gis-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-gis-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "f69c20cdd61ca7d59ba13e46d8119f5c",
-        "size compressed (bytes)": 44265052,
-        "total_terms": 3789161,
-        "documents": 37637,
-        "unique_terms": 183298,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-mathematica-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-mathematica. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-mathematica-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-mathematica-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-mathematica-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "74ef57dcbca928d6ac77b79bb9e6c9ad",
-        "size compressed (bytes)": 21944398,
-        "total_terms": 2234369,
-        "documents": 16705,
-        "unique_terms": 111306,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-physics-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-physics. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-physics-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-physics-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-physics-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "be67a3ae1f91fbe3fb26262e695871f3",
-        "size compressed (bytes)": 38801084,
-        "total_terms": 3542078,
-        "documents": 38316,
-        "unique_terms": 55229,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-programmers-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-programmers. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-programmers-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-programmers-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-programmers-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "8d40c0e813171a68ea27da42e1943ebe",
-        "size compressed (bytes)": 41061263,
-        "total_terms": 3682227,
-        "documents": 32176,
-        "unique_terms": 73765,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-stats-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-stats. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-stats-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-stats-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-stats-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "d00eec70ebfba38d32e5d588be7e0d74",
-        "size compressed (bytes)": 53164818,
-        "total_terms": 5073873,
-        "documents": 42269,
-        "unique_terms": 182933,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-tex-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-tex. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-tex-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-tex-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-tex-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "6952954b17ebe87987c08d1994bcb801",
-        "size compressed (bytes)": 93231672,
-        "total_terms": 9155404,
-        "documents": 68184,
-        "unique_terms": 287392,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-unix-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-unix. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-unix-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-unix-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-unix-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "858632caf3b93fd0ce6f2c4cdc95503b",
-        "size compressed (bytes)": 54854147,
-        "total_terms": 5449726,
-        "documents": 47382,
-        "unique_terms": 205471,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-webmasters-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-webmasters. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-webmasters-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-webmasters-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-webmasters-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "d40fbb1d750a8d4bfcb77edd3d74e758",
-        "size compressed (bytes)": 15560909,
-        "total_terms": 1358292,
-        "documents": 17405,
-        "unique_terms": 40073,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-wordpress-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): CQADupStack-wordpress. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-wordpress-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-wordpress-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-wordpress-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "938abf49a6835006e1b29b1bcd28602f",
-        "size compressed (bytes)": 55833972,
-        "total_terms": 5151575,
-        "documents": 48605,
-        "unique_terms": 125110,
-        "downloaded": False
-    },
-    "beir-v1.0.0-quora-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): Quora. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-quora-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-quora-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-quora-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "0812beec31e051515524c746323e0ee2",
-        "size compressed (bytes)": 52750399,
-        "total_terms": 4390852,
-        "documents": 522931,
-        "unique_terms": 69597,
-        "downloaded": False
-    },
-    "beir-v1.0.0-dbpedia-entity-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): DBPedia. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-dbpedia-entity-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-dbpedia-entity-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-dbpedia-entity-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "0834295cdc4e955cb9052b24a56f074b",
-        "size compressed (bytes)": 2139032416,
-        "total_terms": 152205484,
-        "documents": 4635922,
-        "unique_terms": 3338466,
-        "downloaded": False
-    },
-    "beir-v1.0.0-scidocs-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): SCIDOCS. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-scidocs-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-scidocs-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-scidocs-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "0944c45ccf3ab5bb3cee5f1863725114",
-        "size compressed (bytes)": 175925466,
-        "total_terms": 3065828,
-        "documents": 25313,
-        "unique_terms": 62562,
-        "downloaded": False
-    },
-    "beir-v1.0.0-fever-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): FEVER. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-fever-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-fever-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-fever-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "3ba53efbdbeed974a641c7dc5860dbc8",
-        "size compressed (bytes)": 3946159718,
-        "total_terms": 310655704,
-        "documents": 5396138,
-        "unique_terms": 3275057,
-        "downloaded": False
-    },
-    "beir-v1.0.0-climate-fever-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): Climate-FEVER. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-climate-fever-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-climate-fever-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-climate-fever-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "998e9e9aa3d91c8022e1f8cae3f75a5f",
-        "size compressed (bytes)": 3946246078,
-        "total_terms": 310661482,
-        "documents": 5396163,
-        "unique_terms": 3275068,
-        "downloaded": False
-    },
-    "beir-v1.0.0-scifact-multifield-lucene8": {
-        "description": "Lucene multifield index of BEIR (v1.0.0): SciFact. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-scifact-multifield.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-scifact-multifield.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-scifact-multifield.20220501.1842ee.tar.gz"
-        ],
-        "md5": "a72d8c62859a2434fba2e0034268dbe4",
-        "size compressed (bytes)": 9078043,
-        "total_terms": 784591,
-        "documents": 5183,
-        "unique_terms": 28581,
+        "md5": "d44ca9c7b634cf56e8cfd5892a3d3427",
+        "size compressed (bytes)": 8470981318,
+        "total_terms": 803227160,
+        "documents": 3179206,
+        "unique_terms": 1616532,
         "downloaded": False
     }
-
 }
 
-TF_INDEX_INFO = {**TF_INDEX_INFO_CURRENT, **TF_INDEX_INFO_DEPRECATED}
+TF_INDEX_INFO = {**TF_INDEX_INFO_MSMARCO,
+                 **TF_INDEX_INFO_BEIR,
+                 **TF_INDEX_INFO_MRTYDI,
+                 **TF_INDEX_INFO_MIRACL,
+                 **TF_INDEX_INFO_OTHER}
 
-IMPACT_INDEX_INFO_CURRENT = {
+IMPACT_INDEX_INFO_MSMARCO = {
     "msmarco-v1-passage-slimr": {
         "description": "Lucene impact index of the MS MARCO V1 passage corpus enoded by SLIM trained with BM25 negatives. (Lucene 9)",
         "filename": "lucene-index.msmarco-v1-passage-slimr.20230220.tar.gz",
@@ -4201,8 +2469,10 @@ IMPACT_INDEX_INFO_CURRENT = {
         "documents": 124131404,
         "unique_terms": 29172,
         "downloaded": False
-    },
+    }
+}
 
+IMPACT_INDEX_INFO_BEIR = {
     # BEIR (v1.0.0) impact indexes encoded by SPLADE-distill CoCodenser-medium
     "beir-v1.0.0-trec-covid-splade_distil_cocodenser_medium": {
         "description": "Lucene impact index of BEIR (v1.0.0): TREC-COVID encoded by SPLADE-distill CoCodenser-medium",
@@ -4609,589 +2879,11 @@ IMPACT_INDEX_INFO_CURRENT = {
         "documents": 5183,
         "unique_terms": 17486,
         "downloaded": False
-    },
-}
-
-IMPACT_INDEX_INFO_DEPRECATED = {
-
-    # Deprecated: Lucene 8 indexes
-    "msmarco-v2-passage-unicoil-0shot-lucene8": {
-        "description": "Lucene impact index of the MS MARCO V2 passage corpus for uniCOIL. (Lucene 8)",
-        "filename": "lucene-index.msmarco-v2-passage-unicoil-0shot.20220219.6a7080.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-unicoil-0shot.20220219.6a7080.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-unicoil-0shot.20220219.6a7080.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/SCskjTJLX4CExkF/download"
-        ],
-        "md5": "ea024b0dd43a574deb65942e14d32630",
-        "size compressed (bytes)": 22212154603,
-        "total_terms": 775253560148,
-        "documents": 138364198,
-        "unique_terms": 29149,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-unicoil-noexp-0shot-lucene8": {
-        "description": "Lucene impact index of the MS MARCO V2 passage corpus for uniCOIL (noexp). (Lucene 8)",
-        "filename": "lucene-index.msmarco-v2-passage-unicoil-noexp-0shot.20220219.6a7080.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage-unicoil-noexp-0shot.20220219.6a7080.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot.20220219.6a7080.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/FmW6N5FpMCyjMCE/download"
-        ],
-        "md5": "fb356e7614afc07e330b0559ae5cef18",
-        "size compressed (bytes)": 14615689637,
-        "total_terms": 411330032512,
-        "documents": 138364198,
-        "unique_terms": 29148,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-unicoil-tilde-lucene8": {
-        "description": "Lucene impact index of the MS MARCO V2 passage corpus encoded by uniCOIL-TILDE. (Lucene 8)",
-        "filename": "lucene-index.msmarco-v2-passage.unicoil-tilde.20211012.58d286.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage.unicoil-tilde.20211012.58d286.readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage.unicoil-tilde.20211012.58d286.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/oGQ8tWifozPaHLK/download"
-        ],
-        "md5": "562f9534eefe04ab8c07beb304074d41",
-        "size compressed (bytes)": 31168302160,
-        "total_terms": 1155211154985,
-        "documents": 138364198,
-        "unique_terms": 29149,
-        "downloaded": False
-    },
-
-    "msmarco-v2-doc-segmented-unicoil-0shot-lucene8": {
-        "description": "Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL. (Lucene 8)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-unicoil-0shot.20220219.6a7080.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-unicoil-0shot.20220219.6a7080.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot.20220219.6a7080.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/7PTnyEGwNGoJjXm/download"
-        ],
-        "md5": "94fc8af0d08682f7c79ffb16d82dcfab",
-        "size compressed (bytes)": 32787358081,
-        "total_terms": 1185840285417,
-        "documents": 124131414,
-        "unique_terms": 29169,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-segmented-unicoil-0shot-v2-lucene8": {
-        "description": "Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL, with title prepended. (Lucene 8)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2.20220419.c47993.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2.20220419.c47993.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2.20220419.c47993.tar.gz"
-        ],
-        "md5": "109572d65098021642b33e0feecde057",
-        "size compressed (bytes)": 33967003367,
-        "total_terms": 1204542769110,
-        "documents": 124131414,
-        "unique_terms": 29168,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-segmented-unicoil-noexp-0shot-lucene8": {
-        "description": "Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL (noexp). (Lucene 8)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot.20220219.6a7080.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot.20220219.6a7080.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot.20220219.6a7080.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/PoWYJzGJYx6nCik/download"
-        ],
-        "md5": "d7807b60087b630010e9c31b59d30b69",
-        "size compressed (bytes)": 28640356748,
-        "total_terms": 805830282591,
-        "documents": 124131404,
-        "unique_terms": 29172,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2-lucene8": {
-        "description": "Lucene impact index of the MS MARCO V2 segmented document corpus for uniCOIL (noexp) with title prepended. (Lucene 8)",
-        "filename": "lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.20220419.c47993.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.20220419.c47993.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.20220419.c47993.tar.gz"
-        ],
-        "md5": "8a48373934ad45052b5267ba73cdcad0",
-        "size compressed (bytes)": 29662349942,
-        "total_terms": 820664704261,
-        "documents": 124131404,
-        "unique_terms": 29172,
-        "downloaded": False
-    },
-
-    # These MS MARCO uniCOIL models are deprecated, but keeping around for archival reasons
-    "msmarco-passage-unicoil-d2q": {
-        "description": "Lucene impact index of the MS MARCO passage corpus encoded by uniCOIL-d2q (deprecated; use msmarco-v1-passage-unicoil instead).",
-        "filename": "lucene-index.msmarco-passage.unicoil-d2q.20211012.58d286.tar.gz",
-        "readme": "lucene-index.msmarco-passage.unicoil-d2q.20211012.58d286.readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-passage.unicoil-d2q.20211012.58d286.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/LGoAAXM7ZEbyQ7y/download"
-        ],
-        "md5": "4a8cb3b86a0d9085a0860c7f7bb7fe99",
-        "size compressed (bytes)": 1205104390,
-        "total_terms": 44495093768,
-        "documents": 8841823,
-        "unique_terms": 27678,
-        "downloaded": False
-    },
-    "msmarco-doc-per-passage-unicoil-d2q": {
-        "description": "Lucene impact index of the MS MARCO doc corpus per passage expansion encoded by uniCOIL-d2q (deprecated; use msmarco-v1-doc-segmented-unicoil instead).",
-        "filename": "lucene-index.msmarco-doc-per-passage-expansion.unicoil-d2q.20211012.58d286.tar.gz",
-        "readme": "lucene-index.msmarco-doc-per-passage-expansion.unicoil-d2q.20211012.58d286.readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-doc-per-passage-expansion.unicoil-d2q.20211012.58d286.tar.gz",
-        ],
-        "md5": "44bfc848f9a77302b10a59c5b136eb95",
-        "size compressed (bytes)": 5945466106,
-        "total_terms": 214505277898,
-        "documents": 20545677,
-        "unique_terms": 29142,
-        "downloaded": False
-    },
-    "msmarco-v2-passage-unicoil-noexp-0shot-deprecated": {
-        "description": "Lucene impact index of the MS MARCO V2 passage corpus encoded by uniCOIL (zero-shot, no expansions) (deprecated; use msmarco-v2-passage-unicoil-noexp-0shot instead).",
-        "filename": "lucene-index.msmarco-v2-passage.unicoil-noexp-0shot.20211012.58d286.tar.gz",
-        "readme": "lucene-index.msmarco-v2-passage.unicoil-noexp-0shot.20211012.58d286.readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-passage.unicoil-noexp-0shot.20211012.58d286.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/eXA2BHF8WQjdY8R/download"
-        ],
-        "md5": "8886a8d9599838bc6d8d61464da61086",
-        "size compressed (bytes)": 14801476783,
-        "total_terms": 411330032512,
-        "documents": 138364198,
-        "unique_terms": 29148,
-        "downloaded": False
-    },
-    "msmarco-v2-doc-per-passage-unicoil-noexp-0shot": {
-        "description": "Lucene impact index of the MS MARCO V2 document corpus per passage encoded by uniCOIL (zero-shot, no expansions) (deprecated; msmarco-v2-doc-segmented-unicoil-noexp-0shot).",
-        "filename": "lucene-index.msmarco-v2-doc-per-passage.unicoil-noexp-0shot.20211012.58d286.tar.gz",
-        "readme": "lucene-index.msmarco-v2-doc-per-passage.unicoil-noexp-0shot.20211012.58d286.readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.msmarco-v2-doc-per-passage.unicoil-noexp-0shot.20211012.58d286.tar.gz",
-            "https://vault.cs.uwaterloo.ca/s/BSrJmAFJywsRYXo/download"
-        ],
-        "md5": "1980db886d969c3393e4da20190eaa8f",
-        "size compressed (bytes)": 29229949764,
-        "total_terms": 805830282591,
-        "documents": 124131404,
-        "unique_terms": 29172,
-        "downloaded": False
-    },
-
-    # BEIR (v1.0.0) impact indexes encoded by SPLADE-distill CoCodenser-medium (Lucene 8; deprecated)
-    "beir-v1.0.0-trec-covid-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): TREC-COVID encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-trec-covid-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-trec-covid-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-trec-covid-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "b9c3837f2421667ba48adb84fcb599aa",
-        "size compressed (bytes)": 57011989,
-        "total_terms": 1697942549,
-        "documents": 171332,
-        "unique_terms": 26611,
-        "downloaded": False
-    },
-    "beir-v1.0.0-bioasq-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): BioASQ encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-bioasq-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-bioasq-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-bioasq-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "96ebb0b9016d9894e9784fa71ad7595d",
-        "size compressed (bytes)": 5474720263,
-        "total_terms": 181960155708,
-        "documents": 14914603,
-        "unique_terms": 27703,
-        "downloaded": False
-    },
-    "beir-v1.0.0-nfcorpus-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): NFCorpus encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-nfcorpus-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-nfcorpus-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-nfcorpus-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "7f5ec129305d630a18d63f188e08aa22",
-        "size compressed (bytes)": 1445273,
-        "total_terms": 41582222,
-        "documents": 3633,
-        "unique_terms": 16295,
-        "downloaded": False
-    },
-    "beir-v1.0.0-nq-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): NQ encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-nq-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-nq-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-nq-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "026dc3c2ed7292e7549ce4ff9ae2c318",
-        "size compressed (bytes)": 859416460,
-        "total_terms": 21901570532,
-        "documents": 2681468,
-        "unique_terms": 28747,
-        "downloaded": False
-    },
-    "beir-v1.0.0-hotpotqa-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): HotpotQA encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-hotpotqa-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-hotpotqa-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-hotpotqa-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "3edf537dfed5a9274ba56ef58ab090f6",
-        "size compressed (bytes)": 1197602761,
-        "total_terms": 32565190895,
-        "documents": 5233329,
-        "unique_terms": 28724,
-        "downloaded": False
-    },
-    "beir-v1.0.0-fiqa-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): FiQA-2018 encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-fiqa-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-fiqa-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-fiqa-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "a6ff07fe2a75f30838c3faf7c133efc1",
-        "size compressed (bytes)": 19858617,
-        "total_terms": 487502241,
-        "documents": 57638,
-        "unique_terms": 26244,
-        "downloaded": False
-    },
-    "beir-v1.0.0-signal1m-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): Signal-1M encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-signal1m-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-signal1m-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-signal1m-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "6d1fedefd3cb3a08820edc9552dd44b6",
-        "size compressed (bytes)": 611827346,
-        "total_terms": 13103073741,
-        "documents": 2866316,
-        "unique_terms": 28130,
-        "downloaded": False
-    },
-    "beir-v1.0.0-trec-news-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): TREC-NEWS encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-trec-news-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-trec-news-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-trec-news-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "05faf28e84259629aceb4d39d52471db",
-        "size compressed (bytes)": 278203568,
-        "total_terms": 7519025445,
-        "documents": 594977,
-        "unique_terms": 27745,
-        "downloaded": False
-    },
-    "beir-v1.0.0-robust04-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): Robust04 encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-robust04-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-robust04-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-robust04-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "c2c7f69edf7bc0edf2ede9d88f4d0402",
-        "size compressed (bytes)": 217727819,
-        "total_terms": 6718533167,
-        "documents": 528155,
-        "unique_terms": 27623,
-        "downloaded": False
-    },
-    "beir-v1.0.0-arguana-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): ArguAna encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-arguana-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-arguana-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-arguana-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "2dbb3cdd8412697cc336197912783eb2",
-        "size compressed (bytes)": 3866879,
-        "total_terms": 96421121,
-        "documents": 8674,
-        "unique_terms": 22536,
-        "downloaded": False
-    },
-    "beir-v1.0.0-webis-touche2020-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): Webis-Touche2020 encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-webis-touche2020-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-webis-touche2020-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-webis-touche2020-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "ff5cb006fac08086c575109e0ac80a1c",
-        "size compressed (bytes)": 126819142,
-        "total_terms": 3229042324,
-        "documents": 382545,
-        "unique_terms": 27742,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-android-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-android encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-android-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-android-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-android-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "1fb9462d93a21293a0c7aedd26653158",
-        "size compressed (bytes)": 6068305,
-        "total_terms": 157949889,
-        "documents": 22998,
-        "unique_terms": 18891,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-english-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-english encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-english-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-english-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-english-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "12f4581a96b775166210b462a78f72e3",
-        "size compressed (bytes)": 9955691,
-        "total_terms": 218761119,
-        "documents": 40221,
-        "unique_terms": 26613,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-gaming-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-gaming encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-gaming-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-gaming-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-gaming-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "310750f0cbe930fd521d875b6df7a61f",
-        "size compressed (bytes)": 13104645,
-        "total_terms": 296073202,
-        "documents": 45301,
-        "unique_terms": 24564,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-gis-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-gis encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-gis-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-gis-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-gis-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "3b42c73ccc278cc0bb823829867c6fce",
-        "size compressed (bytes)": 10380891,
-        "total_terms": 296967034,
-        "documents": 37637,
-        "unique_terms": 22034,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-mathematica-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-mathematica encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-mathematica-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-mathematica-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-mathematica-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "5b9d594270ff7417aabf1e9ca0a5bdf5",
-        "size compressed (bytes)": 4823160,
-        "total_terms": 132796971,
-        "documents": 16705,
-        "unique_terms": 19765,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-physics-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-physics encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-physics-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-physics-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-physics-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "a520cde380062b58f52c90e15d05e445",
-        "size compressed (bytes)": 11011175,
-        "total_terms": 284896455,
-        "documents": 38316,
-        "unique_terms": 22985,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-programmers-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-programmers encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-programmers-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-programmers-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-programmers-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "a90bd4f1185184881cbeaae095eb9e6f",
-        "size compressed (bytes)": 10146685,
-        "total_terms": 258856106,
-        "documents": 32176,
-        "unique_terms": 22560,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-stats-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-stats encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-stats-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-stats-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-stats-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "33f8e2025e89fd637806fe3083b61e86",
-        "size compressed (bytes)": 12016946,
-        "total_terms": 333590386,
-        "documents": 42269,
-        "unique_terms": 23322,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-tex-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-tex encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-tex-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-tex-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-tex-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "c20a0543a3ed90cf0ac8a2f4f52a8f7a",
-        "size compressed (bytes)": 19883333,
-        "total_terms": 604604076,
-        "documents": 68184,
-        "unique_terms": 24669,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-unix-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-unix encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-unix-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-unix-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-unix-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "7fdc9d04b7a3ced70bdef10e1bf92a09",
-        "size compressed (bytes)": 12857043,
-        "total_terms": 369576280,
-        "documents": 47382,
-        "unique_terms": 21712,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-webmasters-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-webmasters encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-webmasters-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-webmasters-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-webmasters-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "71a8d47e53a7befd43d4e29827699bfd",
-        "size compressed (bytes)": 5044024,
-        "total_terms": 127823828,
-        "documents": 17405,
-        "unique_terms": 20286,
-        "downloaded": False
-    },
-    "beir-v1.0.0-cqadupstack-wordpress-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): CQADupStack-wordpress encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-cqadupstack-wordpress-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-cqadupstack-wordpress-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-cqadupstack-wordpress-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "370d0a704300987447a884bce28b0057",
-        "size compressed (bytes)": 12737602,
-        "total_terms": 362488001,
-        "documents": 48605,
-        "unique_terms": 21867,
-        "downloaded": False
-    },
-    "beir-v1.0.0-quora-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): Quora encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-quora-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-quora-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-quora-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "0fc0e726e877bfcc65f00d11e62d014a",
-        "size compressed (bytes)": 52687112,
-        "total_terms": 1322737004,
-        "documents": 522931,
-        "unique_terms": 27042,
-        "downloaded": False
-    },
-    "beir-v1.0.0-dbpedia-entity-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): DBPedia encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-dbpedia-entity-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-dbpedia-entity-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-dbpedia-entity-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "3e0979e02c97ee76ae30b1bf135ac2c8",
-        "size compressed (bytes)": 1230929506,
-        "total_terms": 30490098411,
-        "documents": 4635922,
-        "unique_terms": 28709,
-        "downloaded": False
-    },
-    "beir-v1.0.0-scidocs-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): SCIDOCS encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-scidocs-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-scidocs-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-scidocs-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "ac689f1bcf15d858fdbec70e692f9642",
-        "size compressed (bytes)": 11401355,
-        "total_terms": 273175826,
-        "documents": 25657,
-        "unique_terms": 24241,
-        "downloaded": False
-    },
-    "beir-v1.0.0-fever-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): FEVER encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-fever-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-fever-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-fever-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "99ac85688f3bee09a14334a02e0bc06c",
-        "size compressed (bytes)": 1504352314,
-        "total_terms": 38844967407,
-        "documents": 5416568,
-        "unique_terms": 28670,
-        "downloaded": False
-    },
-    "beir-v1.0.0-climate-fever-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): Climate-FEVER encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-climate-fever-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-climate-fever-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-climate-fever-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "60956badd9028ad18adfaf0a87e2c2d7",
-        "size compressed (bytes)": 1504855696,
-        "total_terms": 38845226073,
-        "documents": 5416593,
-        "unique_terms": 28670,
-        "downloaded": False
-    },
-    "beir-v1.0.0-scifact-splade_distil_cocodenser_medium-lucene8": {
-        "description": "Lucene impact index of BEIR (v1.0.0): SciFact encoded by SPLADE-distill CoCodenser-medium. (Lucene 8; deprecated)",
-        "filename": "lucene-index.beir-v1.0.0-scifact-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz",
-        "readme": "lucene-index.beir-v1.0.0-scifact-splade_distil_cocodenser_medium.20220501.1842ee.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.beir-v1.0.0-scifact-splade_distil_cocodenser_medium.20220501.1842ee.tar.gz"
-        ],
-        "md5": "bb0f30dad94daa06766da55ae615091d",
-        "size compressed (bytes)": 2184301,
-        "total_terms": 65836037,
-        "documents": 5183,
-        "unique_terms": 17486,
-        "downloaded": False
     }
-
 }
 
-IMPACT_INDEX_INFO = {**IMPACT_INDEX_INFO_CURRENT, **IMPACT_INDEX_INFO_DEPRECATED}
+IMPACT_INDEX_INFO = {**IMPACT_INDEX_INFO_MSMARCO,
+                     **IMPACT_INDEX_INFO_BEIR}
 
 FAISS_INDEX_INFO = {
     # Aggretriever indexes

--- a/pyserini/search/lucene/irst/_searcher.py
+++ b/pyserini/search/lucene/irst/_searcher.py
@@ -33,7 +33,7 @@ from transformers import AutoTokenizer
 from pyserini.pyclass import autoclass
 from pyserini.search.lucene import LuceneSearcher
 from pyserini.util import download_prebuilt_index, get_cache_home, download_url, download_and_unpack_index
-from pyserini.prebuilt_index_info import TF_INDEX_INFO_CURRENT
+from pyserini.prebuilt_index_info import TF_INDEX_INFO
 
 # Wrappers around Anserini classes
 JQuery = autoclass('org.apache.lucene.search.Query')
@@ -59,16 +59,16 @@ class LuceneIrstSearcher(object):
         index_directory = os.path.join(get_cache_home(), 'indexes')
         if index == 'msmarco-v1-passage':
             index_path = os.path.join(index_directory,
-                                      TF_INDEX_INFO_CURRENT['msmarco-v1-passage']['filename'][:-6] +
-                                      TF_INDEX_INFO_CURRENT['msmarco-v1-passage']['md5'])
+                                      TF_INDEX_INFO['msmarco-v1-passage']['filename'][:-6] +
+                                      TF_INDEX_INFO['msmarco-v1-passage']['md5'])
         elif index == 'msmarco-v1-doc':
             index_path = os.path.join(index_directory,
-                                      TF_INDEX_INFO_CURRENT['msmarco-v1-doc']['filename'][:-6] +
-                                      TF_INDEX_INFO_CURRENT['msmarco-v1-doc']['md5'])
+                                      TF_INDEX_INFO['msmarco-v1-doc']['filename'][:-6] +
+                                      TF_INDEX_INFO['msmarco-v1-doc']['md5'])
         elif index == 'msmarco-v1-doc-segmented':
             index_path = os.path.join(index_directory,
-                                      TF_INDEX_INFO_CURRENT['msmarco-v1-doc-segmented']['filename'][:-6] +
-                                      TF_INDEX_INFO_CURRENT['msmarco-v1-doc-segmented']['md5'])
+                                      TF_INDEX_INFO['msmarco-v1-doc-segmented']['filename'][:-6] +
+                                      TF_INDEX_INFO['msmarco-v1-doc-segmented']['md5'])
         else:
             print("We currently only support three indexes: msmarco-passage, msmarco-v1-doc and msmarco-v1-doc-segmented but the index you inserted is not one of those")
         self.object = JLuceneSearcher(index_path)

--- a/tests/test_prebuilt_index.py
+++ b/tests/test_prebuilt_index.py
@@ -25,7 +25,7 @@ class TestPrebuiltIndexes(unittest.TestCase):
         urls = []
         cnt = 0
         for key in TF_INDEX_INFO:
-            if 'beir' in key and 'lucene8' not in key:
+            if 'beir' in key:
                 cnt += 1
                 for url in TF_INDEX_INFO[key]['urls']:
                     urls.append(url)
@@ -38,7 +38,7 @@ class TestPrebuiltIndexes(unittest.TestCase):
         urls = []
         cnt = 0
         for key in TF_INDEX_INFO:
-            if 'mrtydi' in key and 'lucene8' not in key:
+            if 'mrtydi' in key:
                 cnt += 1
                 for url in TF_INDEX_INFO[key]['urls']:
                     urls.append(url)
@@ -64,13 +64,14 @@ class TestPrebuiltIndexes(unittest.TestCase):
         urls = []
         cnt = 0
         for key in IMPACT_INDEX_INFO:
-            if 'miracl' in key:
+            if 'beir' in key:
                 cnt += 1
                 for url in IMPACT_INDEX_INFO[key]['urls']:
                     urls.append(url)
 
-        # currently, none
-        self.assertEqual(cnt, 0)
+        # 29 from SPLADE-distill CoCodenser-medium
+        self.assertEqual(cnt, 29)
+        self._test_urls(urls)
 
     def test_impact_mrtydi(self):
         urls = []


### PR DESCRIPTION
After discuss with @MXueguang , we agree that this is a better org than #1490

Lucene8 deprecated indexes have been removed.

The diff is really ugly, but the high-level organization is as follows -

<img width="471" alt="Screen Shot 2023-04-10 at 10 27 41 PM" src="https://user-images.githubusercontent.com/313837/231039926-2eb4d9be-e56f-476e-b269-a13fa0ff536a.png">
