### PR TITLE
Add onboarding repro logs

### DIFF
--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -387,3 +387,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@lucedes27](https://github.com/lucedes27) on 2023-09-10 (commit [`54014af`](https://github.com/castorini/pyserini/commit/54014af8fe4bf4ba75daba9119acac94c7191cdb))
 + Results reproduced by [@MojTabaa4](https://github.com/MojTabaa4) on 2023-09-14 (commit [`d4a829d`](https://github.com/castorini/pyserini/commit/d4a829d18043783ef3dec2a8adce50e4061ba99a))
 + Results reproduced by [@MelvinMo](https://github.com/MelvinMo) on 2023-09-24 (commit [`7d18f4b`](https://github.com/castorini/pyserini/commit/7d18f4bd3f98d4f901dc061ffd93a1c656e32d0d))
++ Results reproduced by [@Mofetoluwa](https://github.com/Mofetoluwa) on 2023-10-02 (commit [`88f1f5b`](https://github.com/castorini/pyserini/commit/88f1f5b653021e249f45bb85c3297bb6af862c3d))


### PR DESCRIPTION
Adding reproduction logs for:
- conceptual-framework2.md

Environment:
- Results were reproduced on orca
- Apache Maven: 3.9.2
- Java version: 11.0.13
- Python: 3.8.16

Results:
All results were reproduced as expected.