### PR TITLE
Reorganize FAISS pre-built index info

### DIFF
--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -2882,7 +2882,7 @@ IMPACT_INDEX_INFO_BEIR = {
 IMPACT_INDEX_INFO = {**IMPACT_INDEX_INFO_MSMARCO,
                      **IMPACT_INDEX_INFO_BEIR}
 
-FAISS_INDEX_INFO = {
+FAISS_INDEX_INFO_MSMARCO = {
     # Aggretriever indexes
     "msmarco-passage.aggretriever-cocondenser": {
         "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by aggretriever-cocondenser encoder.",
@@ -2909,6 +2909,154 @@ FAISS_INDEX_INFO = {
         "texts": "msmarco-v1-passage"
     },
 
+    "msmarco-v1-passage.ance": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the ANCE MS MARCO passage encoder",
+        "filename": "faiss.msmarco-v1-passage.ance.20210224.060cef.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.ance.20210224.060cef.tar.gz"
+        ],
+        "md5": "c4e485efd0802031783d6fe487125446",
+        "size compressed (bytes)": 25102344836,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.distilbert-dot-margin-mse-t2": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the distilbert-dot-margin_mse-T2-msmarco encoder",
+        "filename": "faiss.msmarco-v1-passage.distilbert-dot-margin_mse-t2.20210316.d44c3a.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.distilbert-dot-margin_mse-t2.20210316.d44c3a.tar.gz"
+        ],
+        "md5": "66dcbf3331f270673e3b9702a6ad3540",
+        "size compressed (bytes)": 25162771693,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.distilbert-dot-tas_b-b256": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by distilbert-dot-tas_b-b256-msmarco encoder",
+        "filename": "faiss.msmarco-v1-passage.distilbert-dot-tas_b-b256.20210527.63276f.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.distilbert-dot-tas_b-b256.20210527.63276f.tar.gz"
+        ],
+        "md5": "4e64a643fc051bc9506a3a554e9394e7",
+        "size compressed (bytes)": 25162329414,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.sbert": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the SBERT MS MARCO passage encoder",
+        "filename": "faiss.msmarco-v1-passage.sbert.20210313.a0fbb3.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.sbert.20210313.a0fbb3.tar.gz"
+        ],
+        "md5": "d5d9eb67fa9da8b77a219ac77a5a3d3e",
+        "size compressed (bytes)": 25214193092,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.tct_colbert": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by TCT-ColBERT",
+        "filename": "faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz"
+        ],
+        "md5": "2dea6e8697b220719139027c7ee2aff0",
+        "size compressed (bytes)": 25204501822,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.tct_colbert.hnsw": {
+        "description": "Faiss HNSW index of the MS MARCO passage corpus encoded by TCT-ColBERT",
+        "filename": "hnsw-faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/hnsw-faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz"
+        ],
+        "md5": "24acb6e6ba0ac1f5c6b73bd3e6d6477f",
+        "size compressed (bytes)": 33359120779,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.tct_colbert-v2": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2 passage encoder",
+        "filename": "faiss.msmarco-v1-passage.tct_colbert-v2.20210608.5f341b.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert-v2.20210608.5f341b.tar.gz"
+        ],
+        "md5": "805bb253828a59af1899a8cc42e0f766",
+        "size compressed (bytes)": 25211079468,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.tct_colbert-v2-hn": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2-hn passage encoder",
+        "filename": "faiss.msmarco-v1-passage.tct_colbert-v2-hn.20210608.5f341b.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert-v2-hn.20210608.5f341b.tar.gz"
+        ],
+        "md5": "569f0ee9d45586b547d84fcd240e5cee",
+        "size compressed (bytes)": 25205730053,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+    "msmarco-v1-passage.tct_colbert-v2-hnp": {
+        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2-hnp passage encoder",
+        "filename": "faiss.msmarco-v1-passage.tct_colbert-v2-hnp.20210608.5f341b.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert-v2-hnp.20210608.5f341b.tar.gz"
+        ],
+        "md5": "53bcaa78ab0ca629f3379b8aa00eb3ae",
+        "size compressed (bytes)": 25225526436,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
+
+    "msmarco-v1-doc.ance-maxp": {
+        "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by the ANCE MaxP encoder",
+        "filename": "faiss.msmarco-v1-doc.ance_maxp.20210304.b2a1b0.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-doc.ance_maxp.20210304.b2a1b0.tar.gz"
+        ],
+        "md5": "6b484b0c04872f22ae903ed7d7ba1327",
+        "size compressed (bytes)": 58312805253,
+        "documents": 20544550,
+        "downloaded": False,
+        "texts": "msmarco-v1-doc"
+    },
+    "msmarco-v1-doc.tct_colbert": {
+        "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT",
+        "filename": "faiss.msmarco-v1-doc.tct_colbert.20210112.be7119.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-doc.tct_colbert.20210112.be7119.tar.gz"
+        ],
+        "md5": "4e97e1d6990ba5d4b93b7798c3036edc",
+        "size compressed (bytes)": 58514325945,
+        "documents": 20544550,
+        "downloaded": False,
+        "texts": "smarco-v1-doc"
+    },
+    "msmarco-v1-doc-segmented.tct_colbert-v2-hnp": {
+        "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT-V2-HNP",
+        "filename": "faiss.msmarco-v1-doc-segmented.tct_colbert-v2-hnp.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-doc-segmented.tct_colbert-v2-hnp.tar.gz"
+        ],
+        "md5": "1dab64255822d2fd4dff8c0807319d0a",
+        "size compressed (bytes)": 58586765413,
+        "documents": 20544550,
+        "downloaded": False,
+        "texts": "msmarco-v1-doc-segmented"
+    }
+}
+
+FAISS_INDEX_INFO_BEIR = {
     # BEIR (v1.0.0) contriever indexes
     "beir-v1.0.0-trec-covid.contriever": {
         "description": "Faiss index for BEIR v1.0.0 (TREC-COVID) corpus encoded by Contriever encoder.",
@@ -3665,213 +3813,10 @@ FAISS_INDEX_INFO = {
         "documents": 5183,
         "downloaded": False,
         "texts": "beir-v1.0.0-scifact.flat",
-    },
+    }
+}
 
