### PR TITLE
Update _impact_searcher.py to use renamed java functions.

### DIFF
--- a/pyserini/search/lucene/_impact_searcher.py
+++ b/pyserini/search/lucene/_impact_searcher.py
@@ -243,7 +243,7 @@ class LuceneImpactSearcher:
         Document
             :class:`Document` corresponding to the ``docid``.
         """
-        lucene_document = self.object.document(docid)
+        lucene_document = self.object.doc(docid)
         if lucene_document is None:
             return None
         return Document(lucene_document)
@@ -356,7 +356,7 @@ class LuceneImpactSearcher:
         Document
             :class:`Document` whose ``field`` is ``id``.
         """
-        lucene_document = self.object.documentByField(field, q)
+        lucene_document = self.object.doc_by_field(field, q)
         if lucene_document is None:
             return None
         return Document(lucene_document)


### PR DESCRIPTION
https://github.com/castorini/anserini/commit/e475cc4e885f5fbb223533d75a2da7abaa618c6c renames `document/documentByField` functions to `doc/doc_by_field`. This cl changes the function calls in _impact_searcher.py to match the new names to fix the following error:
````
File ".../lib/python3.10/site-packages/pyserini/search/lucene/_impact_searcher.py", line 248, in doc
    lucene_document = self.object.document(docid)
AttributeError: 'io.anserini.search.SimpleImpactSearcher' object has no attribute 'document'
```