### PR TITLE
Add OpenAI text-embedding-ada-002 API-based encoding

### DIFF
--- a/pyserini/encode/__init__.py
+++ b/pyserini/encode/__init__.py
@@ -26,3 +26,4 @@ from ._cached_data import CachedDataQueryEncoder
 from ._tok_freq import TokFreqQueryEncoder
 from ._splade import SpladeQueryEncoder
 from ._slim import SlimQueryEncoder
+from ._openai import OpenAIDocumentEncoder, OpenAIQueryEncoder, OPENAI_API_RETRY_DELAY

--- a/pyserini/encode/__main__.py
+++ b/pyserini/encode/__main__.py
@@ -20,6 +20,7 @@ import sys
 from pyserini.encode import JsonlRepresentationWriter, FaissRepresentationWriter, JsonlCollectionIterator
 from pyserini.encode import DprDocumentEncoder, TctColBertDocumentEncoder, AnceDocumentEncoder, AggretrieverDocumentEncoder, AutoDocumentEncoder
 from pyserini.encode import UniCoilDocumentEncoder
+from pyserini.encode import OpenAIDocumentEncoder, OPENAI_API_RETRY_DELAY
 
 
 encoder_class_map = {
@@ -29,6 +30,7 @@ encoder_class_map = {
     "ance": AnceDocumentEncoder,
     "sentence-transformers": AutoDocumentEncoder,
     "unicoil": UniCoilDocumentEncoder,
+    "openai-api": OpenAIDocumentEncoder,
     "auto": AutoDocumentEncoder,
 }
 ALLOWED_POOLING_OPTS = ["cls","mean"]
@@ -105,7 +107,7 @@ if __name__ == '__main__':
     encoder_parser = commands.add_parser('encoder')
     encoder_parser.add_argument('--encoder', type=str, help='encoder name or path', required=True)
     encoder_parser.add_argument('--encoder-class', type=str, required=False, default=None,
-                                choices=["dpr", "bpr", "tct_colbert", "ance", "sentence-transformers", "auto"],
+                                choices=["dpr", "bpr", "tct_colbert", "ance", "sentence-transformers", "openai-api", "auto"],
                                 help='which query encoder class to use. `default` would infer from the args.encoder')
     encoder_parser.add_argument('--fields', help='fields to encode', nargs='+', default=['text'], required=False)
     encoder_parser.add_argument('--batch-size', type=int, help='batch size', default=64, required=False)
@@ -116,6 +118,8 @@ if __name__ == '__main__':
     encoder_parser.add_argument('--fp16', action='store_true', default=False)
     encoder_parser.add_argument('--add-sep', action='store_true', default=False)
     encoder_parser.add_argument('--pooling', type=str, default='cls', help='for auto classes, allow the ability to dictate pooling strategy', required=False)
+    encoder_parser.add_argument('--use-openai', help='use OpenAI text-embedding-ada-002 to retreive embeddings', action='store_true', default=False)
+    encoder_parser.add_argument('--rate-limit', type=int, help='rate limit of the requests per minute for OpenAI embeddings', default=3500, required=False)
 
     args = parse_args(parser, commands)
     delimiter = args.input.delimiter.replace("\\n", "\n")  # argparse would add \ prior to the passed '\n\n'
@@ -133,15 +137,26 @@ if __name__ == '__main__':
     collection_iterator = JsonlCollectionIterator(args.input.corpus, args.input.fields, args.input.docid_field, delimiter)
 
     with embedding_writer:
-        for batch_info in collection_iterator(args.encoder.batch_size, args.input.shard_id, args.input.shard_num):
-            kwargs = {
-                'texts': batch_info['text'],
-                'titles': batch_info['title'] if 'title' in args.encoder.fields else None,
-                'expands': batch_info['expand'] if 'expand' in args.encoder.fields else None,
-                'fp16': args.encoder.fp16,
-                'max_length': args.encoder.max_length,
-                'add_sep': args.encoder.add_sep,
-            }
-            embeddings = encoder.encode(**kwargs)
-            batch_info['vector'] = embeddings
-            embedding_writer.write(batch_info, args.input.fields)
+        if args.encoder.use_openai:
+            for batch_info in collection_iterator(int(args.encoder.rate_limit // (60 / OPENAI_API_RETRY_DELAY)), args.input.shard_id, args.input.shard_num):
+                kwargs = {
+                    'texts': batch_info['text'],
+                    'titles': batch_info['title'] if 'title' in args.encoder.fields else None,
+                    'max_length': args.encoder.max_length,
+                }
+                embeddings = encoder.encode(**kwargs)
+                batch_info['vector'] = embeddings
+                embedding_writer.write(batch_info, args.input.fields)
+        else:
+            for batch_info in collection_iterator(args.encoder.batch_size, args.input.shard_id, args.input.shard_num):
+                kwargs = {
+                    'texts': batch_info['text'],
+                    'titles': batch_info['title'] if 'title' in args.encoder.fields else None,
+                    'expands': batch_info['expand'] if 'expand' in args.encoder.fields else None,
+                    'fp16': args.encoder.fp16,
+                    'max_length': args.encoder.max_length,
+                    'add_sep': args.encoder.add_sep,
+                }
+                embeddings = encoder.encode(**kwargs)
+                batch_info['vector'] = embeddings
+                embedding_writer.write(batch_info, args.input.fields)

--- a/pyserini/encode/_openai.py
+++ b/pyserini/encode/_openai.py
@@ -1,0 +1,58 @@
+import openai
+from tenacity import retry, wait_random_exponential, stop_after_attempt
+from typing import List
+import os
+import random
+import time
+from pyserini.encode import DocumentEncoder, QueryEncoder
+import tiktoken
+import numpy as np
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+openai.organization = os.getenv("OPENAI_ORG_KEY")
+OPENAI_API_RETRY_DELAY = 5
+
+def retry_with_delay(func, max_retries: int = 10, errors: tuple = (openai.error.RateLimitError)):
+    def wrapper(*args, **kwargs):
+        num_retries = 0
+        while True:
+            try:
+                return func(*args, **kwargs)
+            except errors as e:
+                num_retries += 1
+                if num_retries > max_retries:
+                    raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
+                time.sleep(OPENAI_API_RETRY_DELAY)
+            except Exception as e:
+                raise e
+    return wrapper
+
+class OpenAIDocumentEncoder(DocumentEncoder):
+    def __init__(self, model_name: str = 'text-embedding-ada-002', tokenizer_name: str = 'cl100k_base', device = None):
+        self.model = model_name
+        self.tokenizer = tiktoken.get_encoding(tokenizer_name)
+
+    @retry_with_delay
+    def get_embeddings(self, inputs: List[str]):
+        response = openai.Embedding.create(input=inputs, model=self.model)
+        embeddings = [item['embedding'] for item in response['data']]
+        return np.array(embeddings)
+
+    def encode(self, texts: List[str], titles = None, max_length: int = 512, **kwargs):
+        texts = [f'{title} {text}' for title, text in zip(titles, texts)] if titles is not None else texts
+        inputs = self.tokenizer.encode_batch(text=texts)
+        inputs = [embedding[:max_length] for embedding in inputs]
+        return self.get_embeddings(inputs)
+    
+class OpenAIQueryEncoder(QueryEncoder):
+    def __init__(self, model_name: str = 'text-embedding-ada-002', tokenizer_name: str = 'cl100k_base', device = None):
+        self.model = model_name
+        self.tokenizer = tiktoken.get_encoding(tokenizer_name)
+
+    # @retry_with_delay TODO: implement query encoder, uncomment when implemented
+    def get_embedding(self, text: str):
+        return np.array(openai.Embedding.create(input=text, model=self.model)['data'][0]['embedding'])
+
+    def encode(self, text: str, max_length: int = 512, **kwargs):
+        inputs = self.tokenizer.encode(text=text)[:max_length]
+        return self.get_embedding(inputs)

--- a/pyserini/encode/_openai.py
+++ b/pyserini/encode/_openai.py
@@ -1,8 +1,6 @@
 import openai
-from tenacity import retry, wait_random_exponential, stop_after_attempt
 from typing import List
 import os
-import random
 import time
 from pyserini.encode import DocumentEncoder, QueryEncoder
 import tiktoken
@@ -49,7 +47,7 @@ class OpenAIQueryEncoder(QueryEncoder):
         self.model = model_name
         self.tokenizer = tiktoken.get_encoding(tokenizer_name)
 
-    # @retry_with_delay TODO: implement query encoder, uncomment when implemented
+    @retry_with_delay
     def get_embedding(self, text: str):
         return np.array(openai.Embedding.create(input=text, model=self.model)['data'][0]['embedding'])
 

--- a/pyserini/encode/_openai.py
+++ b/pyserini/encode/_openai.py
@@ -10,7 +10,7 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 openai.organization = os.getenv("OPENAI_ORG_KEY")
 OPENAI_API_RETRY_DELAY = 5
 
-def retry_with_delay(func, max_retries: int = 10, errors: tuple = (openai.error.RateLimitError)):
+def retry_with_delay(func, delay: int = OPENAI_API_RETRY_DELAY, max_retries: int = 10, errors: tuple = (openai.error.RateLimitError)):
     def wrapper(*args, **kwargs):
         num_retries = 0
         while True:
@@ -20,13 +20,13 @@ def retry_with_delay(func, max_retries: int = 10, errors: tuple = (openai.error.
                 num_retries += 1
                 if num_retries > max_retries:
                     raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
-                time.sleep(OPENAI_API_RETRY_DELAY)
+                time.sleep(delay)
             except Exception as e:
                 raise e
     return wrapper
 
 class OpenAIDocumentEncoder(DocumentEncoder):
-    def __init__(self, model_name: str = 'text-embedding-ada-002', tokenizer_name: str = 'cl100k_base', device = None):
+    def __init__(self, model_name: str = 'text-embedding-ada-002', tokenizer_name: str = 'cl100k_base', **kwargs):
         self.model = model_name
         self.tokenizer = tiktoken.get_encoding(tokenizer_name)
 

--- a/pyserini/encode/query.py
+++ b/pyserini/encode/query.py
@@ -53,6 +53,7 @@ if __name__ == '__main__':
     parser.add_argument('--output', type=str, help='path to stored encoded queries', required=True)
     parser.add_argument('--device', type=str, help='device cpu or cuda [cuda:0, cuda:1...]',
                         default='cpu', required=False)
+    parser.add_argument('--max-length', type=int, help='max length', default=256, required=False)
     args = parser.parse_args()
 
     encoder = init_encoder(args.encoder, device=args.device)
@@ -63,7 +64,7 @@ if __name__ == '__main__':
     query_texts = []
     query_embeddings = []
     for topic_id, text in tqdm(query_iterator):
-        embedding = encoder.encode(text)
+        embedding = encoder.encode(text, max_length=args.max_length)
         if isinstance(embedding, dict):
             is_sparse = True
             pseudo_str = []

--- a/pyserini/encode/query.py
+++ b/pyserini/encode/query.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 from pyserini.query_iterator import DefaultQueryIterator
 from pyserini.encode import DprQueryEncoder, TctColBertQueryEncoder, AnceQueryEncoder, AutoQueryEncoder
-from pyserini.encode import UniCoilQueryEncoder, SpladeQueryEncoder
+from pyserini.encode import UniCoilQueryEncoder, SpladeQueryEncoder, OpenAIQueryEncoder
 
 
 def init_encoder(encoder, device):
@@ -37,6 +37,8 @@ def init_encoder(encoder, device):
         return UniCoilQueryEncoder(encoder, device=device)
     elif 'splade' in encoder.lower():
         return SpladeQueryEncoder(encoder, device=device)
+    elif 'openai-api' in encoder.lower():
+        return OpenAIQueryEncoder()
     else:
         return AutoQueryEncoder(encoder, device=device)
 

--- a/pyserini/search/__init__.py
+++ b/pyserini/search/__init__.py
@@ -24,6 +24,7 @@ from .faiss import DenseSearchResult, PRFDenseSearchResult, FaissSearcher, Binar
     DprQueryEncoder, BprQueryEncoder, DkrrDprQueryEncoder, TctColBertQueryEncoder, AnceQueryEncoder, AggretrieverQueryEncoder, AutoQueryEncoder
 from .faiss import AnceEncoder
 from .faiss import DenseVectorAveragePrf, DenseVectorRocchioPrf, DenseVectorAncePrf
+from .faiss import OpenAIQueryEncoder
 
 
 __all__ = ['JQuery',
@@ -54,6 +55,7 @@ __all__ = ['JQuery',
            'AnceEncoder',
            'AnceQueryEncoder',
            'AggretrieverQueryEncoder',
+           'OpenAIQueryEncoder',
            'AutoQueryEncoder',
            'DenseVectorAveragePrf',
            'DenseVectorRocchioPrf',

--- a/pyserini/search/faiss/__init__.py
+++ b/pyserini/search/faiss/__init__.py
@@ -15,11 +15,13 @@
 #
 
 from ._searcher import DenseSearchResult, PRFDenseSearchResult, FaissSearcher, BinaryDenseSearcher, QueryEncoder, \
-    DprQueryEncoder, BprQueryEncoder, DkrrDprQueryEncoder, TctColBertQueryEncoder, AnceQueryEncoder, AggretrieverQueryEncoder, AutoQueryEncoder
+    DprQueryEncoder, BprQueryEncoder, DkrrDprQueryEncoder, TctColBertQueryEncoder, AnceQueryEncoder, AggretrieverQueryEncoder, OpenAIQueryEncoder, \
+    AutoQueryEncoder
 
 from ._model import AnceEncoder
 from._prf import DenseVectorAveragePrf, DenseVectorRocchioPrf, DenseVectorAncePrf
 
 __all__ = ['DenseSearchResult', 'PRFDenseSearchResult', 'FaissSearcher', 'BinaryDenseSearcher', 'QueryEncoder',
            'DprQueryEncoder', 'BprQueryEncoder', 'DkrrDprQueryEncoder', 'TctColBertQueryEncoder', 'AnceEncoder',
-           'AnceQueryEncoder', 'AggretrieverQueryEncoder', 'AutoQueryEncoder', 'DenseVectorAveragePrf', 'DenseVectorRocchioPrf', 'DenseVectorAncePrf']
+           'AnceQueryEncoder', 'AggretrieverQueryEncoder', 'AutoQueryEncoder', 'DenseVectorAveragePrf', 'DenseVectorRocchioPrf', 'DenseVectorAncePrf',
+           'OpenAIQueryEncoder']

--- a/pyserini/search/faiss/_searcher.py
+++ b/pyserini/search/faiss/_searcher.py
@@ -25,6 +25,8 @@ from typing import Dict, List, Union, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+import openai
+import tiktoken
 
 from transformers import (AutoModel, AutoTokenizer, BertModel, BertTokenizer, BertTokenizerFast,
                           DPRQuestionEncoder, DPRQuestionEncoderTokenizer, RobertaTokenizer)
@@ -310,6 +312,32 @@ class AnceQueryEncoder(QueryEncoder):
         embeddings = self.model(inputs["input_ids"]).detach().cpu().numpy()
         return embeddings
 
+class OpenAIQueryEncoder(QueryEncoder):
+    from pyserini.encode._openai import retry_with_delay
+
+    def __init__(self, encoder_dir: str = None, encoded_query_dir: str = None,
+                 tokenizer_name: str = None, max_length: int = 512, **kwargs):
+        super().__init__(encoded_query_dir)
+        if encoder_dir:
+            openai.api_key = os.getenv("OPENAI_API_KEY")
+            openai.organization = os.getenv("OPENAI_ORG_KEY")
+            self.model = encoder_dir
+            self.tokenizer = tiktoken.get_encoding(tokenizer_name)
+            self.max_length = max_length
+            self.has_model = True
+        if (not self.has_model) and (not self.has_encoded_query):
+            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
+
+    @retry_with_delay
+    def get_embedding(self, text: str):
+        return np.array(openai.Embedding.create(input=text, model=self.model)['data'][0]['embedding'])
+
+    def encode(self, query: str, **kwargs):
+        if self.has_model:
+            inputs = self.tokenizer.encode(text=query)[:self.max_length]
+            return self.get_embedding(inputs)
+        else:
+            return super().encode(query)
 
 class AutoQueryEncoder(QueryEncoder):
 


### PR DESCRIPTION
DEPENDENCIES ADDED: 
```
openai             0.28.0
tiktoken           0.4.0
```

TODO: incorporate OpenAI API query encoder into `pyserini.search`

To reproduce the [nfcorpus](https://github.com/castorini/pyserini/blob/master/docs/experiments-nfcorpus.md) experiment:

Indexing: 
```bash
python -m pyserini.encode \
  input   --corpus collections/nfcorpus/corpus.jsonl \
          --fields title text \
  output  --embeddings indexes/faiss.nfcorpus.contriever-msmacro \
          --to-faiss \
  encoder --encoder text-embedding-ada-002 \
          --encoder-class openai-api \
          --use-openai \
          --rate-limit 3500 \
          --device cpu \
          --dimension 1536 \
          --fields title text
```

Query Encoding:
```bash
python pyserini/encode/query.py \
--topics collections/nfcorpus/queries.tsv \
--encoder openai-api \
--max-length 512 \
--output openai-api/embedding.pkl
```

Retrieval with encoded queries from prior:
```bash
python -m pyserini.search.faiss \
  --encoded-queries openai-api \
  --index indexes/faiss.nfcorpus.contriever-msmacro \
  --topics collections/nfcorpus/queries.tsv \
  --output runs/run.beir-contriever-msmarco.nfcorpus.txt \
  --batch 128 --threads 16 \
  --hits 1000
```

Retrieval whilst encoding on the fly:
```bash
python -m pyserini.search.faiss \
  --encoder text-embedding-ada-002 \
  --encoder-class openai-api \
  --tokenizer cl100k_base \
  --index indexes/faiss.nfcorpus.contriever-msmacro \
  --topics collections/nfcorpus/queries.tsv \
  --output runs/run.beir-contriever-msmarco.nfcorpus.txt \
  --max-length 512 \
  --batch 128 --threads 16 \
  --hits 1000
```

Results: 
```
ndcg_cut_10             all     0.3676
```
