### PR TITLE
Add OpenAI ada2 2CR (reg/hyde)

### DIFF
--- a/docs/2cr/msmarco-v1-passage.html
+++ b/docs/2cr/msmarco-v1-passage.html
@@ -3530,7 +3530,7 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 <!-- Condition: OpenAI ada2: pre-encoded queries -->
 <tr class="accordion-toggle collapsed" id="row33" data-toggle="collapse" data-parent="#row33" href="#collapse33">
 <td class="expand-button"></td>
-<td style="min-width: 85px">[9]</td>
+<td style="min-width: 85px"></td>
 <td style="min-width: 400px">OpenAI ada2: pre-encoded queries</td>
 <td>0.4788</td>
 <td>0.7035</td>
@@ -3631,7 +3631,7 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 <!-- Condition: HyDE-OpenAI ada2: pre-encoded queries -->
 <tr class="accordion-toggle collapsed" id="row34" data-toggle="collapse" data-parent="#row34" href="#collapse34">
 <td class="expand-button"></td>
-<td style="min-width: 85px">[9]</td>
+<td style="min-width: 85px"></td>
 <td style="min-width: 400px">HyDE-OpenAI ada2: pre-encoded queries</td>
 <td>0.5125</td>
 <td>0.7163</td>
@@ -3752,8 +3752,6 @@ python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarc
 <li><p>[8] Sheng-Chieh Lin, Minghan Li and Jimmy Lin.
 <a href="https://arxiv.org/abs/2208.00511">Aggretriever: A Simple Approach to Aggregate Textual Representation for Robust Dense Passage Retrieval.</a>
 <i>arXiv:2208.00511</i>, July 2022.</p></li>
-
-<li><p>[9] TODO: add openai ada2 paper  </p></li>
 
 </ul>
 

--- a/docs/2cr/msmarco-v1-passage.html
+++ b/docs/2cr/msmarco-v1-passage.html
@@ -3526,6 +3526,192 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 
 </div></td>
 </tr>
