### PR TITLE
Adds reproduction logs for onboarding docs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -315,3 +315,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@pratyushpal](https://github.com/pratyushpal) on 2023-07-14 (commit [`760c22a`](https://github.com/castorini/pyserini/commit/760c22a3300a4fc3bfc83991140cdc1d6d7a35f9))
 + Results reproduced by [@sahel-sh](https://github.com/sahel-sh) on 2023-07-22 (commit [`863ff361`](https://github.com/castorini/pyserini/commit/863ff361fd671bb79b07f8f89a4b8121b7b46e8e))
 + Results reproduced by [@yilinjz](https://github.com/yilinjz) on 2023-08-25 (commit [`b57b583`](https://github.com/castorini/pyserini/commit/b57b5838bcb48ecbc478302d364eace787cc1b6f))
++ Results reproduced by [@UShivani3](https://github.com/UShivani3) on 2023-08-29 (commit [`d9da49e`](https://github.com/castorini/pyserini/commit/d9da49eb3a23fb9daa26399a2e27a5efc73beb71))


### PR DESCRIPTION
Environment:
Apple m1

While following `docs/installation.md` faced trouble with pip installation of `Pyserini`. 

Following are the steps I followed before encountering the error:

1. Environment creation and it's activation:
```
$ conda create -n pyserini python=3.8
$ conda activate pyserini
```

2. JDK 11 installation:
`$ conda install -c conda-forge openjdk=11
`

3. Pip installation for Pyserini:
`pip install pyserini`

Referring this GitHub [issue](https://github.com/nmslib/nmslib/issues/476) I was able to overcome the issue with `nmslib` (previously the build was getting stuck for both `lightgbm` and `nsmlib`). However, the one with `lightgbm` still persists.

Screenshot for the error:
<img width="1260" alt="Screenshot 2023-08-29 at 1 53 58 PM" src="https://github.com/castorini/pyserini/assets/56012908/2498d0db-fe4f-4727-b11f-396d52e5101b">