### PR TITLE
Fix typo in searchFields method name

### DIFF
--- a/pyserini/search/lucene/_impact_searcher.py
+++ b/pyserini/search/lucene/_impact_searcher.py
@@ -151,7 +151,7 @@ class LuceneImpactSearcher:
         if not fields:
             hits = self.object.search(jquery, k)
         else:
-            hits = self.object.searchFields(jquery, jfields, k)
+            hits = self.object.search_fields(jquery, jfields, k)
 
         return hits
 
@@ -334,7 +334,7 @@ class SlimSearcher(LuceneImpactSearcher):
         if not fields:
             hits = self.object.search(jquery, search_k)
         else:
-            hits = self.object.searchFields(jquery, jfields, search_k)
+            hits = self.object.search_fields(jquery, jfields, search_k)
         hits = self.fast_rerank([sparse_encoded_query], {0: hits}, k)[0]
         return hits
     

--- a/pyserini/search/lucene/_searcher.py
+++ b/pyserini/search/lucene/_searcher.py
@@ -128,7 +128,7 @@ class LuceneSearcher:
             if not fields:
                 hits = self.object.search(query_generator, q, k)
             else:
-                hits = self.object.searchFields(query_generator, q, jfields, k)
+                hits = self.object.search_fields(query_generator, q, jfields, k)
         elif isinstance(q, JQuery):
             # Note that RM3 requires the notion of a query (string) to estimate the appropriate models. If we're just
             # given a Lucene query, it's unclear what the "query" is for this estimation. One possibility is to extract


### PR DESCRIPTION
Fix typo when searching with fields. Rename method `searchFields` to correct one `search_fields`

`AttributeError: 'io.anserini.search.SimpleSearcher' object has no attribute 'searchFields'`