+<tr><td style="border-bottom: 0"></td></tr>
+<!-- Condition: OpenAI ada2: pre-encoded queries -->
+<tr class="accordion-toggle collapsed" id="row33" data-toggle="collapse" data-parent="#row33" href="#collapse33">
+<td class="expand-button"></td>
+<td style="min-width: 85px">[9]</td>
+<td style="min-width: 400px">OpenAI ada2: pre-encoded queries</td>
+<td>0.4788</td>
+<td>0.7035</td>
+<td>0.8629</td>
+<td></td>
+<td>0.4771</td>
+<td>0.6759</td>
+<td>0.8705</td>
+<td></td>
+<td>0.3435</td>
+<td>0.9858</td>
+</tr>
+<tr class="hide-table-padding">
+<td></td>
+<td colspan="11">
+<div id="collapse33" class="collapse in p-3">
+
+<!-- Tabs navs -->
+<ul class="nav nav-tabs mb-3" id="row33-tabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <a class="nav-link active" id="row33-tab1-header" data-mdb-toggle="tab" href="#row33-tab1" role="tab" aria-controls="row33-tab1" aria-selected="true" style="text-transform:none">TREC 2019</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="row33-tab2-header" data-mdb-toggle="tab" href="#row33-tab2" role="tab" aria-controls="row33-tab2" aria-selected="false" style="text-transform:none">TREC 2020</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="row33-tab3-header" data-mdb-toggle="tab" href="#row33-tab3" role="tab" aria-controls="row33-tab3" aria-selected="false" style="text-transform:none">dev</a>
+  </li>
+</ul>
+<!-- Tabs navs -->
+
+<!-- Tabs content -->
+<div class="tab-content" id="row33-content">
+  <div class="tab-pane fade show active" id="row33-tab1" role="tabpanel" aria-labelledby="row33-tab1">
+Command to generate run on TREC 2019 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v1-passage.openai-ada2 \
+  --topics dl19-passage --encoded-queries openai-ada2-dl19-passage \
+  --output run.msmarco-v1-passage.openai-ada2.dl19.txt
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.openai-ada2.dl19.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.openai-ada2.dl19.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.openai-ada2.dl19.txt
+</code></pre>
+  </blockquote>
+
+  </div>
+  <div class="tab-pane fade" id="row33-tab2" role="tabpanel" aria-labelledby="row33-tab2">
+    Command to generate run on TREC 2020 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v1-passage.openai-ada2 \
+  --topics dl20 --encoded-queries openai-ada2-dl20 \
+  --output run.msmarco-v1-passage.openai-ada2.dl20.txt
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.openai-ada2.dl20.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.openai-ada2.dl20.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.openai-ada2.dl20.txt
+</code></pre>
+  </blockquote>
+
+  </div>
+  <div class="tab-pane fade" id="row33-tab3" role="tabpanel" aria-labelledby="row33-tab3">
+    Command to generate run on dev queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v1-passage.openai-ada2 \
+  --topics msmarco-passage-dev-subset --encoded-queries openai-ada2-msmarco-passage-dev-subset \
+  --output run.msmarco-v1-passage.openai-ada2.dev.txt
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -M 10 -m recip_rank msmarco-passage-dev-subset run.msmarco-v1-passage.openai-ada2.dev.txt
+python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset run.msmarco-v1-passage.openai-ada2.dev.txt
+</code></pre>
+  </blockquote>
+
+  </div>
+</div>
+<!-- Tabs content -->
+
+</div></td>
+</tr>
+<!-- Condition: HyDE-OpenAI ada2: pre-encoded queries -->
+<tr class="accordion-toggle collapsed" id="row34" data-toggle="collapse" data-parent="#row34" href="#collapse34">
+<td class="expand-button"></td>
+<td style="min-width: 85px">[9]</td>
+<td style="min-width: 400px">HyDE-OpenAI ada2: pre-encoded queries</td>
+<td>0.5125</td>
+<td>0.7163</td>
+<td>0.9002</td>
+<td></td>
+<td>0.4938</td>
+<td>0.6666</td>
+<td>0.8919</td>
+<td></td>
+<td>-</td>
+<td>-</td>
+</tr>
+<tr class="hide-table-padding">
+<td></td>
+<td colspan="11">
+<div id="collapse34" class="collapse in p-3">
+
+<!-- Tabs navs -->
+<ul class="nav nav-tabs mb-3" id="row34-tabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <a class="nav-link active" id="row34-tab1-header" data-mdb-toggle="tab" href="#row34-tab1" role="tab" aria-controls="row34-tab1" aria-selected="true" style="text-transform:none">TREC 2019</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="row34-tab2-header" data-mdb-toggle="tab" href="#row34-tab2" role="tab" aria-controls="row34-tab2" aria-selected="false" style="text-transform:none">TREC 2020</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="row34-tab3-header" data-mdb-toggle="tab" href="#row34-tab3" role="tab" aria-controls="row34-tab3" aria-selected="false" style="text-transform:none">dev</a>
+  </li>
+</ul>
+<!-- Tabs navs -->
+
+<!-- Tabs content -->
+<div class="tab-content" id="row34-content">
+  <div class="tab-pane fade show active" id="row34-tab1" role="tabpanel" aria-labelledby="row34-tab1">
+Command to generate run on TREC 2019 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v1-passage.openai-ada2 \
+  --topics dl19-passage --encoded-queries openai-ada2-dl19-passage-hyde \
+  --output run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
+</code></pre>
+  </blockquote>
+
+  </div>
+  <div class="tab-pane fade" id="row34-tab2" role="tabpanel" aria-labelledby="row34-tab2">
+    Command to generate run on TREC 2020 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.faiss \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v1-passage.openai-ada2 \
+  --topics dl20 --encoded-queries openai-ada2-dl20-hyde \
+  --output run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
+</code></pre>
+  </blockquote>
+
+  </div>
+  <div class="tab-pane fade" id="row34-tab3" role="tabpanel" aria-labelledby="row34-tab3">
+    Not available.</div>
+</div>
+<!-- Tabs content -->
+
+</div></td>
+</tr>
 
     </tbody>
   </table>
@@ -3567,6 +3753,7 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset r
 <a href="https://arxiv.org/abs/2208.00511">Aggretriever: A Simple Approach to Aggregate Textual Representation for Robust Dense Passage Retrieval.</a>
 <i>arXiv:2208.00511</i>, July 2022.</p></li>
 
