### PR TITLE
Update conceptual-framework2.md with repro log

### DIFF
--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -377,3 +377,5 @@ Okay, that's it for this lesson.
 Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page, following the same format: use `yyyy-mm-dd`, make sure you're using a commit id that's on the main trunk of Pyserini, and use its 7-hexadecimal prefix for the link anchor text.
 
 ## Reproduction Log[*](reproducibility.md)
+
++ Results reproduced by [@sahel-sh](https://github.com/sahel-sh) on 2023-08-07 (commit [`9dab30f`](https://github.com/castorini/pyserini/commit/9dab30f1ac2b7672ffc65477f0d4279d30e97ad4))


### PR DESCRIPTION
Adding `sahel-sh` to `conceptual-framework2.md`'s repro log. 