-    "msmarco-v1-passage.tct_colbert.hnsw": {
-        "description": "Faiss HNSW index of the MS MARCO passage corpus encoded by TCT-ColBERT",
-        "filename": "hnsw-faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/hnsw-faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz"
-        ],
-        "md5": "24acb6e6ba0ac1f5c6b73bd3e6d6477f",
-        "size compressed (bytes)": 33359120779,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-passage.tct_colbert": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by TCT-ColBERT",
-        "filename": "faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert.20210112.be7119.tar.gz"
-        ],
-        "md5": "2dea6e8697b220719139027c7ee2aff0",
-        "size compressed (bytes)": 25204501822,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-doc.tct_colbert": {
-        "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT",
-        "filename": "faiss.msmarco-v1-doc.tct_colbert.20210112.be7119.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-doc.tct_colbert.20210112.be7119.tar.gz"
-        ],
-        "md5": "4e97e1d6990ba5d4b93b7798c3036edc",
-        "size compressed (bytes)": 58514325945,
-        "documents": 20544550,
-        "downloaded": False,
-        "texts": "smarco-v1-doc"
-    },
-    "msmarco-v1-doc-segmented.tct_colbert-v2-hnp": {
-        "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT-V2-HNP",
-        "filename": "faiss.msmarco-v1-doc-segmented.tct_colbert-v2-hnp.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-doc-segmented.tct_colbert-v2-hnp.tar.gz"
-        ],
-        "md5": "1dab64255822d2fd4dff8c0807319d0a",
-        "size compressed (bytes)": 58586765413,
-        "documents": 20544550,
-        "downloaded": False,
-        "texts": "msmarco-v1-doc-segmented"
-    },
-    "wikipedia-dpr-100w.dpr-multi": {
-        "description": "Faiss FlatIP index of Wikipedia encoded by the DPR doc encoder trained on multiple QA datasets",
-        "filename": "faiss.wikipedia-dpr-100w.dpr_multi.20200127.f403c3.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dpr_multi.20200127.f403c3.tar.gz"
-        ],
-        "md5": "fe307ef2e60ab6e6f3ad66e24a4144ae",
-        "size compressed (bytes)": 59836766732,
-        "documents": 21015320,
-        "downloaded": False,
-        "texts": "wikipedia-dpr-100w"
-    },
-    "wikipedia-dpr-100w.dpr-single-nq": {
-        "description": "Faiss FlatIP index of Wikipedia encoded by the DPR doc encoder trained on NQ",
-        "filename": "faiss.wikipedia-dpr-100w.dpr_single-nq.20200115.cd5034.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dpr_single-nq.20200115.cd5034.tar.gz"
-        ],
-        "md5": "01fb6bcaa047df254663d0a3d854b7cc",
-        "size compressed (bytes)": 59836863979,
-        "documents": 21015320,
-        "downloaded": False,
-        "texts": "wikipedia-dpr-100w"
-    },
-    "wikipedia-dpr-100w.bpr-single-nq": {
-        "description": "Faiss binary index of Wikipedia encoded by the BPR doc encoder trained on NQ",
-        "filename": "faiss.wikipedia-dpr-100w.bpr_single-nq.20210827.8a8f75.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.bpr_single-nq.20210827.8a8f75.tar.gz"
-        ],
-        "md5": "b022580ab2fc66f6eaa54af241dba690",
-        "size compressed (bytes)": 1886380629,
-        "documents": 21015320,
-        "downloaded": False,
-        "texts": "wikipedia-dpr-100w"
-    },
-    "msmarco-v1-passage.ance": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the ANCE MS MARCO passage encoder",
-        "filename": "faiss.msmarco-v1-passage.ance.20210224.060cef.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.ance.20210224.060cef.tar.gz"
-        ],
-        "md5": "c4e485efd0802031783d6fe487125446",
-        "size compressed (bytes)": 25102344836,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-doc.ance-maxp": {
-        "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by the ANCE MaxP encoder",
-        "filename": "faiss.msmarco-v1-doc.ance_maxp.20210304.b2a1b0.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-doc.ance_maxp.20210304.b2a1b0.tar.gz"
-        ],
-        "md5": "6b484b0c04872f22ae903ed7d7ba1327",
-        "size compressed (bytes)": 58312805253,
-        "documents": 20544550,
-        "downloaded": False,
-        "texts": "msmarco-v1-doc"
-    },
-    "wikipedia-dpr-100w.ance-multi": {
-        "description": "Faiss FlatIP index of Wikipedia encoded by the ANCE-multi encoder",
-        "filename": "faiss.wikipedia-dpr-100w.ance_multi.20210224.060cef.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.ance_multi.20210224.060cef.tar.gz"
-        ],
-        "md5": "eb00e096460c8e6296a39732f1676dd7",
-        "size compressed (bytes)": 59890491335,
-        "documents": 21015320,
-        "downloaded": False,
-        "texts": "wikipedia-dpr-100w"
-    },
-    "msmarco-v1-passage.sbert": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the SBERT MS MARCO passage encoder",
-        "filename": "faiss.msmarco-v1-passage.sbert.20210313.a0fbb3.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.sbert.20210313.a0fbb3.tar.gz"
-        ],
-        "md5": "d5d9eb67fa9da8b77a219ac77a5a3d3e",
-        "size compressed (bytes)": 25214193092,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-passage.distilbert-dot-margin-mse-t2": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the distilbert-dot-margin_mse-T2-msmarco encoder",
-        "filename": "faiss.msmarco-v1-passage.distilbert-dot-margin_mse-t2.20210316.d44c3a.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.distilbert-dot-margin_mse-t2.20210316.d44c3a.tar.gz"
-        ],
-        "md5": "66dcbf3331f270673e3b9702a6ad3540",
-        "size compressed (bytes)": 25162771693,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-passage.distilbert-dot-tas_b-b256": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by distilbert-dot-tas_b-b256-msmarco encoder",
-        "filename": "faiss.msmarco-v1-passage.distilbert-dot-tas_b-b256.20210527.63276f.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.distilbert-dot-tas_b-b256.20210527.63276f.tar.gz"
-        ],
-        "md5": "4e64a643fc051bc9506a3a554e9394e7",
-        "size compressed (bytes)": 25162329414,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-passage.tct_colbert-v2": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2 passage encoder",
-        "filename": "faiss.msmarco-v1-passage.tct_colbert-v2.20210608.5f341b.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert-v2.20210608.5f341b.tar.gz"
-        ],
-        "md5": "805bb253828a59af1899a8cc42e0f766",
-        "size compressed (bytes)": 25211079468,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-passage.tct_colbert-v2-hn": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2-hn passage encoder",
-        "filename": "faiss.msmarco-v1-passage.tct_colbert-v2-hn.20210608.5f341b.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert-v2-hn.20210608.5f341b.tar.gz"
-        ],
-        "md5": "569f0ee9d45586b547d84fcd240e5cee",
-        "size compressed (bytes)": 25205730053,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "msmarco-v1-passage.tct_colbert-v2-hnp": {
-        "description": "Faiss FlatIP index of the MS MARCO passage corpus encoded by the tct_colbert-v2-hnp passage encoder",
-        "filename": "faiss.msmarco-v1-passage.tct_colbert-v2-hnp.20210608.5f341b.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.tct_colbert-v2-hnp.20210608.5f341b.tar.gz"
-        ],
-        "md5": "53bcaa78ab0ca629f3379b8aa00eb3ae",
-        "size compressed (bytes)": 25225526436,
-        "documents": 8841823,
-        "downloaded": False,
-        "texts": "msmarco-v1-passage"
-    },
-    "cast2019-tct_colbert-v2.hnsw": {
-        "description": "Faiss HNSW index of the CAsT2019 passage corpus encoded by the tct_colbert-v2 passage encoder",
-        "filename": "faiss-hnsw.cast2019.tct_colbert-v2.tar.gz",
-        "readme": "faiss-hnsw.cast2019.tct_colbert-v2-readme.txt",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/hnsw-faiss.cast2019.tct_colbert-v2.tar.gz"
-        ],
-        "md5": "2ce7ce8064ed235a9b6aad08571340d4",
-        "size compressed (bytes)": 112121368296,
-        "documents": 38429835,
-        "downloaded": False,
-        "texts": "cast2019"
-    },
+FAISS_INDEX_INFO_MRTYDI = {
     "mrtydi-v1.1-arabic-mdpr-nq": {
         "description": "Faiss index for Mr.TyDi v1.1 (Arabic) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
         "filename": "faiss.mrtydi-v1.1-arabic.20220207.5df364.tar.gz",
@@ -4026,30 +3971,7 @@ FAISS_INDEX_INFO = {
         "downloaded": False,
         "texts": "mrtydi-v1.1-thai"
     },
-    "wikipedia-dpr-100w.dkrr-nq": {
-        "description": "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on NQ",
-        "filename": "faiss.wikipedia-dpr-100w.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz",
-        ],
-        "md5": "36a658e08dafb3e3313b05f88e001557",
-        "size compressed (bytes)": 37812137732,
-        "documents": 21015324,
-        "downloaded": False,
-        "texts": "wwikipedia-dpr-100w"
-    },
-    "wikipedia-dpr-100w.dkrr-tqa": {
-        "description": "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on TriviaQA",
-        "filename": "faiss.wikipedia-dpr-100w.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz",
-        ],
-        "md5": "072a514ca3ff7717339038d024019e3d",
-        "size compressed (bytes)": 37802648577,
-        "documents": 21015324,
-        "downloaded": False,
-        "texts": "wikipedia-dpr-100w"
-    },
+
     "mrtydi-v1.1-arabic-mdpr-tied-pft-msmarco": {
         "description": "Faiss index for Mr.TyDi v1.1 (Arabic) corpus encoded by mDPR passage encoder pre-fine-tuned on MS MARCO.",
         "filename": "faiss.mrtydi-v1.1-arabic.20220413.aa1c0e9.tar.gz",
@@ -4336,6 +4258,7 @@ FAISS_INDEX_INFO = {
         "downloaded": False,
         "texts": "mrtydi-v1.1-thai"
     },
+
     "mrtydi-v1.1-arabic-mdpr-tied-pft-msmarco-ft-all": {
         "description": "Faiss index for Mr.TyDi v1.1 (Arabic) corpus encoded by mDPR passage encoder pre-fine-tuned on NQ.",
         "filename": "faiss.mrtydi-v1.1-arabic.20220524.7b099d5.tar.gz",
@@ -4478,8 +4401,10 @@ FAISS_INDEX_INFO = {
         "documents": 568855,
         "downloaded": False,
         "texts": "mrtydi-v1.1-thai"
-    },
+    }
+}
 