+<li><p>[9] TODO: add openai ada2 paper  </p></li>
 
 </ul>
 

--- a/pyserini/2cr/msmarco-v1-passage.yaml
+++ b/pyserini/2cr/msmarco-v1-passage.yaml
@@ -750,15 +750,15 @@ conditions:
     display: "HyDE-OpenAI ada2: pre-encoded queries"
     display-html: "HyDE-OpenAI ada2: pre-encoded queries"
     display-row: "[9]"
-    command: python -m pyserini.search.faiss --threads 16 --batch-size 128 --index msmarco-v1-passage.openai-ada2 --topics $topics --encoded-queries openai-ada2-$topics --output $output
+    command: python -m pyserini.search.faiss --threads 16 --batch-size 128 --index msmarco-v1-passage.openai-ada2 --topics $topics --encoded-queries openai-ada2-$topics-hyde --output $output
     topics:
-      - topic_key: dl19-passage-hyde
+      - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
           - MAP: 0.5125
             nDCG@10: 0.7163
             R@1K: 0.9002
-      - topic_key: dl20-hyde
+      - topic_key: dl20
         eval_key: dl20-passage
         scores:
           - MAP: 0.4938

--- a/pyserini/2cr/msmarco-v1-passage.yaml
+++ b/pyserini/2cr/msmarco-v1-passage.yaml
@@ -726,7 +726,6 @@ conditions:
   - name: openai-ada2
     display: "OpenAI ada2: pre-encoded queries"
     display-html: "OpenAI ada2: pre-encoded queries"
-    display-row: "[9]"
     command: python -m pyserini.search.faiss --threads 16 --batch-size 128 --index msmarco-v1-passage.openai-ada2 --topics $topics --encoded-queries openai-ada2-$topics --output $output
     topics:
       - topic_key: msmarco-passage-dev-subset
@@ -749,7 +748,6 @@ conditions:
   - name: openai-ada2-hyde
     display: "HyDE-OpenAI ada2: pre-encoded queries"
     display-html: "HyDE-OpenAI ada2: pre-encoded queries"
-    display-row: "[9]"
     command: python -m pyserini.search.faiss --threads 16 --batch-size 128 --index msmarco-v1-passage.openai-ada2 --topics $topics --encoded-queries openai-ada2-$topics-hyde --output $output
     topics:
       - topic_key: dl19-passage

--- a/pyserini/2cr/msmarco-v1-passage.yaml
+++ b/pyserini/2cr/msmarco-v1-passage.yaml
@@ -723,3 +723,44 @@ conditions:
           - MAP: 0.4710
             nDCG@10: 0.6972
             R@1K: 0.8555
+  - name: openai-ada2
+    display: "OpenAI ada2: pre-encoded queries"
+    display-html: "OpenAI ada2: pre-encoded queries"
+    display-row: "[9]"
+    command: python -m pyserini.search.faiss --threads 16 --batch-size 128 --index msmarco-v1-passage.openai-ada2 --topics $topics --encoded-queries openai-ada2-$topics --output $output
+    topics:
+      - topic_key: msmarco-passage-dev-subset
+        eval_key: msmarco-passage-dev-subset
+        scores:
+          - MRR@10: 0.3435
+            R@1K: 0.9858
+      - topic_key: dl19-passage
+        eval_key: dl19-passage
+        scores:
+          - MAP: 0.4788
+            nDCG@10: 0.7035
+            R@1K: 0.8629
+      - topic_key: dl20
+        eval_key: dl20-passage
+        scores:
+          - MAP: 0.4771
+            nDCG@10: 0.6759
+            R@1K: 0.8705
+  - name: openai-ada2-hyde
+    display: "HyDE-OpenAI ada2: pre-encoded queries"
+    display-html: "HyDE-OpenAI ada2: pre-encoded queries"
+    display-row: "[9]"
+    command: python -m pyserini.search.faiss --threads 16 --batch-size 128 --index msmarco-v1-passage.openai-ada2 --topics $topics --encoded-queries openai-ada2-$topics --output $output
+    topics:
+      - topic_key: dl19-passage-hyde
+        eval_key: dl19-passage
+        scores:
+          - MAP: 0.5125
+            nDCG@10: 0.7163
+            R@1K: 0.9002
+      - topic_key: dl20-hyde
+        eval_key: dl20-passage
+        scores:
+          - MAP: 0.4938
+            nDCG@10: 0.6666
+            R@1K: 0.8919

