### PR TITLE
Update OpenAI embeddings API to version >= 1.0.0

### DIFF
--- a/pyserini/encode/_openai.py
+++ b/pyserini/encode/_openai.py
@@ -8,9 +8,10 @@ import numpy as np
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 openai.organization = os.getenv("OPENAI_ORG_KEY")
+client = openai.OpenAI()
 OPENAI_API_RETRY_DELAY = 5
 
-def retry_with_delay(func, delay: int = OPENAI_API_RETRY_DELAY, max_retries: int = 10, errors: tuple = (openai.error.RateLimitError)):
+def retry_with_delay(func, delay: int = OPENAI_API_RETRY_DELAY, max_retries: int = 10, errors: tuple = (openai.RateLimitError)):
     def wrapper(*args, **kwargs):
         num_retries = 0
         while True:
@@ -49,7 +50,7 @@ class OpenAIQueryEncoder(QueryEncoder):
 
     @retry_with_delay
     def get_embedding(self, text: str):
-        return np.array(openai.Embedding.create(input=text, model=self.model)['data'][0]['embedding'])
+        return np.array(client.embeddings.create(input=text, model=self.model)['data'][0]['embedding'])
 
     def encode(self, text: str, max_length: int = 512, **kwargs):
         inputs = self.tokenizer.encode(text=text)[:max_length]

--- a/pyserini/search/faiss/_searcher.py
+++ b/pyserini/search/faiss/_searcher.py
@@ -321,6 +321,7 @@ class OpenAIQueryEncoder(QueryEncoder):
         if encoder_dir:
             openai.api_key = os.getenv("OPENAI_API_KEY")
             openai.organization = os.getenv("OPENAI_ORG_KEY")
+            self.client = openai.OpenAI()
             self.model = encoder_dir
             self.tokenizer = tiktoken.get_encoding(tokenizer_name)
             self.max_length = max_length
@@ -330,7 +331,7 @@ class OpenAIQueryEncoder(QueryEncoder):
 
     @retry_with_delay
     def get_embedding(self, text: str):
-        return np.array(openai.Embedding.create(input=text, model=self.model)['data'][0]['embedding'])
+        return np.array(self.client.embeddings.create(input=text, model=self.model)['data'][0]['embedding'])
 
     def encode(self, query: str, **kwargs):
         if self.has_model:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ onnxruntime>=1.8.1
 lightgbm>=3.3.2
 spacy>=3.2.1
 pyyaml
-openai>=0.28.0
+openai>=1.0.0
 tiktoken>=0.4.0


### PR DESCRIPTION
Fixes some deprecation issues after OpenAI's 1.0.0 update