+FAISS_INDEX_INFO_MIRACL = {
     "miracl-v1.0-ar-mdpr-tied-pft-msmarco": {
         "description": "Faiss index for MIRACL v1.0 (Arabic) corpus encoded by mDPR passage encoder pre-fine-tuned on MS MARCO.",
         "filename": "faiss.miracl-v1.0-ar.mdpr-tied-pft-msmarco.20221004.2b2856.tar.gz",
@@ -4950,19 +4875,6 @@ FAISS_INDEX_INFO = {
         "texts": "miracl-v1.0-yo",
     },
 
-    "wiki-all-6-3.dpr2-multi-retriever": {
-        "description": "Faiss FlatIP index of wiki-all-6-3-tamber encoded by a 2nd iteration DPR model trained on multiple QA datasets",
-        "filename": "faiss.wiki-all-6-3.dpr2-multi-retriever.20230103.186fa7.tar.gz",
-        "readme": "faiss-flat.wiki-all-6-3.dpr2-multi-retriever.20230103.186fa7.README.md",
-        "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wiki-all-6-3.dpr2-multi-retriever.20230103.186fa7.tar.gz",
-        ],
-        "md5": "823b6297d6fd8011598e7618742ac7f8",
-        "size compressed (bytes)": 218257913366,
-        "documents": 76680040,
-        "downloaded": False,
-        "texts": "wiki-all-6-3-tamber"
-    },
     "miracl-v1.0-ar-mdpr-tied-pft-msmarco-ft-miracl-ar": {
         "description": "Faiss index for MIRACL v1.0 (Arabic) corpus encoded by mDPR passage encoder pre-fine-tuned on MS MARCO, then fine-tuned in-language with MIRACL.",
         "filename": "faiss.miracl-v1.0-ar.mdpr-tied-pft-msmarco-ft-miracl-ar.20230329.e40d4a.tar.gz",
@@ -5170,5 +5082,116 @@ FAISS_INDEX_INFO = {
         "documents": 4934368,
         "downloaded": False,
         "texts": "miracl-v1.0-zh"
-    },
+    }
 }
