### PR TITLE
Fix clprf integration tests due to path changes in anserini

### DIFF
--- a/integrations/clprf/test_clprf.py
+++ b/integrations/clprf/test_clprf.py
@@ -100,7 +100,7 @@ class TestSearchIntegration(unittest.TestCase):
                       --collection core17 --output {self.tmp}/core17_lr.txt --classifier lr ')
 
         cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                 {self.tmp}/core17_lr.txt'
 
         status = os.system(cmd)
@@ -128,7 +128,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_lr.txt'
 
         status = os.system(score_cmd)
@@ -150,7 +150,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_lr_rm3.txt'
 
         status = os.system(score_cmd)
@@ -172,7 +172,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_svm.txt'
 
         status = os.system(score_cmd)
@@ -194,7 +194,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_svm_rm3.txt'
 
         status = os.system(score_cmd)
@@ -216,7 +216,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_avg.txt'
 
         status = os.system(score_cmd)
@@ -238,7 +238,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_avg_rm3.txt'
 
         status = os.system(score_cmd)
@@ -273,7 +273,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_rrf.txt'
 
         status = os.system(score_cmd)
@@ -308,7 +308,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core17.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core17.txt \
                       {self.tmp}/core17_rrf_rm3.txt'
 
         status = os.system(score_cmd)
@@ -336,7 +336,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_lr.txt'
 
         status = os.system(score_cmd)
@@ -358,7 +358,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_lr_rm3.txt'
 
         status = os.system(score_cmd)
@@ -380,7 +380,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_svm.txt'
 
         status = os.system(score_cmd)
@@ -402,7 +402,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_svm_rm3.txt'
 
         status = os.system(score_cmd)
@@ -424,7 +424,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_avg.txt'
 
         status = os.system(score_cmd)
@@ -446,7 +446,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_avg_rm3.txt'
 
         status = os.system(score_cmd)
@@ -481,7 +481,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_rrf.txt'
 
         status = os.system(score_cmd)
@@ -516,7 +516,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.core18.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.core18.txt \
                       {self.tmp}/core18_rrf_rm3.txt'
 
         status = os.system(score_cmd)
@@ -544,7 +544,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_lr.txt'
 
         status = os.system(score_cmd)
@@ -566,7 +566,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_lr_rm3.txt'
 
         status = os.system(score_cmd)
@@ -588,7 +588,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_svm.txt'
 
         status = os.system(score_cmd)
@@ -610,7 +610,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_svm_rm3.txt'
 
         status = os.system(score_cmd)
@@ -632,7 +632,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_avg.txt'
 
         status = os.system(score_cmd)
@@ -654,7 +654,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_avg_rm3.txt'
 
         status = os.system(score_cmd)
@@ -689,7 +689,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_rrf.txt'
 
         status = os.system(score_cmd)
@@ -724,7 +724,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust04.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust04.txt \
                       {self.tmp}/robust04_rrf_rm3.txt'
 
         status = os.system(score_cmd)
@@ -752,7 +752,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_lr.txt'
 
         status = os.system(score_cmd)
@@ -774,7 +774,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_lr_rm3.txt'
 
         status = os.system(score_cmd)
@@ -796,7 +796,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_svm.txt'
 
         status = os.system(score_cmd)
@@ -818,7 +818,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_svm_rm3.txt'
 
         status = os.system(score_cmd)
@@ -840,7 +840,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_avg.txt'
 
         status = os.system(score_cmd)
@@ -862,7 +862,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_avg_rm3.txt'
 
         status = os.system(score_cmd)
@@ -897,7 +897,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_rrf.txt'
 
         status = os.system(score_cmd)
@@ -932,7 +932,7 @@ class TestSearchIntegration(unittest.TestCase):
         self.assertEqual(status, 0)
 
         score_cmd = f'{self.pyserini_eval_cmd} -m map -m P.30 \
-                      {self.anserini_root}/src/main/resources/topics-and-qrels/qrels.robust05.txt \
+                      {self.anserini_root}/tools/topics-and-qrels/qrels.robust05.txt \
                       {self.tmp}/robust05_rrf_rm3.txt'
 
         status = os.system(score_cmd)

--- a/integrations/clprf/test_trec_covid_r3.py
+++ b/integrations/clprf/test_trec_covid_r3.py
@@ -43,7 +43,7 @@ class TestSearchIntegration(unittest.TestCase):
         os.mkdir(f'{self.tmp}/runs')
 
         self.round3_runs = {
-            'https://raw.githubusercontent.com/castorini/anserini/master/src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt':
+            'https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/qrels.covid-round3-cumulative.txt':
                 'dfccc32efd58a8284ae411e5c6b27ce9',
         }
 

--- a/integrations/clprf/test_trec_covid_r4.py
+++ b/integrations/clprf/test_trec_covid_r4.py
@@ -44,7 +44,7 @@ class TestSearchIntegration(unittest.TestCase):
         os.mkdir(f'{self.tmp}/runs')
 
         self.round4_runs = {
-            'https://raw.githubusercontent.com/castorini/anserini/master/src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt':
+            'https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/qrels.covid-round4-cumulative.txt':
                 '7a5c27e8e052c49ff72d557051825973',
         }
 

--- a/scripts/classifier_prf/cross_validate.py
+++ b/scripts/classifier_prf/cross_validate.py
@@ -39,7 +39,7 @@ def get_trec_eval_cmd(anserini_root: str):
 
 
 def get_qrels_path(anserini_root: str, collection: str):
-    return f"{anserini_root}/src/main/resources/topics-and-qrels/qrels.{collection}.txt"
+    return f"{anserini_root}/tools/topics-and-qrels/qrels.{collection}.txt"
 
 
 def read_topics_alpha_map(anserini_root, collection, run_file, classifier, rm3: bool):


### PR DESCRIPTION
qrels removed from src/main/resources/topics-and-qrels/ in anserini; use tools/topics-and-qrels/ instead.