### PR TITLE
Add AToMiC bm25 reproduction baselines

### DIFF
--- a/docs/experiments-atomic-bm25.md
+++ b/docs/experiments-atomic-bm25.md
@@ -2,45 +2,57 @@
 # Pyserini: Reproducing AToMiC BM 25 Baselines
 
 Pyserini provides the following pre-built indexes for the AToMiC dataset to reproduce the baselines in the [AToMiC paper](https://arxiv.org/pdf/2304.01961.pdf):
-- `lucene-index.atomic.text.flat.small.validation`
-- `lucene-index.atomic.text.flat.base`
-- `lucene-index.atomic.text.flat.large`
-- `lucene-index.atomic.image.flat.small.validation`
-- `lucene-index.atomic.image.flat.base`
-- `lucene-index.atomic.image.flat.large`
+- `atomic_text_v0.2.1_small_validation`
+- `atomic_text_v0.2.1_base`
+- `atomic_text_v0.2.1_large`
+- `atomic_image_v0.2_small_validation`
+- `atomic_image_v0.2_base`
+- `atomic_image_v0.2_large`
 
 ## Data Prep
-We need the topic files (`validation.text.search.jsonl` and `validation.image-caption.search.jsonl`) and the qrels files (`validation.qrels.t2i.projected.trec` and `validation.qrels.i2t.projected.trec`) to reproduce the baselines given in the paper.
+We need the topic files (`topics.atomic.validation.text.jsonl` and `topics.atomic.validation.image-caption.jsonl`) and the qrels files (`qrels.atomic.validation.t2i.trec` and `qrels.atomic.validation.i2t.trec`) to reproduce the baselines given in the paper.
 
-If you have a dev installation of `pyserini`, the required files are located under `pyserini/tools/topics-and-qrels/`. Otherwise, you can download them at [this repository](https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/tree/main/). 
+The required files are located under [`pyserini/tools/topics-and-qrels/`](https://github.com/castorini/anserini-tools/tree/7b84f773225b5973b4533dfa0aa18653409a6146/topics-and-qrels). If you have a dev installation of pyserini, you can simply access the files there.
+Otherwise,
+```bash
+export DATA_DIR="https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main" # TODO: replace with link from anserini-tools repo once merged
+
+mkdir topics
+wget ${DATA_DIR}/topics/topics.atomic.validation.text.jsonl -P topics
+wget ${DATA_DIR}/topics/topics.atomic.validation.image-caption.jsonl -P topics
+
+mkdir qrels
+wget ${DATA_DIR}/qrels/qrels.atomic.validation.i2t.trec -P qrels
+wget ${DATA_DIR}/qrels/qrels.atomic.validation.t2i.trec -P qrels
+```
 
 ## Batch Retrieval Run
 We can perform a batch retrieval run as follows, replacing `{setting}` with the desired setting (`small.validation`, `base`, `large`):
 ```bash
 # Text to Image
 python -m pyserini.search.lucene \
-  --index lucene-index.atomic.image.{setting} \
-  --topics validation.text.search.jsonl \
-  --output runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
+  --index atomic_text_v0.2.1_{setting} \
+  --topics topics.atomic.validation.text.jsonl \
+  --output runs/run.validation.bm25-anserini-default.t2i.{setting}.trec \
   --bm25 --hits 1000 --threads 16 --batch-size 64
   
 # Image to Text
 python -m pyserini.search.lucene \
-  --index lucene-index.atomic.text.{setting} \
-  --topics validation.image-caption.search.jsonl \
-  --output runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
+  --index atomic_image_v0.2_{setting} \
+  --topics topics.atomic.validation.image-caption.jsonl\
+  --output runs/run.validation.bm25-anserini-default.i2t.{setting}.trec \
   --bm25 --hits 1000 --threads 16 --batch-size 64
 ```
 
 We can evaluate using `trec_eval`:
 ```bash
 # Text to Image
-python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 validation.qrels.t2i.projected.trec runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
-python -m pyserini.eval.trec_eval -c -m recall.10,1000 validation.qrels.t2i.projected.trec runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 qrels.atomic.validation.t2i.trec runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recall.10,1000 qrels.atomic.validation.t2i.trec runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
 
 # Image to Text
-python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 validation.qrels.i2t.projected.trec runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
-python -m pyserini.eval.trec_eval -c -m recall.10,1000 validation.qrels.i2t.projected.trec runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 qrels.atomic.validation.i2t.trec runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recall.10,1000 qrels.atomic.validation.i2t.trec runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
 ```
 
 ## Known Issues

--- a/docs/experiments-atomic-bm25.md
+++ b/docs/experiments-atomic-bm25.md
@@ -1,0 +1,71 @@
+
+# Pyserini: Reproducing AToMiC BM 25 Baselines
+
+Pyserini provides the following pre-built indexes for the AToMiC dataset to reproduce the baselines in the [AToMiC paper](https://arxiv.org/pdf/2304.01961.pdf):
+- `lucene-index.atomic.text.flat.small.validation`
+- `lucene-index.atomic.text.flat.base`
+- `lucene-index.atomic.text.flat.large`
+- `lucene-index.atomic.image.flat.small.validation`
+- `lucene-index.atomic.image.flat.base`
+- `lucene-index.atomic.image.flat.large`
+
+## Data Prep
+We need the topic files (`validation.text.search.jsonl` and `validation.image-caption.search.jsonl`) and the qrels files (`validation.qrels.t2i.projected.trec` and `validation.qrels.i2t.projected.trec`) to reproduce the baselines given in the paper.
+
+If you have a dev installation of `pyserini`, the required files are located under `pyserini/tools/topics-and-qrels/`. Otherwise, you can download them at [this repository](https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/tree/main/). 
+
+## Batch Retrieval Run
+We can perform a batch retrieval run as follows, replacing `{setting}` with the desired setting (`small.validation`, `base`, `large`):
+```bash
+# Text to Image
+python -m pyserini.search.lucene \
+  --index lucene-index.atomic.image.{setting} \
+  --topics validation.text.search.jsonl \
+  --output runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
+  --bm25 --hits 1000 --threads 16 --batch-size 64
+  
+# Image to Text
+python -m pyserini.search.lucene \
+  --index lucene-index.atomic.text.{setting} \
+  --topics validation.image-caption.search.jsonl \
+  --output runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
+  --bm25 --hits 1000 --threads 16 --batch-size 64
+```
+
+We can evaluate using `trec_eval`:
+```bash
+# Text to Image
+python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 validation.qrels.t2i.projected.trec runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recall.10,1000 validation.qrels.t2i.projected.trec runs/run.validation.bm25-anserini-default.t2i.{setting}.trec
+
+# Image to Text
+python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 validation.qrels.i2t.projected.trec runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recall.10,1000 validation.qrels.i2t.projected.trec runs/run.validation.bm25-anserini-default.i2t.{setting}.trec
+```
+
+## Known Issues
+We have noticed that using `python -m pyserini.search.lucene` can be slow for certain queries (especially when searching using the `large` indexes). Using Anserini's `SearchCollection` can significantly speed up the search time. This can be done in a Python shell as follows:
+```python
+from pyserini.pyclass import autoclass
+SearchCollection = autoclass("io.anserini.search.SearchCollection")
+# Text to Image
+t2i_search_args = [
+    "-index", "lucene-index.atomic.image.{setting}",
+    "-topics", "validation.text.search.jsonl",
+    "-topicreader", "JsonString",
+    "-topicfield", "title",
+    "-output", "runs/run.validation.bm25-anserini-default.t2i.{setting}.trec",
+    "-bm25", "-hits", "1000", "-parallelism", "64", "-threads", "64"
+
+]
+# Image to Text
+i2t_search_args = [
+    "-index", "lucene-index.atomic.text.{setting}",
+    "-topics", "validation.image-caption.search.jsonl",
+    "-topicreader", "JsonString",
+    "-topicfield", "title",
+    "-output", "runs/run.validation.bm25-anserini-default.i2t.{setting}.trec",
+    "-bm25", "-hits", "1000", "-parallelism", "64", "-threads", "64"
+]
+SearchCollection.main(search_args)
+```

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -2272,7 +2272,91 @@ TF_INDEX_INFO_OTHER = {
         "documents": 3179206,
         "unique_terms": 1616532,
         "downloaded": False
-    }
+    },  # TODO: need to update links to these files to rgw.cs.uwaterloo.ca/...
+    "atomic_text_v0.2.1_small_validation": {
+        "description": "Lucene index for AToMiC Text v0.2.1 small setting on validation set (Lucene 9)",
+        "filename": "lucene-index.atomic.image.flat.small.validation.tar.gz",
+        "readme": "lucene-index.atomic.20230525.a7df7f.README.md",
+        "urls": [
+            "https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/prebuilt_indexes/lucene-index.atomic.text.flat.small.validation.tar.gz"
+        ],
+        "md5": "377f3e4ae48e1afbe05650e339322050",
+        "size compressed (bytes)": 32900945,
+        "total_terms": 2999824,
+        "documents": 17173,
+        "unique_terms": 118071,
+        "downloaded": False
+    },
+    "atomic_text_v0.2.1_base": {
+        "description": "Lucene index for AToMiC Text v0.2.1 base setting on validation set (Lucene 9)",
+        "filename": "lucene-index.atomic.image.flat.base.tar.gz",
+        "readme": "lucene-index.atomic.20230525.a7df7f.README.md",
+        "urls": [
+            "https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/prebuilt_indexes/lucene-index.atomic.text.flat.base.tar.gz"
+        ],
+        "md5": "41ca80241e77ed3515dd48bfc047a923",
+        "size compressed (bytes)": 5532178004,
+        "total_terms": 520954965,
+        "documents": 3029504,
+        "unique_terms": -1,
+        "downloaded": False
+    },
+    "atomic_text_v0.2.1_large": {
+        "description": "Lucene index for AToMiC Text v0.2.1 large setting on validation set (Lucene 9)",
+        "filename": "lucene-index.atomic.image.flat.large.tar.gz",
+        "readme": "lucene-index.atomic.20230525.a7df7f.README.md",
+        "urls": [
+            "https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/prebuilt_indexes/lucene-index.atomic.text.flat.large.tar.gz"
+        ],
+        "md5": "0dd1975d82fa7c57a471e4e6b1882177",
+        "size compressed (bytes)": 18224101285,
+        "total_terms": 1727597393,
+        "documents": 10134744,
+        "unique_terms": -1,
+        "downloaded": False
+    },
+    "atomic_image_v0.2_small_validation": {
+        "description": "Lucene index for AToMiC Images v0.2 small setting on validation set (Lucene 9)",
+        "filename": "lucene-index.atomic.image.flat.small.validation.tar.gz",
+        "readme": "lucene-index.atomic.20230525.a7df7f.README.md",
+        "urls": [
+            "https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/prebuilt_indexes/lucene-index.atomic.image.flat.small.validation.tar.gz"
+        ],
+        "md5": "b5363a9a7ecd0f071fb8e0319168ccf8",
+        "size compressed (bytes)": 4902534,
+        "total_terms": 308646,
+        "documents": 16126,
+        "unique_terms": 48666,
+        "downloaded": False
+    },
+    "atomic_image_v0.2_base": {
+        "description": "Lucene index for AToMiC Images v0.2 base setting on validation set (Lucene 9)",
+        "filename": "lucene-index.atomic.image.flat.base.tar.gz",
+        "readme": "lucene-index.atomic.20230525.a7df7f.README.md",
+        "urls": [
+            "https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/prebuilt_indexes/lucene-index.atomic.image.flat.base.tar.gz"
+        ],
+        "md5": "55e88e334165b7147092ee67dfa74955",
+        "size compressed (bytes)": 1218292466,
+        "total_terms": 100743397,
+        "documents": 3410779,
+        "unique_terms": -1,
+        "downloaded": False
+    },
+    "atomic_image_v0.2_large": {
+        "description": "Lucene index for AToMiC Images v0.2 large setting on validation set (Lucene 9)",
+        "filename": "lucene-index.atomic.image.flat.large.tar.gz",
+        "readme": "lucene-index.atomic.20230525.a7df7f.README.md",
+        "urls": [
+            "https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/prebuilt_indexes/lucene-index.atomic.image.flat.large.tar.gz"
+        ],
+        "md5": "919c3f870968ffbe24f30407ad1385f8",
+        "size compressed (bytes)": 1341866370,
+        "total_terms": 108550562,
+        "documents": 3803656,
+        "unique_terms": -1,
+        "downloaded": False
+    },
 }
 
 TF_INDEX_INFO = {**TF_INDEX_INFO_MSMARCO,

--- a/pyserini/query_iterator.py
+++ b/pyserini/query_iterator.py
@@ -84,7 +84,7 @@ class DefaultQueryIterator(QueryIterator):
             if topics_path.endswith('.json'):
                 with open(topics_path, 'r') as f:
                     topics = json.load(f)
-            elif "beir" in topics_path:
+            elif 'beir' in topics_path:
                 topics = get_topics_with_reader('io.anserini.search.topicreader.TsvStringTopicReader', topics_path)
             elif topics_path.endswith('.tsv') or topics_path.endswith('.tsv.gz'):
                 try:
@@ -95,6 +95,8 @@ class DefaultQueryIterator(QueryIterator):
                 topics = get_topics_with_reader('io.anserini.search.topicreader.TrecTopicReader', topics_path)
             elif 'cacm' in topics_path:
                 topics = get_topics_with_reader('io.anserini.search.topicreader.CacmTopicReader', topics_path)
+            elif topics_path.endswith('.jsonl'):
+                topics = get_topics_with_reader('io.anserini.search.topicreader.JsonStringTopicReader', topics_path)
             else:
                 raise NotImplementedError(f"Not sure how to parse {topics_path}. Please specify the file extension.")
         else:

--- a/pyserini/resources/index-metadata/lucene-index.atomic.20230525.a7df7f.README.md
+++ b/pyserini/resources/index-metadata/lucene-index.atomic.20230525.a7df7f.README.md
@@ -1,0 +1,5 @@
+# AToMiC BM 25 Indexes
+
+Lucene indexes for the AToMiC dataset (text collection v0.2.1, image collection v0.2)
+
+These indexes were generated on 2023/05/25 at Anserini commit [`a7df7f`](https://github.com/castorini/anserini/commit/a7df7fc5d527ede8f34ee60afa41dec4f6b0e93a) on Compute Canada's Cedar cluster running [this script](https://github.com/TREC-AToMiC/AToMiC/blob/f2f9b58ffd39d920c7599ba49de40a34dd1a21b8/examples/bm25_en_caption/run_bm25_baseline.py#L62) (in particular, the `create_index` function).


### PR DESCRIPTION
Add prebuilt indexes for reproducing atomic bm25 baselines and a README showing how to reproduce the results.
(they are currently hosted on my personal huggingface space)

Also a small change in the query iterator to work with `jsonl` files

Note:
- need to update links to the indexes once they are moved to the `rgw.cs.uwaterloo.ca` server
- also a related PR adding the topics and qrels files https://github.com/castorini/anserini-tools/pull/51

I did a quick test of the commands given in `docs/experiments-atomic-bm25.md` using the `small` settings and verified that the numbers match up with those given in https://docs.google.com/spreadsheets/d/1wSi_79Qx3GA1WAirwvoapiWJ4m2bPRM_rtUWRZ2qRIo/edit#gid=0