### PR TITLE
Add script to convert AToMiC raw numpy embeddings to pyserini format

### DIFF
--- a/docs/experiments-atomic-ViT-L-14.laion2b_s32b_b82k.md
+++ b/docs/experiments-atomic-ViT-L-14.laion2b_s32b_b82k.md
@@ -1,0 +1,72 @@
+# Pyserini: Reproducing AToMiC ViT-L-14-laion2B-s32B-b82K Baselines
+
+Pyserini provides the following pre-built indexes for the AToMiC dataset, encoded with [`laion/CLIP-ViT-L-14-laion2B-s32B-b82K`](https://huggingface.co/laion/CLIP-ViT-L-14-laion2B-s32B-b82K):
+- `atomic-v0.2.1.ViT-L-14.laion2b_s32b_b82k.text.base`
+- `atomic-v0.2.1.ViT-L-14.laion2b_s32b_b82k.text.large`
+- `atomic-v0.2.1.ViT-L-14.laion2b_s32b_b82k.text.validation`
+- `atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.base`
+- `atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.large`
+- `atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.validation`
+
+## Data Prep
+We need the topic directories (`ViT-L-14.laion2b_s32b_b82k.text.validation` and `ViT-L-14.laion2b_s32b_b82k.image.validation`) and the qrels files (`qrels.atomic.validation.t2i.trec` and `qrels.atomic.validation.i2t.trec`) to reproduce the baselines. This can be done by running the following script:
+
+```bash
+cd scripts/atomic
+mkdir topics
+wget https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/topics/ViT-L-14.laion2b_s32b_b82k.image.validation.tar.gz -P topics
+tar -xzvf topics/ViT-L-14.laion2b_s32b_b82k.image.validation.tar.gz -C topics
+wget https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/topics/ViT-L-14.laion2b_s32b_b82k.text.validation.tar.gz -P topics
+tar -xzvf topics/ViT-L-14.laion2b_s32b_b82k.text.validation.tar.gz -C topics
+
+mkdir qrels
+wget https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/qrels/qrels.atomic.validation.i2t.trec -P qrels
+wget https://huggingface.co/spaces/dlrudwo1269/AToMiC_bm25_files/resolve/main/qrels/qrels.atomic.validation.t2i.trec -P qrels
+```
+
+## Convert Topics
+We can convert the numpy topics to pyserini format as follows:
+```bash
+mkdir converted.ViT-L-14.laion2b_s32b_b82k.text.validation && mkdir converted.ViT-L-14.laion2b_s32b_b82k.image.validation
+# Text
+python convert_embeddings.py --encode-type text --inputs topics/ViT-L-14.laion2b_s32b_b82k.text.validation --topics-output converted.ViT-L-14.laion2b_s32b_b82k.text --embeddings-output converted.ViT-L-14.laion2b_s32b_b82k.text
+# Image
+python convert_embeddings.py --encode-type image --inputs topics/ViT-L-14.laion2b_s32b_b82k.image.validation --topics-output converted.ViT-L-14.laion2b_s32b_b82k.image --embeddings-output converted.ViT-L-14.laion2b_s32b_b82k.image
+```
+
+## Batch Retrieval Run
+We can perform a batch retrieval run as follows, replacing `{setting}` with the desired setting (`base`, `large`, `validation`):
+```bash
+# Text to Image
+python -m pyserini.search.faiss \
+    --topics converted.ViT-L-14.laion2b_s32b_b82k.text.validation/topics.json \
+    --index atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.{setting} \
+    --hits 1000 \
+    --encoder converted.ViT-L-14.laion2b_s32b_b82k.text.validation \
+    --batch-size 256 \
+    --threads 32 \
+    --output run.ViT-L-14.laion2b_s32b_b82k.t2i.{setting}.trec
+  
+# Image to Text
+python -m pyserini.search.faiss \
+    --topics converted.ViT-L-14.laion2b_s32b_b82k.image.validation/topics.json \
+    --index atomic-v0.2.1.ViT-L-14.laion2b_s32b_b82k.text.{setting} \
+    --hits 1000 \
+    --encoded-queries converted.ViT-L-14.laion2b_s32b_b82k.image.validation \
+    --batch-size 256 \
+    --threads 32 \
+    --output run.ViT-L-14.laion2b_s32b_b82k.i2t.{setting}.trec
+```
+
+We can evaluate using `trec_eval`:
+```bash
+# Text to Image
+python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 qrels/qrels.atomic.validation.t2i.trec run.ViT-L-14.laion2b_s32b_b82k.t2i.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recall.10,1000 qrels/qrels.atomic.validation.t2i.trec run.ViT-L-14.laion2b_s32b_b82k.t2i.{setting}.trec
+
+# Image to Text
+python -m pyserini.eval.trec_eval -c -m recip_rank -M 10 qrels/qrels.atomic.validation.i2t.trec run.ViT-L-14.laion2b_s32b_b82k.i2t.{setting}.trec
+python -m pyserini.eval.trec_eval -c -m recall.10,1000 qrels/qrels.atomic.validation.i2t.trec run.ViT-L-14.laion2b_s32b_b82k.i2t.{setting}.trec
+```
+
+The results should line up with [this spreadsheet](https://docs.google.com/spreadsheets/d/1wSi_79Qx3GA1WAirwvoapiWJ4m2bPRM_rtUWRZ2qRIo).

--- a/docs/experiments-atomic-ViT-L-14.laion2b_s32b_b82k.md
+++ b/docs/experiments-atomic-ViT-L-14.laion2b_s32b_b82k.md
@@ -29,9 +29,9 @@ We can convert the numpy topics to pyserini format as follows:
 ```bash
 mkdir converted.ViT-L-14.laion2b_s32b_b82k.text.validation && mkdir converted.ViT-L-14.laion2b_s32b_b82k.image.validation
 # Text
-python convert_embeddings.py --encode-type text --inputs topics/ViT-L-14.laion2b_s32b_b82k.text.validation --topics-output converted.ViT-L-14.laion2b_s32b_b82k.text --embeddings-output converted.ViT-L-14.laion2b_s32b_b82k.text
+python convert_embeddings.py --encode-type text --inputs topics/ViT-L-14.laion2b_s32b_b82k.text.validation --topics-output converted.ViT-L-14.laion2b_s32b_b82k.text.validation --embeddings-output converted.ViT-L-14.laion2b_s32b_b82k.text.validation
 # Image
-python convert_embeddings.py --encode-type image --inputs topics/ViT-L-14.laion2b_s32b_b82k.image.validation --topics-output converted.ViT-L-14.laion2b_s32b_b82k.image --embeddings-output converted.ViT-L-14.laion2b_s32b_b82k.image
+python convert_embeddings.py --encode-type image --inputs topics/ViT-L-14.laion2b_s32b_b82k.image.validation --topics-output converted.ViT-L-14.laion2b_s32b_b82k.image.validation --embeddings-output converted.ViT-L-14.laion2b_s32b_b82k.image.validation
 ```
 
 ## Batch Retrieval Run
@@ -42,7 +42,7 @@ python -m pyserini.search.faiss \
     --topics converted.ViT-L-14.laion2b_s32b_b82k.text.validation/topics.json \
     --index atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.{setting} \
     --hits 1000 \
-    --encoder converted.ViT-L-14.laion2b_s32b_b82k.text.validation \
+    --encoded-queries converted.ViT-L-14.laion2b_s32b_b82k.text.validation \
     --batch-size 256 \
     --threads 32 \
     --output run.ViT-L-14.laion2b_s32b_b82k.t2i.{setting}.trec

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -5603,7 +5603,86 @@ FAISS_INDEX_INFO_OTHER = {
         "documents": 38429835,
         "downloaded": False,
         "texts": "cast2019"
-    }
+    },
+    # TODO: update urls to rgw.cs.uwaterloo.ca/....
+    "atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.base": {
+        "description": "Faiss index for AToMiC Images v0.2 on base corpus encoded by laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+        "filename": "ViT-L-14.laion2b_s32b_b82k.image.base.faiss.flat.tar.gz",
+        "readme": "faiss.atomic.ViT-L-14.laion2b_s32b_b82k.20230621.83e97fc.README.md",
+        "urls": [
+            "https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/indexes/ViT-L-14.laion2b_s32b_b82k.image.base.faiss.flat.tar.gz"
+        ],
+        "md5": "7e7abf80e99b81c444281405db19c579",
+        "size compressed (bytes)": 9284282630,
+        "documents": 3410779,
+        "downloaded": False,
+        "texts": "atomic_image_v0.2_base"
+    },
+    "atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.large": {
+        "description": "Faiss index for AToMiC Images v0.2 on large corpus encoded by laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+        "filename": "ViT-L-14.laion2b_s32b_b82k.image.faiss.flat.tar.gz",
+        "readme": "faiss.atomic.ViT-L-14.laion2b_s32b_b82k.20230621.83e97fc.README.md",
+        "urls": [
+            "https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/indexes/ViT-L-14.laion2b_s32b_b82k.image.faiss.flat.tar.gz"
+        ],
+        "md5": "501b7477a8e1eea9e10904a2ea307906",
+        "size compressed (bytes)": 29984366146,
+        "documents": 3803656,
+        "downloaded": False,
+        "texts": "atomic_image_v0.2_large"
+    },
+    "atomic-v0.2.ViT-L-14.laion2b_s32b_b82k.image.validation": {
+        "description": "Faiss index for AToMiC Images v0.2 on validation corpus encoded by laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+        "filename": "ViT-L-14.laion2b_s32b_b82k.image.small.validation.faiss.flat.tar.gz",
+        "readme": "faiss.atomic.ViT-L-14.laion2b_s32b_b82k.20230621.83e97fc.README.md",
+        "urls": [
+            "https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/indexes/ViT-L-14.laion2b_s32b_b82k.image.small.validation.faiss.flat.tar.gz"
+        ],
+        "md5": "798d601cfc505a4b290bb708290a38fc",
+        "size compressed (bytes)": 43875634,
+        "documents": 16126,
+        "downloaded": False,
+        "texts": "atomic_image_v0.2_small_validation"
+    },
+     "atomic-v0.2.1.ViT-L-14.laion2b_s32b_b82k.text.base": {
+        "description": "Faiss index for AToMiC Texts v0.2.1 on base corpus encoded by laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+        "filename": "ViT-L-14.laion2b_s32b_b82k.text.base.faiss.flat.tar.gz",
+        "readme": "faiss.atomic.ViT-L-14.laion2b_s32b_b82k.20230621.83e97fc.README.md",
+        "urls": [
+            "https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/indexes/ViT-L-14.laion2b_s32b_b82k.text.base.faiss.flat.tar.gz"
+        ],
+        "md5": "1d90ecfb703b96f003a9d6dc054c057b",
+        "size compressed (bytes)": 8187618352,
+        "documents": 3029504,
+        "downloaded": False,
+        "texts": "atomic_text_v0.2.1_base"
+    },
+    "atomic-v0.2.1.ViT-L-14.laion2b_s32b_b82k.text.large": {
+        "description": "Faiss index for AToMiC Texts v0.2.1 on large corpus encoded by laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+        "filename": "ViT-L-14.laion2b_s32b_b82k.image.faiss.flat.tar.gz",
+        "readme": "faiss.atomic.ViT-L-14.laion2b_s32b_b82k.20230621.83e97fc.README.md",
+        "urls": [
+            "https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/indexes/ViT-L-14.laion2b_s32b_b82k.text.faiss.flat.tar.gz"
+        ],
+        "md5": "9f5962e0b29bb341cba88041107b693e",
+        "size compressed (bytes)": 27373277238,
+        "documents": 10134744,
+        "downloaded": False,
+        "texts": "atomic_text_v0.2.1_large"
+    },
+    "atomic-v0.2.1.ViT-L-14.laion2b_s32b_b82k.text.validation": {
+        "description": "Faiss index for AToMiC Texts v0.2.1 on validation corpus encoded by laion/CLIP-ViT-L-14-laion2B-s32B-b82K",
+        "filename": "ViT-L-14.laion2b_s32b_b82k.image.small.validation.faiss.flat.tar.gz",
+        "readme": "faiss.atomic.ViT-L-14.laion2b_s32b_b82k.20230621.83e97fc.README.md",
+        "urls": [
+            "https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/resolve/main/indexes/ViT-L-14.laion2b_s32b_b82k.text.small.validation.faiss.flat.tar.gz"
+        ],
+        "md5": "2dd9d0c805bbef6a6a23ece3c2b221a3",
+        "size compressed (bytes)": 46421016,
+        "documents": 17173,
+        "downloaded": False,
+        "texts": "atomic_text_v0.2.1_small_validation"
+    },
 }
 
 FAISS_INDEX_INFO = {**FAISS_INDEX_INFO_MSMARCO,

--- a/scripts/atomic/README.md
+++ b/scripts/atomic/README.md
@@ -1,0 +1,9 @@
+# Usage Guide
+
+We can convert the numpy-style AToMiC prebuilt topics to that of pyserini format as below:
+
+```bash
+python convert_embeddings.py --encode-type text --inputs ViT-L-14.laion2b_s32b_b82k.text.validation --topics-output output_dir/ --embeddings-output output_dir/
+```
+
+The inputs (AToMiC prebuilt topics) can be found in [this repo](https://huggingface.co/datasets/TREC-AToMiC/AToMiC-Baselines/tree/main).

--- a/scripts/atomic/convert_embeddings.py
+++ b/scripts/atomic/convert_embeddings.py
@@ -10,8 +10,8 @@ def get_args_parser():
     parser = argparse.ArgumentParser('Encode embeddings', add_help=False)
     parser.add_argument('--inputs', type=str, help='directory of the AToMiC prebuilt topic embeddings', required=True)
     parser.add_argument('--encode-type', type=str, default='text', choices=['text', 'image'], required=True)
-    parser.add_argument('--topics-output', type=str, help='directory to store topics file', required=True)
-    parser.add_argument('--embeddings-output', type=str, help='directory to store embeddings file', required=True)
+    parser.add_argument('--topics-output', type=str, help='directory to store topics file', default='')
+    parser.add_argument('--embeddings-output', type=str, help='directory to store embeddings file', default='')
 
     # only required for text datasets, to process the raw text
     parser.add_argument('--dataset', type=str, default='TREC-AToMiC/AToMiC-Texts-v0.2.1')

--- a/scripts/atomic/convert_embeddings.py
+++ b/scripts/atomic/convert_embeddings.py
@@ -1,0 +1,77 @@
+from reader import NumpyReader
+from tqdm import tqdm
+import pandas as pd
+import os
+import json
+import argparse
+from data import AtomicDataset
+
+def get_args_parser():
+    parser = argparse.ArgumentParser('Encode embeddings', add_help=False)
+    parser.add_argument('--inputs', type=str, help='directory of the AToMiC prebuilt topic embeddings', required=True)
+    parser.add_argument('--encode-type', type=str, default='text', choices=['text', 'image'], required=True)
+    parser.add_argument('--topics-output', type=str, help='directory to store topics file', required=True)
+    parser.add_argument('--embeddings-output', type=str, help='directory to store embeddings file', required=True)
+
+    # only required for text datasets, to process the raw text
+    parser.add_argument('--dataset', type=str, default='TREC-AToMiC/AToMiC-Texts-v0.2.1')
+    parser.add_argument('--id-column', type=str, default='text_id')
+    parser.add_argument('--split', type=str, default='validation')
+    parser.add_argument('--qrels', type=str, default='TREC-AToMiC/AToMiC-Qrels-v0.2')
+
+    return parser
+
+def main(args):
+    reader = NumpyReader(args.inputs)
+
+    if args.encode_type == 'text':
+        dataset = AtomicDataset(
+            data_name_or_path=args.dataset,
+            id_column=args.id_column,
+            qrel_name_or_path=args.qrels,
+        )
+        if args.split:
+            dataset = dataset.get_split(args.split)
+        dataset_dict = dataset.to_dict()
+        field_col=['page_title', 'section_title', 'hierachy', 'context_section_description', 'context_page_description']
+        
+    query_file = {'id': [], 'text': [], 'embedding': []}
+    topic_file = {}
+    for item in tqdm(reader, total=len(reader), desc='converting...'):
+        id = item['id']
+        vec = item['vector']
+        query_file['id'].append(id)
+        query_file['embedding'].append(vec)
+        if args.encode_type == 'text':
+            content = []
+            index = index = dataset_dict['text_id'].index(id)
+            if isinstance(field_col, list):
+                for field in field_col:
+                    # if the column val is a list, concat again
+                    value = dataset_dict[field][index]
+                    if isinstance(value, list):
+                        content.append(' '.join(value))
+                    else:
+                        content.append(value)
+            else:
+                content.append(dataset_dict[field_col][index])
+            
+            text = ' '.join(content)
+            query_file['text'].append(text)
+            topic_file[id] = {'title': text}
+        else:
+            # image dataset doesn't provide text to encode, so we use its ID to delineate it
+            query_file['text'].append(id)
+            topic_file[id] = {'title': id}
+
+    df = pd.DataFrame(query_file)
+    df.to_pickle(os.path.join(args.embeddings_output, 'embedding.pkl'))
+
+    with open(os.path.join(args.topics_output, 'topics.json'), 'w') as f:
+        json.dump(topic_file, f)
+
+if __name__ == "__main__":
+    parser = get_args_parser()
+    args = parser.parse_args()
+
+    main(args)

--- a/scripts/atomic/data.py
+++ b/scripts/atomic/data.py
@@ -1,0 +1,86 @@
+import json
+from collections import defaultdict
+from datasets import Dataset, load_dataset
+from tqdm.auto import tqdm
+from pathlib import Path
+
+class AtomicDataset(Dataset):
+    def __init__(
+        self,
+        data_name_or_path="TREC-AToMiC/AToMiC-Images-v0.2",
+        cache_file_path=None,
+        id_column="image_id",
+        qrel_name_or_path=None,
+    ):
+        dataset = load_dataset(data_name_or_path, split="train")
+        super().__init__(dataset._data)
+
+        if cache_file_path:
+            self.cache_file_path = cache_file_path
+        else:
+            # set default cache directory as .cache/
+            self.cache_file_path = Path(Path().resolve(), ".cache", f"{id_column}.row-index.json")
+
+        if not self.cache_file_path.parent.exists():
+            self.cache_file_path.parent.mkdir(parents=True)
+
+        self.id_index_dict = self._get_info_dict(id_column)
+
+        self.split_dict = None
+        if qrel_name_or_path:
+            self.cache_split_path = Path(Path().resolve(), ".cache", f"{id_column}.split.json")
+            qrels = load_dataset(qrel_name_or_path)
+            self.split_dict = self._get_split_dict(qrels, id_column)
+
+    def _get_info_dict(self, id_column):
+
+        if self.cache_file_path.exists():
+            with open(self.cache_file_path, "r") as f:
+                return json.load(f)
+        else:
+            id_index_dict = {
+                row: index
+                for index, row in tqdm(
+                    enumerate(self[id_column]),
+                    total=len(self),
+                    desc="build id2row dict",
+                )
+            }
+            with open(self.cache_file_path, "w") as f:
+                json.dump(id_index_dict, f)
+            return id_index_dict
+
+    def _get_split_dict(self, qrels, id_column):
+        if self.cache_split_path.exists():
+            with open(self.cache_split_path, "r") as f:
+                return json.load(f)
+        else:
+            train = set(qrels["train"][id_column])
+            validation = set(qrels["validation"][id_column])
+            test = set(qrels["test"][id_column])
+            split_dict = defaultdict(list)
+            for index, row in tqdm(
+                enumerate(self[id_column]), total=len(self), desc="build split dict"
+            ):
+                if row in train:
+                    split_dict["train"].append(index)
+                elif row in validation:
+                    split_dict["validation"].append(index)
+                elif row in test:
+                    split_dict["test"].append(index)
+                else:
+                    split_dict["other"].append(index)
+
+            with open(self.cache_split_path, "w") as f:
+                json.dump(split_dict, f)
+            return split_dict
+
+    def get_data_by_id(self, example_id):
+        row_index = self.id_index_dict[example_id]
+        return self[row_index]
+
+    def get_split(self, split):
+        if not self.split_dict:
+            raise ValueError
+        else:
+            return self.select(self.split_dict[split])

--- a/scripts/atomic/reader.py
+++ b/scripts/atomic/reader.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import numpy as np
+from tqdm import tqdm
+
+class NumpyReader:
+    def __init__(self, embedding_dir):
+        self.embedding_dir = embedding_dir
+        vec_files = list(Path(self.embedding_dir).glob('embeddings*.npy'))
+        self.vec_files = sorted(vec_files)
+        id_files = Path(embedding_dir).glob('ids*.txt')
+        self.id_files = sorted(id_files)
+        self.load_embeddings()
+        self.dim = self.vectors.shape[1]
+
+        
+    def load_embeddings(self):
+        self.vectors = []
+        self.ids = []
+        for f in tqdm(self.vec_files, total=len(self.vec_files)):
+            self.vectors.append(np.load(f))
+        
+        self.vectors = np.concatenate(self.vectors)
+    
+        for _id in tqdm(self.id_files, total=len(self.id_files)):
+            with open(_id, 'r') as f_id:
+                _ids = [l.strip('\n') for l in f_id.readlines()]
+                self.ids.extend(_ids)   
+    
+    def __iter__(self):
+        for _id, vec in zip(self.ids, self.vectors):
+            yield {'id': _id, 'vector': vec}
+    
+    def __len__(self):
+        return len(self.ids)


### PR DESCRIPTION
Converts raw numpy embeddings (`embeddings.npy` and `ids.txt`) files to pyserini-format topics (`topic.json`) and encoded queries (`embedding.pkl`) to be able to use `pyserini.search.faiss` to run baselines on the AToMiC dataset