### PR TITLE
Add support for pandas v2.0.0+.

### DIFF
--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -194,7 +194,7 @@ def get_sparse_indexes_info():
         df[index]['downloaded'] = check_downloaded(index)
 
     with pd.option_context('display.max_rows', None, 'display.max_columns',
-                           None, 'display.max_colwidth', -1, 'display.colheader_justify', 'left'):
+                           None, 'display.max_colwidth', None, 'display.colheader_justify', 'left'):
         print(df)
 
 
@@ -204,7 +204,7 @@ def get_impact_indexes_info():
         df[index]['downloaded'] = check_downloaded(index)
 
     with pd.option_context('display.max_rows', None, 'display.max_columns',
-                           None, 'display.max_colwidth', -1, 'display.colheader_justify', 'left'):
+                           None, 'display.max_colwidth', None, 'display.colheader_justify', 'left'):
         print(df)
 
 
@@ -214,7 +214,7 @@ def get_dense_indexes_info():
         df[index]['downloaded'] = check_downloaded(index)
 
     with pd.option_context('display.max_rows', None, 'display.max_columns',
-                           None, 'display.max_colwidth', -1, 'display.colheader_justify', 'left'):
+                           None, 'display.max_colwidth', None, 'display.colheader_justify', 'left'):
         print(df)
 
 


### PR DESCRIPTION
After pandas 2.0.0, using -1 for display.max_colwidth was removed in favor of None. Using -1 throws a ValueError. 

Reference from pandas: https://github.com/pandas-dev/pandas/pull/49295/files

See additional discussion here: https://github.com/castorini/pyserini/issues/1563