### PR TITLE
Add an entry in Pyserini's Passage Ranking Experiment Reproduction Log for ugrad onboarding

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -314,3 +314,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Richard5678](https://github.com/richard5678) on 2023-06-13 (commit [`ccb6df5`](https://github.com/castorini/pyserini/commit/ccb6df50f37590b861e960989d98450b6de43850))
 + Results reproduced by [@pratyushpal](https://github.com/pratyushpal) on 2023-07-14 (commit [`760c22a`](https://github.com/castorini/pyserini/commit/760c22a3300a4fc3bfc83991140cdc1d6d7a35f9))
 + Results reproduced by [@sahel-sh](https://github.com/sahel-sh) on 2023-07-22 (commit [`863ff361`](https://github.com/castorini/pyserini/commit/863ff361fd671bb79b07f8f89a4b8121b7b46e8e))
++ Results reproduced by [@yilinjz](https://github.com/yilinjz) on 2023-08-25 (commit [`b57b583`](https://github.com/castorini/pyserini/commit/b57b5838bcb48ecbc478302d364eace787cc1b6f))


### PR DESCRIPTION

**OS**: macOS Ventura Version 13.5 
**Hardware**: M2 MacBook Pro (2023), 16 GB RAM 
**Conda**: 23.7.2 
**Python**: (Conda Environment): 3.8.17
**Java**: (Conda Environment) 11.0.13
**Maven**: (Conda Environment) 3.9.4

**Result**: I was able to replicate (most of) the Indexing, Retrieval & Evaluation steps with Pyserini on my machine with the above settings. Outputs are the same as listed in the document.  

**Additional Comment**: I encountered two (and only two) failed unit tests (from running “python -m unittest”) when following the “pyserini/docs/installation.md” file. Namely,

- test_remove_undjudged (tests.test_trectools.TestTrecTools)
- test_undjudged_keep (tests.test_trectools.TestTrecTools)

This seems to be caused by the **TREC evaluation tool**. When running the following command:

python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap \
   collections/msmarco-passage/qrels.dev.small.trec \
   runs/run.msmarco-passage.bm25tuned.trec

I got:

Running command: ['java', '-jar', '/Users/jasonzhang/.cache/pyserini/eval/jtreceval-0.0.5-jar-with-dependencies.jar', '-c', '-mrecall.1000', '-mmap', 'collections/msmarco-passage/qrels.dev.small.trec', 'runs/run.msmarco-passage.bm25tuned.trec']
Exception in thread "main" java.lang.UnsupportedOperationException: **Unsupported os/arch: trec_eval-macosx-aarch64**
        at uk.ac.gla.terrier.jtreceval.trec_eval.getTrecEvalBinary(trec_eval.java:80)
        at uk.ac.gla.terrier.jtreceval.trec_eval.<init>(trec_eval.java:130)
        at uk.ac.gla.terrier.jtreceval.trec_eval.main(trec_eval.java:262)

which seems to be **Apple's M1/M2 chips related**. There is surprisingly little information about this error on Google (it needs a better IR system!). As a side note, according to previous commits, it seems others have succeeded with M1 MacBooks (but no commit with M2). 

On the other hand, the official MS MARCO evaluation script worked perfectly fine for me.

For the next step, I'm planning on replicating this experiment again with my old laptop (which has intel chips), but before that I thought I'd record this issue here as potential reference for future users.