+
+FAISS_INDEX_INFO_WIKIPEDIA = {
+    "wikipedia-dpr-100w.dpr-multi": {
+        "description": "Faiss FlatIP index of Wikipedia encoded by the DPR doc encoder trained on multiple QA datasets",
+        "filename": "faiss.wikipedia-dpr-100w.dpr_multi.20200127.f403c3.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dpr_multi.20200127.f403c3.tar.gz"
+        ],
+        "md5": "fe307ef2e60ab6e6f3ad66e24a4144ae",
+        "size compressed (bytes)": 59836766732,
+        "documents": 21015320,
+        "downloaded": False,
+        "texts": "wikipedia-dpr-100w"
+    },
+    "wikipedia-dpr-100w.dpr-single-nq": {
+        "description": "Faiss FlatIP index of Wikipedia encoded by the DPR doc encoder trained on NQ",
+        "filename": "faiss.wikipedia-dpr-100w.dpr_single-nq.20200115.cd5034.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dpr_single-nq.20200115.cd5034.tar.gz"
+        ],
+        "md5": "01fb6bcaa047df254663d0a3d854b7cc",
+        "size compressed (bytes)": 59836863979,
+        "documents": 21015320,
+        "downloaded": False,
+        "texts": "wikipedia-dpr-100w"
+    },
+    "wikipedia-dpr-100w.bpr-single-nq": {
+        "description": "Faiss binary index of Wikipedia encoded by the BPR doc encoder trained on NQ",
+        "filename": "faiss.wikipedia-dpr-100w.bpr_single-nq.20210827.8a8f75.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.bpr_single-nq.20210827.8a8f75.tar.gz"
+        ],
+        "md5": "b022580ab2fc66f6eaa54af241dba690",
+        "size compressed (bytes)": 1886380629,
+        "documents": 21015320,
+        "downloaded": False,
+        "texts": "wikipedia-dpr-100w"
+    },
+    "wikipedia-dpr-100w.ance-multi": {
+        "description": "Faiss FlatIP index of Wikipedia encoded by the ANCE-multi encoder",
+        "filename": "faiss.wikipedia-dpr-100w.ance_multi.20210224.060cef.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.ance_multi.20210224.060cef.tar.gz"
+        ],
+        "md5": "eb00e096460c8e6296a39732f1676dd7",
+        "size compressed (bytes)": 59890491335,
+        "documents": 21015320,
+        "downloaded": False,
+        "texts": "wikipedia-dpr-100w"
+    },
+    "wikipedia-dpr-100w.dkrr-nq": {
+        "description": "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on NQ",
+        "filename": "faiss.wikipedia-dpr-100w.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dkrr-dpr-nq-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        ],
+        "md5": "36a658e08dafb3e3313b05f88e001557",
+        "size compressed (bytes)": 37812137732,
+        "documents": 21015324,
+        "downloaded": False,
+        "texts": "wwikipedia-dpr-100w"
+    },
+    "wikipedia-dpr-100w.dkrr-tqa": {
+        "description": "Faiss FlatIP index of Wikipedia DPR encoded by the retriever model from 'Distilling Knowledge from Reader to Retriever for Question Answering' trained on TriviaQA",
+        "filename": "faiss.wikipedia-dpr-100w.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wikipedia-dpr-100w.dkrr-dpr-tqa-retriever.20220217.25ed1f.cc91b2.tar.gz",
+        ],
+        "md5": "072a514ca3ff7717339038d024019e3d",
+        "size compressed (bytes)": 37802648577,
+        "documents": 21015324,
+        "downloaded": False,
+        "texts": "wikipedia-dpr-100w"
+    },
+    "wiki-all-6-3.dpr2-multi-retriever": {
+        "description": "Faiss FlatIP index of wiki-all-6-3-tamber encoded by a 2nd iteration DPR model trained on multiple QA datasets",
+        "filename": "faiss.wiki-all-6-3.dpr2-multi-retriever.20230103.186fa7.tar.gz",
+        "readme": "faiss-flat.wiki-all-6-3.dpr2-multi-retriever.20230103.186fa7.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.wiki-all-6-3.dpr2-multi-retriever.20230103.186fa7.tar.gz",
+        ],
+        "md5": "823b6297d6fd8011598e7618742ac7f8",
+        "size compressed (bytes)": 218257913366,
+        "documents": 76680040,
+        "downloaded": False,
+        "texts": "wiki-all-6-3-tamber"
+    }
+}
+
+FAISS_INDEX_INFO_OTHER = {
+    "cast2019-tct_colbert-v2.hnsw": {
+        "description": "Faiss HNSW index of the CAsT2019 passage corpus encoded by the tct_colbert-v2 passage encoder",
+        "filename": "faiss-hnsw.cast2019.tct_colbert-v2.tar.gz",
+        "readme": "faiss-hnsw.cast2019.tct_colbert-v2-readme.txt",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/hnsw-faiss.cast2019.tct_colbert-v2.tar.gz"
+        ],
+        "md5": "2ce7ce8064ed235a9b6aad08571340d4",
+        "size compressed (bytes)": 112121368296,
+        "documents": 38429835,
+        "downloaded": False,
+        "texts": "cast2019"
+    }
+}
+
+FAISS_INDEX_INFO = {**FAISS_INDEX_INFO_MSMARCO,
+                    **FAISS_INDEX_INFO_BEIR,
+                    **FAISS_INDEX_INFO_MRTYDI,
+                    **FAISS_INDEX_INFO_MIRACL,
+                    **FAISS_INDEX_INFO_WIKIPEDIA,
+                    **FAISS_INDEX_INFO_OTHER}

