### PR TITLE
Fix bug with ImpactSearcher initialization

### DIFF
--- a/pyserini/search/lucene/__main__.py
+++ b/pyserini/search/lucene/__main__.py
@@ -184,6 +184,11 @@ if __name__ == "__main__":
                     searcher = SlimSearcher.from_prebuilt_index(args.encoded_corpus, args.index, args.onnx_encoder, args.min_idf)
                 else:
                     searcher = LuceneImpactSearcher.from_prebuilt_index(args.index, args.onnx_encoder, args.min_idf, 'onnx')
+        # These are the cases where we're specifying pre-encoded queries
+        elif os.path.exists(args.index):
+            searcher = LuceneImpactSearcher(args.index, args.encoder, args.min_idf)
+        else:
+            searcher = LuceneImpactSearcher.from_prebuilt_index(args.index, args.encoder, args.min_idf)
 
     if args.language != 'en':
         searcher.set_language(args.language)


### PR DESCRIPTION
hey @alexlimh as part of #1445 - you accidentally removed the branch when we specify pre-encoded queries, i.e., `args.encoder` isn't set. Adding back in.