### PR TITLE
Tweak regression numbers to pin to tuna results as ground truth

### DIFF
--- a/pyserini/2cr/miracl.py
+++ b/pyserini/2cr/miracl.py
@@ -382,13 +382,8 @@ def run_conditions(args):
                             if math.isclose(score, float(expected[metric])):
                                 result_str = ok_str
                             # Flaky tests
-                            elif (name == 'mdpr-tied-pft-msmarco.hi' and split == 'train'
-                                  and math.isclose(score, float(expected[metric]), abs_tol=2e-4)) or \
-                                 (name == 'bm25-mdpr-tied-pft-msmarco-hybrid.zh'
-                                  and split == 'dev' and metric == 'nDCG@10'
-                                  and math.isclose(score, float(expected[metric]), abs_tol=2e-4)) or \
-                                 (name == 'mdpr-tied-pft-msmarco-ft-all.ru'
-                                  # Flaky on Jimmy's Mac Studio (Apple M1 Ultra), nDCG@10: 0.3932 -> expected 0.3933
+                            elif (name == 'bm25-mdpr-tied-pft-msmarco-hybrid.zh'
+                                  # Flaky on Jimmy's Mac Studio (Apple M1 Ultra), nDCG@10: 0.5255 -> expected 0.5254
                                   and split == 'dev' and metric == 'nDCG@10'
                                   and math.isclose(score, float(expected[metric]), abs_tol=2e-4)) or \
                                  (name == 'bm25-mdpr-tied-pft-msmarco-hybrid.te'
@@ -396,9 +391,9 @@ def run_conditions(args):
                                   and split == 'train' and metric == 'nDCG@10'
                                   and math.isclose(score, float(expected[metric]), abs_tol=2e-4)) or \
                                  (name == 'mcontriever-tied-pft-msmarco.id'
-                                  # Flaky on Jimmy's Mac Studio (Apple M1 Ultra), nDCG@10: 0.3748 -> expected 0.3749
+                                  # Flaky on Jimmy's Mac Studio (Apple M1 Ultra), nDCG@10: 0.3749 -> expected 0.3748
                                   and split == 'train' and metric == 'nDCG@10'
-                                  and math.isclose(score, float(expected[metric]), abs_tol=2e-4)):
+                                  and math.isclose(score, float(expected[metric]), abs_tol=1e-4)):
                                 result_str = okish_str
                             else:
                                 result_str = fail_str + f' expected {expected[metric]:.4f}'

--- a/pyserini/2cr/miracl.yaml
+++ b/pyserini/2cr/miracl.yaml
@@ -562,7 +562,7 @@ conditions:
             R@100: 0.8188
       - split: dev
         scores:
-          - nDCG@10: 0.3933
+          - nDCG@10: 0.3932
             R@100: 0.6707
   - name: mdpr-tied-pft-msmarco-ft-all.sw
     eval_key: miracl-v1.0-sw
@@ -792,7 +792,7 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG@10: 0.6000
+          - nDCG@10: 0.5998
             R@100: 0.8717
       - split: dev
         scores:
@@ -1072,7 +1072,7 @@ conditions:
     splits:
       - split: train
         scores:
-          - nDCG@10: 0.3749
+          - nDCG@10: 0.3748
             R@100: 0.7955
       - split: dev
         scores:

--- a/pyserini/2cr/mrtydi.py
+++ b/pyserini/2cr/mrtydi.py
@@ -265,18 +265,6 @@ def run_conditions(args):
                                                                      trec_eval_metric_definitions[metric], runfile))
                             if math.isclose(score, float(expected[metric])):
                                 result_str = ok_str
-                            # Flaky test: small difference on orca
-                            elif name == 'mdpr-tied-pft-nq.te' and split == 'dev' \
-                                    and math.isclose(score, float(expected[metric]), abs_tol=2e-4):
-                                result_str = okish_str
-                            # Flaky test: small difference on orca
-                            elif name == 'mdpr-tied-pft-msmarco-ft-all.ko' and split == 'train' \
-                                    and math.isclose(score, float(expected[metric]), abs_tol=4e-4):
-                                result_str = okish_str
-                            # Flaky test: small difference on Mac Studio (M1)
-                            elif name == 'mdpr-tied-pft-msmarco.th' and split == 'train' \
-                                    and math.isclose(score, float(expected[metric]), abs_tol=3e-4):
-                                result_str = okish_str
                             else:
                                 result_str = fail_str + f' expected {expected[metric]:.4f}'
                             print(f'      {metric:7}: {score:.4f} {result_str}')

--- a/pyserini/2cr/msmarco-v1-passage.yaml
+++ b/pyserini/2cr/msmarco-v1-passage.yaml
@@ -8,7 +8,7 @@ conditions:
       - topic_key: msmarco-passage-dev-subset
         eval_key: msmarco-passage-dev-subset
         scores:
-          - MRR@10: 0.3300
+          - MRR@10: 0.3301
             R@1K: 0.9811
       - topic_key: dl19-passage
         eval_key: dl19-passage

--- a/pyserini/2cr/msmarco.py
+++ b/pyserini/2cr/msmarco.py
@@ -517,11 +517,6 @@ def run_conditions(args):
                                     runfile))
                             if math.isclose(score, float(expected[metric])):
                                 result_str = ok_str
-                            # Flaky test on Jimmy's iMac Pro and Jimmy's Mac Studio
-                            elif args.collection == 'msmarco-v1-passage' and name == 'splade-pp-ed-rocchio-pytorch' \
-                                    and topic_key == 'msmarco-passage-dev-subset' \
-                                    and metric == 'MRR@10' and abs(score-float(expected[metric])) <= 0.0001:
-                                result_str = okish_str
                             # Flaky test on Jimmy's Mac Studio
                             elif args.collection == 'msmarco-v1-passage' and name == 'distilbert-kd-tasb-avg-prf-pytorch' \
                                     and topic_key == 'msmarco-passage-dev-subset' \

--- a/scripts/jobs.regressions-all.txt
+++ b/scripts/jobs.regressions-all.txt
@@ -1,0 +1,9 @@
+python -m pyserini.2cr.msmarco --collection v1-passage --all --directory runs/ --display-commands > logs/log.msmarco-v1-passage 2>&1
+python -m pyserini.2cr.msmarco --collection v1-doc     --all --directory runs/ --display-commands > logs/log.msmarco-v1-doc 2>&1
+python -m pyserini.2cr.msmarco --collection v2-passage --all --directory runs/ --display-commands > logs/log.msmarco-v2-passage 2>&1
+python -m pyserini.2cr.msmarco --collection v2-doc     --all --directory runs/ --display-commands > logs/log.msmarco-v2-doc 2>&1
+python -m pyserini.2cr.miracl --all --directory runs/ --display-commands > logs/log.miracl 2>&1
+python -m pyserini.2cr.mrtydi --all --directory runs/ --display-commands > logs/log.mrtydi 2>&1
+python -m pyserini.2cr.beir   --all --directory runs/ --display-commands > logs/log.beir 2>&1
+python -m pyserini.2cr.odqa   --all --directory runs/ --topic tqa --display-commands > logs/log.odqa.tqa 2>&1
+python -m pyserini.2cr.odqa   --all --directory runs/ --topic nq  --display-commands > logs/log.odqa.nq 2>&1


### PR DESCRIPTION
After recent upgrade of `tuna` to Unbuntu 22, we're using the machine a "ground truth" for the regression numbers. This PR pins the results to `tuna` - thus small changes from before.