--- a/tests/test_prebuilt_index.py
+++ b/tests/test_prebuilt_index.py
@@ -136,6 +136,30 @@ class TestPrebuiltIndexes(unittest.TestCase):
         self.assertEqual(cnt, 52)
         self._test_urls(urls)
 
+    def test_faiss_msmarco(self):
+        urls = []
+        cnt = 0
+        for key in FAISS_INDEX_INFO:
+            if 'msmarco-v' in key:
+                cnt += 1
+                for url in FAISS_INDEX_INFO[key]['urls']:
+                    urls.append(url)
+
+        self.assertEqual(cnt, 12)
+        self._test_urls(urls)
+
+    def test_faiss_wikipedia(self):
+        urls = []
+        cnt = 0
+        for key in FAISS_INDEX_INFO:
+            if 'wiki' in key:
+                cnt += 1
+                for url in FAISS_INDEX_INFO[key]['urls']:
+                    urls.append(url)
+
+        self.assertEqual(cnt, 7)
+        self._test_urls(urls)
+
     def _test_urls(self, urls):
         cnt = 0
         for url in urls:


### PR DESCRIPTION
Top-level organization looks like this:

<img width="445" alt="Screen Shot 2023-04-18 at 7 09 17 AM" src="https://user-images.githubusercontent.com/313837/232760767-06e15985-4bb6-4d16-b463-999762e00720.png">
