### PR TITLE
Reproduce TCT-ColBERTv1/v2 runs

### DIFF
--- a/docs/experiments-tct_colbert-v2.md
+++ b/docs/experiments-tct_colbert-v2.md
@@ -322,3 +322,4 @@ ndcg_cut_10             all     0.6094
 + Results reproduced by [@yuki617](https://github.com/yuki617) on 2021-06-30 (commit [`b3f3d9`](https://github.com/castorini/pyserini/commit/b3f3d94f2d2397e684094be7e997c9fe45c6fa76))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-25 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-05-06 (commit [`dcc0ba`](https://github.com/castorini/pyserini/commit/dcc0ba06585a08d7c78cbffac4217b57e170fc3a))

--- a/docs/experiments-tct_colbert.md
+++ b/docs/experiments-tct_colbert.md
@@ -73,6 +73,7 @@ Dense retrieval with TCT-ColBERT, HNSW index:
 python -m pyserini.search.faiss \
   --index msmarco-v1-passage.tct_colbert.hnsw \
   --topics msmarco-passage-dev-subset \
+  --encoded-queries tct_colbert-msmarco-passage-dev-subset \
   --output runs/run.msmarco-passage.tct_colbert.hnsw.tsv \
   --output-format msmarco
 ```
@@ -336,3 +337,4 @@ recall_100            	all	0.9083
 + Results reproduced by [@ArthurChen189](https://github.com/ArthurChen189) on 2021-06-12 (commit [`f61411`](https://github.com/castorini/pyserini/commit/f614111f014b7490f75e585e610f64f769164dd2))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2022-12-24 (commit [`0c495c`](https://github.com/castorini/pyserini/commit/0c495cf2999dda980eb1f85efa30a4323cef5855))
 + Results reproduced by [@lintool](https://github.com/lintool) on 2023-01-10 (commit [`7dafc4`](https://github.com/castorini/pyserini/commit/7dafc4f918bd44ada3771a5c81692ab19cc2cae9))
++ Results reproduced by [@lintool](https://github.com/lintool) on 2023-05-06 (commit [`dcc0ba`](https://github.com/castorini/pyserini/commit/dcc0ba06585a08d7c78cbffac4217b57e170fc3a))


### PR DESCRIPTION
hey @jacklin64 @justram I reproduced the TCT-ColBERTv1/v2 runs with the new renamed indexes. Everything looks good.