--- a/pyserini/2cr/msmarco.py
+++ b/pyserini/2cr/msmarco.py
@@ -72,7 +72,10 @@ models = {
      'slimr-pp',
      '',
      'Aggretriever-Distilbert-otf',
-     'Aggretriever-coCondenser-otf'],
+     'Aggretriever-coCondenser-otf',
+     '',
+     'openai-ada2',
+     'openai-ada2-hyde'],
     'msmarco-v1-doc':
     ['bm25-doc-default',
      'bm25-doc-segmented-default',

--- a/pyserini/2cr/msmarco_html_v1_passage.template
+++ b/pyserini/2cr/msmarco_html_v1_passage.template
@@ -215,6 +215,7 @@ $rows
 <a href="https://arxiv.org/abs/2208.00511">Aggretriever: A Simple Approach to Aggregate Textual Representation for Robust Dense Passage Retrieval.</a>
 <i>arXiv:2208.00511</i>, July 2022.</p></li>
 
+<li><p>[9] TODO: add openai ada2 paper  </p></li>
 
 </ul>
 

--- a/pyserini/2cr/msmarco_html_v1_passage.template
+++ b/pyserini/2cr/msmarco_html_v1_passage.template
@@ -215,8 +215,6 @@ $rows
 <a href="https://arxiv.org/abs/2208.00511">Aggretriever: A Simple Approach to Aggregate Textual Representation for Robust Dense Passage Retrieval.</a>
 <i>arXiv:2208.00511</i>, July 2022.</p></li>
 
-<li><p>[9] TODO: add openai ada2 paper  </p></li>
-
 </ul>
 
 <div style="padding-top: 20px"/>

--- a/pyserini/encoded_query_info.py
+++ b/pyserini/encoded_query_info.py
@@ -434,5 +434,55 @@ QUERY_INFO = {
         "size (bytes)": 32620950,
         "total_queries": 11313,
         "downloaded": False
-     }     
+     },
+     "openai-ada2-dl19-passage": {
+        "description": "TREC DL19 passage queries encoded by OpenAI ada2.",
+        "urls": [
+            "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-openai-ada2-dl19-passage-20230530-e3a58f.tar.gz",
+        ],
+        "md5": "ab57dab62c5b43508c661b78d6f7b6b9",
+        "size (bytes)": 418940,
+        "total_queries": 43,
+        "downloaded": False
+     },
+     "openai-ada2-dl20": {
+        "description": "TREC DL20 passage queries encoded by OpenAI ada2.",
+        "urls": [
+            "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-openai-ada2-dl20-passage-20230530-e3a58f.tar.gz",
+        ],
+        "md5": "fe711c1e146647396fd06f125882d01c",
+        "size (bytes)": 1939404,
+        "total_queries": 200,
+        "downloaded": False
+     },
+     "openai-ada2-dl19-passage-hyde": {
+        "description": "TREC DL19 passage queries encoded by HyDE-OpenAI ada2.",
+        "urls": [
+            "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-openai-ada2-hyde-dl19-passage-20230530-e3a58f.tar.gz",
+        ],
+        "md5": "bc981187dc18f3fbf21698605e2349b5",
+        "size (bytes)": 508400,
+        "total_queries": 43,
+        "downloaded": False
+     },
+     "openai-ada2-dl20-hyde": {
+        "description": "TREC DL20 passage queries encoded by HyDE-OpenAI ada2.",
+        "urls": [
+            "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-openai-ada2-hyde-dl20-passage-20230530-e3a58f.tar.gz",
+        ],
+        "md5": "12389d6affdab9231996834f7022beab",
+        "size (bytes)": 645105,
+        "total_queries": 200,
+        "downloaded": False
+     },
+     "openai-ada2-msmarco-passage-dev-subset": {
+        "description": "MS MARCO passage dev set queries encoded by OpenAI ada2.",
+        "urls": [
+            "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-openai-ada2-msmarco-passage-dev-subset-20230530-e3a58f.tar.gz",
+        ],
+        "md5": "0d9c7311e2e3819183d7ae2b4889e4ba",
+        "size (bytes)": 67615770,
+        "total_queries": 6980,
+        "downloaded": False
+     },    
 }

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -3190,7 +3190,7 @@ FAISS_INDEX_INFO_MSMARCO = {
         "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT-V2-HNP",
         "filename": "faiss.msmarco-v1-passage.openai-ada2.20230530.e3a58f.tar.gz",
         "urls": [
-            ""
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/faiss.msmarco-v1-passage.openai-ada2.20230530.e3a58f.tar.gz"
         ],
         "md5": "14725ced21bdcd0c9866aab1cfe8f2e0",
         "size compressed (bytes)": 45649935573,

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -3186,6 +3186,18 @@ FAISS_INDEX_INFO_MSMARCO = {
         "downloaded": False,
         "texts": "msmarco-v1-passage"
     },
+    "msmarco-v1-passage.openai-ada2": {
+        "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by TCT-ColBERT-V2-HNP",
+        "filename": "faiss.msmarco-v1-passage.openai-ada2.20230530.e3a58f.tar.gz",
+        "urls": [
+            ""
+        ],
+        "md5": "14725ced21bdcd0c9866aab1cfe8f2e0",
+        "size compressed (bytes)": 45649935573,
+        "documents": 8841823,
+        "downloaded": False,
+        "texts": "msmarco-v1-passage"
+    },
 
     "msmarco-v1-doc.ance-maxp": {
         "description": "Faiss FlatIP index of the MS MARCO document corpus encoded by the ANCE MaxP encoder",


### PR DESCRIPTION
**Reproduction Instructions**
--

**TREC 2019**
Search:
``` bash
python -m pyserini.search.faiss \
  --threads 16 --batch-size 128 \
  --index msmarco-v1-passage.openai-ada2 \
  --topics dl19-passage --encoded-queries openai-ada2-dl19-passage \
  --output run.msmarco-v1-passage.openai-ada2.dl19.txt
```
Eval:
```bash
python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.openai-ada2.dl19.txt
python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.openai-ada2.dl19.txt
python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.openai-ada2.dl19.txt
```
---
**TREC 2020**
Search:
```bash
python -m pyserini.search.faiss \
  --threads 16 --batch-size 128 \
  --index msmarco-v1-passage.openai-ada2 \
  --topics dl20 --encoded-queries openai-ada2-dl20 \
  --output run.msmarco-v1-passage.openai-ada2.dl20.txt
```
Eval:
```
python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.openai-ada2.dl20.txt
python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.openai-ada2.dl20.txt
python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.openai-ada2.dl20.txt
```
---
**dev**
Search:
```bash
python -m pyserini.search.faiss \
  --threads 16 --batch-size 128 \
  --index msmarco-v1-passage.openai-ada2 \
  --topics msmarco-passage-dev-subset --encoded-queries openai-ada2-msmarco-passage-dev-subset \
  --output run.msmarco-v1-passage.openai-ada2.dev.txt
```
Eval:
```bash
python -m pyserini.eval.trec_eval -c -M 10 -m recip_rank msmarco-passage-dev-subset run.msmarco-v1-passage.openai-ada2.dev.txt
python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-passage-dev-subset run.msmarco-v1-passage.openai-ada2.dev.txt
```
---
**TREC 2019 (HyDE)**
Search:
``` bash
python -m pyserini.search.faiss \
  --threads 16 --batch-size 128 \
  --index msmarco-v1-passage.openai-ada2 \
  --topics dl19-passage --encoded-queries openai-ada2-dl19-passage-hyde \
  --output run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
```
Eval:
```bash
python -m pyserini.eval.trec_eval -c -l 2 -m map dl19-passage run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl19-passage run.msmarco-v1-passage.openai-ada2-hyde.dl19.txt
```
---
**TREC 2020 (HyDE)**
Search:
```bash
python -m pyserini.search.faiss \
  --threads 16 --batch-size 128 \
  --index msmarco-v1-passage.openai-ada2 \
  --topics dl20 --encoded-queries openai-ada2-dl20-hyde \
  --output run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
```
Eval:
```
python -m pyserini.eval.trec_eval -c -l 2 -m map dl20-passage run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl20-passage run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl20-passage run.msmarco-v1-passage.openai-ada2-hyde.dl20.txt
```