### PR TITLE
Fix flaky mrtydi test on M1

### DIFF
--- a/scripts/repro_matrix/run_all_mrtydi.py
+++ b/scripts/repro_matrix/run_all_mrtydi.py
@@ -87,6 +87,10 @@ if __name__ == '__main__':
                             elif name == 'mdpr-tied-pft-msmarco-ft-all.ko' and split == 'train' \
                                     and math.isclose(score, float(expected[metric]), abs_tol=4e-4):
                                 result_str = okish_str
+                            # Flaky test: small difference on Mac Studio (M1)
+                            elif name == 'mdpr-tied-pft-msmarco.th' and split == 'train' \
+                                    and math.isclose(score, float(expected[metric]), abs_tol=3e-4):
+                                result_str = okish_str
                             else:
                                 result_str = fail_str + f' expected {expected[metric]:.4f}'
                             print(f'      {metric:7}: {score:.4f} {result_str}')


### PR DESCRIPTION
Minor errors with `mrtydi`:

```
condition mdpr-tied-pft-msmarco.th:
  - split: train
      MRR@100: 0.2334 [OK]
      R@100  : 0.5848 [FAIL] expected 0.5851
  - split: dev
      MRR@100: 0.2407 [OK]
      R@100  : 0.5795 [OK]
  - split: test
      MRR@100: 0.2693 [OK]
      R@100  : 0.5945 [OK]
```
