### PR TITLE
Fix wiki corpora experiments doc

### DIFF
--- a/docs/experiments-wiki-corpora.md
+++ b/docs/experiments-wiki-corpora.md
@@ -89,7 +89,7 @@ Retrieval can be performed in Pyserini as we make the encoded-queries for Natura
 ### Natural Questions
 ```bash
 python -m pyserini.search.faiss \
-  --index wiki-all-6-3-all-dpr2-multi \
+  --index wiki-all-6-3.dpr2-multi-retriever \
   --topics nq-test \
   --encoded-queries wiki-all-6-3-dpr2-multi-nq-test \
   --output runs/run.wiki-all-6-3.nq-test.dpr2.trec \
@@ -118,7 +118,7 @@ Top100  accuracy: 0.9175
 ### TriviaQA
 ```bash
 python -m pyserini.search.faiss \
-  --index wiki-all-6-3-dpr2-multi \
+  --index wiki-all-6-3.dpr2-multi-retriever \
   --topics dpr-trivia-test \
   --encoded-queries wiki-all-6-3-dpr2-multi-dpr-trivia-test \
   --output runs/run.wiki-all-6-3.dpr-trivia-test.dpr2.trec \

--- a/pyserini/encoded_query_info.py
+++ b/pyserini/encoded_query_info.py
@@ -415,7 +415,7 @@ QUERY_INFO = {
         "total_queries": 11313,
         "downloaded": False
      },
-     "wiki-6-3-all-dpr2-multi-nq-test": {
+     "wiki-all-6-3-dpr2-multi-nq-test": {
         "description": "NQ test set questions encoded by castorini/wiki-all-6-3-multi-dpr2-query-encoder.",
         "urls": [
             "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-wiki-all-6-3-dpr2-multi-retriever-nq-test-20230103-186fa7.tar.gz",
@@ -425,7 +425,7 @@ QUERY_INFO = {
         "total_queries": 3610,
         "downloaded": False
      },
-     "wiki-6-3-all-dpr2-multi-dpr-trivia-test": {
+     "wiki-all-6-3-dpr2-multi-dpr-trivia-test": {
         "description": "TriviaQA test set questions encoded by castorini/wiki-all-6-3-multi-dpr2-query-encoder.",
         "urls": [
             "https://github.com/castorini/pyserini-data/raw/main/encoded-queries/query-embedding-wiki-all-6-3-dpr2-multi-retriever-dpr-trivia-test-20230103-186fa7.tar.gz",


### PR DESCRIPTION
The faiss indexes were renamed as of commit: https://github.com/castorini/pyserini/commit/b841b53037ab3042a5f5f2d6e14f7a316da07c11. Also, the encoded queries names were inconsistent.