### PR TITLE
Refactor search code to complement Anserini refactoring

### DIFF
--- a/pyserini/output_writer.py
+++ b/pyserini/output_writer.py
@@ -21,7 +21,7 @@ from abc import ABC, abstractmethod
 from enum import Enum, unique
 from typing import List
 
-from pyserini.search import JLuceneSearcherResult
+from pyserini.search import JScoredDoc
 
 
 @unique
@@ -55,7 +55,7 @@ class OutputWriter(ABC):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self._file.close()
 
-    def hits_iterator(self, hits: List[JLuceneSearcherResult]):
+    def hits_iterator(self, hits: List[JScoredDoc]):
         unique_docs = set()
         rank = 1
         for hit in hits:
@@ -76,24 +76,24 @@ class OutputWriter(ABC):
                 break
 
     @abstractmethod
-    def write(self, topic: str, hits: List[JLuceneSearcherResult]):
+    def write(self, topic: str, hits: List[JScoredDoc]):
         raise NotImplementedError()
 
 
 class TrecWriter(OutputWriter):
-    def write(self, topic: str, hits: List[JLuceneSearcherResult]):
+    def write(self, topic: str, hits: List[JScoredDoc]):
         for docid, rank, score, _ in self.hits_iterator(hits):
             self._file.write(f'{topic} Q0 {docid} {rank} {score:.6f} {self.tag}\n')
 
 
 class MsMarcoWriter(OutputWriter):
-    def write(self, topic: str, hits: List[JLuceneSearcherResult]):
+    def write(self, topic: str, hits: List[JScoredDoc]):
         for docid, rank, score, _ in self.hits_iterator(hits):
             self._file.write(f'{topic}\t{docid}\t{rank}\n')
 
 
 class KiltWriter(OutputWriter):
-    def write(self, topic: str, hits: List[JLuceneSearcherResult]):
+    def write(self, topic: str, hits: List[JScoredDoc]):
         datapoint = self.topics[topic]
         provenance = []
         for docid, rank, score, _ in self.hits_iterator(hits):

--- a/pyserini/search/__init__.py
+++ b/pyserini/search/__init__.py
@@ -16,8 +16,8 @@
 
 from ._base import JQuery, JQueryGenerator, JDisjunctionMaxQueryGenerator, get_topics,\
     get_topics_with_reader, get_qrels_file, get_qrels
-from .lucene import JLuceneSearcherResult, LuceneSimilarities, LuceneFusionSearcher, LuceneSearcher
-from .lucene import JImpactSearcherResult, LuceneImpactSearcher
+from .lucene import JScoredDoc, LuceneSimilarities, LuceneFusionSearcher, LuceneSearcher
+from .lucene import JScoredDoc, LuceneImpactSearcher
 from ._deprecated import SimpleSearcher, ImpactSearcher, SimpleFusionSearcher
 
 from .faiss import DenseSearchResult, PRFDenseSearchResult, FaissSearcher, BinaryDenseSearcher, QueryEncoder, \
@@ -31,9 +31,9 @@ __all__ = ['JQuery',
            'LuceneSimilarities',
            'LuceneFusionSearcher',
            'LuceneSearcher',
-           'JLuceneSearcherResult',
+           'JScoredDoc',
            'LuceneImpactSearcher',
-           'JImpactSearcherResult',
+           'JScoredDoc',
            'JDisjunctionMaxQueryGenerator',
            'JQueryGenerator',
            'get_topics',

--- a/pyserini/search/lucene/__init__.py
+++ b/pyserini/search/lucene/__init__.py
@@ -16,14 +16,14 @@
 
 from ._geo_searcher import LuceneGeoSearcher
 from ._impact_searcher import JScoredDoc, LuceneImpactSearcher, SlimSearcher
-from ._searcher import JScoredDoc, LuceneSimilarities, \
-    LuceneFusionSearcher, LuceneSearcher
+from ._searcher import JScoredDoc, LuceneSimilarities, LuceneFusionSearcher, LuceneSearcher
+from ._hnsw_searcher import LuceneHnswDenseSearcher
 
 __all__ = ['JScoredDoc',
-           'JScoredDoc',
            'LuceneFusionSearcher',
            'LuceneGeoSearcher',
            'LuceneImpactSearcher',
            'LuceneSearcher',
+           'LuceneHnswDenseSearcher',
            'SlimSearcher',
            'LuceneSimilarities']

--- a/pyserini/search/lucene/__init__.py
+++ b/pyserini/search/lucene/__init__.py
@@ -15,12 +15,12 @@
 #
 
 from ._geo_searcher import LuceneGeoSearcher
-from ._impact_searcher import JImpactSearcherResult, LuceneImpactSearcher, SlimSearcher
-from ._searcher import JLuceneSearcherResult, LuceneSimilarities, \
+from ._impact_searcher import JScoredDoc, LuceneImpactSearcher, SlimSearcher
+from ._searcher import JScoredDoc, LuceneSimilarities, \
     LuceneFusionSearcher, LuceneSearcher
 
-__all__ = ['JImpactSearcherResult',
-           'JLuceneSearcherResult',
+__all__ = ['JScoredDoc',
+           'JScoredDoc',
            'LuceneFusionSearcher',
            'LuceneGeoSearcher',
            'LuceneImpactSearcher',

--- a/pyserini/search/lucene/_geo_searcher.py
+++ b/pyserini/search/lucene/_geo_searcher.py
@@ -38,7 +38,7 @@ JLongPoint = autoclass('org.apache.lucene.document.LongPoint')
 
 # Wrappers around Anserini classes
 JGeoSearcher = autoclass('io.anserini.search.SimpleGeoSearcher')
-JGeoSearcherResult = autoclass('io.anserini.search.SimpleSearcher$Result')
+JGeoSearcherResult = autoclass('io.anserini.search.ScoredDoc')
 
 
 class LuceneGeoSearcher:

--- a/pyserini/search/lucene/_geo_searcher.py
+++ b/pyserini/search/lucene/_geo_searcher.py
@@ -38,7 +38,7 @@ JLongPoint = autoclass('org.apache.lucene.document.LongPoint')
 
 # Wrappers around Anserini classes
 JGeoSearcher = autoclass('io.anserini.search.SimpleGeoSearcher')
-JGeoSearcherResult = autoclass('io.anserini.search.ScoredDoc')
+JScoredDoc = autoclass('io.anserini.search.ScoredDoc')
 
 
 class LuceneGeoSearcher:
@@ -54,7 +54,7 @@ class LuceneGeoSearcher:
         self.index_dir = index_dir
         self.object = JGeoSearcher(index_dir)
 
-    def search(self, q: JQuery, k: int = 10, sort: JSort = None) -> List[JGeoSearcherResult]:
+    def search(self, q: JQuery, k: int = 10, sort: JSort = None) -> List[JScoredDoc]:
         """Search the collection.
 
         Parameters
@@ -68,7 +68,7 @@ class LuceneGeoSearcher:
 
         Returns
         -------
-        List[JGeoSearcherResult]
+        List[JScoredDoc]
             List of search results.
         """
         if sort:

--- a/pyserini/search/lucene/_hnsw_searcher.py
+++ b/pyserini/search/lucene/_hnsw_searcher.py
@@ -1,0 +1,54 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+This module provides Pyserini's Python search interface to Anserini. The main entry point is the ``LuceneSearcher``
+class, which wraps the Java class with the same name in Anserini.
+"""
+
+import logging
+from typing import Dict, List, Optional, Union
+
+from pyserini.fusion import FusionMethod, reciprocal_rank_fusion
+from pyserini.index import Document, IndexReader
+from pyserini.pyclass import autoclass, JFloat, JArrayList, JHashMap
+from pyserini.search import JQuery, JQueryGenerator
+from pyserini.trectools import TrecRun
+from pyserini.util import download_prebuilt_index, get_sparse_indexes_info
+
+logger = logging.getLogger(__name__)
+
+# Wrappers around Anserini classes
+JHnswDenseSearcher = autoclass('io.anserini.search.HnswDenseSearcher')
+JHnswDenseSearcher = autoclass('io.anserini.search.HnswDenseSearcher$Args')
+JScoredDoc = autoclass('io.anserini.search.JScoredDoc')
+
+
+class LuceneHnswDenseSearcher:
+    """Wrapper class for ``SimpleSearcher`` in Anserini.
+
+    Parameters
+    ----------
+    index_dir : str
+        Path to Lucene index directory.
+    """
+
+    def __init__(self, index_dir: str, prebuilt_index_name=None):
+        self.index_dir = index_dir
+        self.object = JLuceneSearcher(index_dir)
+        self.num_docs = self.object.get_total_num_docs()
+        # Keep track if self is a known pre-built index.
+        self.prebuilt_index_name = prebuilt_index_name

--- a/pyserini/search/lucene/_impact_searcher.py
+++ b/pyserini/search/lucene/_impact_searcher.py
@@ -53,7 +53,7 @@ class LuceneImpactSearcher:
         QueryEncoder to encode query text
     """
 
-    def __init__(self, index_dir: str, query_encoder: Union[QueryEncoder, str], min_idf=0, encoder_type: str='pytorch', prebuilt_index_name = None):
+    def __init__(self, index_dir: str, query_encoder: Union[QueryEncoder, str], min_idf=0, encoder_type: str = 'pytorch', prebuilt_index_name=None):
         self.index_dir = index_dir
         self.idf = self._compute_idf(index_dir)
         self.min_idf = min_idf
@@ -76,7 +76,7 @@ class LuceneImpactSearcher:
             raise ValueError(f'Invalid encoder type: {encoder_type}')
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str, query_encoder: Union[QueryEncoder, str], min_idf=0, encoder_type: str='pytorch'):
+    def from_prebuilt_index(cls, prebuilt_index_name: str, query_encoder: Union[QueryEncoder, str], min_idf=0, encoder_type: str = 'pytorch'):
         """Build a searcher from a pre-built index; download the index if necessary.
 
         Parameters
@@ -92,7 +92,7 @@ class LuceneImpactSearcher:
 
         Returns
         -------
-        LuceneSearcher
+        LuceneImpactSearcher
             Searcher built from the prebuilt index.
         """
         print(f'Attempting to initialize pre-built index {prebuilt_index_name}.')
@@ -136,7 +136,7 @@ class LuceneImpactSearcher:
 
         Returns
         -------
-        List[JImpactSearcherResult]
+        List[JScoredDoc]
             List of search results.
         """
 
@@ -179,7 +179,7 @@ class LuceneImpactSearcher:
 
         Returns
         -------
-        Dict[str, List[JImpactSearcherResult]]
+        Dict[str, List[JScoredDoc]]
             Dictionary holding the search results, with the query ids as keys and the corresponding lists of search
             results as the values.
         """
@@ -224,7 +224,7 @@ class LuceneImpactSearcher:
         self.object.set_analyzer(analyzer)
 
     def set_language(self, language):
-        """Set language of LuceneSearcher"""
+        """Set language of LuceneSearcher."""
         self.object.set_language(language)
 
     def doc(self, docid: Union[str, int]) -> Optional[Document]:
@@ -290,7 +290,6 @@ class LuceneImpactSearcher:
 
     def set_rocchio(self):
         self.object.set_rocchio()
-
 
     def set_rocchio(self, top_fb_terms=10, top_fb_docs=10, bottom_fb_terms=10, bottom_fb_docs=10,
                     alpha=1, beta=0.75, gamma=0, debug=False, use_negative=False):
@@ -393,6 +392,7 @@ class LuceneImpactSearcher:
 
 SlimResult = namedtuple("SlimResult", "docid score")
 
+
 def maxsim(entry):
     q_embed, d_embeds, d_lens, qid, scores, docids = entry
     if len(d_embeds) == 0:
@@ -406,6 +406,7 @@ def maxsim(entry):
         start += d_len
     scores, docids = list(zip(*sorted(list(zip(scores, docids)), key=lambda x: -x[0])))
     return qid, scores, docids
+
 
 class SlimSearcher(LuceneImpactSearcher):
     def __init__(self, encoded_corpus, *args, **kwargs):

--- a/pyserini/search/lucene/_impact_searcher.py
+++ b/pyserini/search/lucene/_impact_searcher.py
@@ -38,8 +38,8 @@ from pyserini.util import download_prebuilt_index, download_encoded_corpus
 logger = logging.getLogger(__name__)
 
 # Wrappers around Anserini classes
-JImpactSearcher = autoclass('io.anserini.search.SimpleImpactSearcher')
-JImpactSearcherResult = autoclass('io.anserini.search.SimpleImpactSearcher$Result')
+JSimpleImpactSearcher = autoclass('io.anserini.search.SimpleImpactSearcher')
+JScoredDoc = autoclass('io.anserini.search.ScoredDoc')
 
 
 class LuceneImpactSearcher:
@@ -57,7 +57,7 @@ class LuceneImpactSearcher:
         self.index_dir = index_dir
         self.idf = self._compute_idf(index_dir)
         self.min_idf = min_idf
-        self.object = JImpactSearcher(index_dir)
+        self.object = JSimpleImpactSearcher(index_dir)
         self.num_docs = self.object.get_total_num_docs()
         self.encoder_type = encoder_type
         self.query_encoder = query_encoder
@@ -122,7 +122,7 @@ class LuceneImpactSearcher:
         """Display information about available prebuilt indexes."""
         print("Not Implemented")
 
-    def search(self, q: str, k: int = 10, fields=dict()) -> List[JImpactSearcherResult]:
+    def search(self, q: str, k: int = 10, fields=dict()) -> List[JScoredDoc]:
         """Search the collection.
 
         Parameters
@@ -161,7 +161,7 @@ class LuceneImpactSearcher:
         return hits
 
     def batch_search(self, queries: List[str], qids: List[str],
-                     k: int = 10, threads: int = 1, fields=dict()) -> Dict[str, List[JImpactSearcherResult]]:
+                     k: int = 10, threads: int = 1, fields=dict()) -> Dict[str, List[JScoredDoc]]:
         """Search the collection concurrently for multiple queries, using multiple threads.
 
         Parameters
@@ -429,7 +429,7 @@ class SlimSearcher(LuceneImpactSearcher):
         print(f'Initializing {prebuilt_index_name}...')
         return cls(encoded_corpus, index_dir, query_encoder, min_idf)
 
-    def search(self, q: str, k: int = 10, fields=dict()) -> List[JImpactSearcherResult]:
+    def search(self, q: str, k: int = 10, fields=dict()) -> List[JScoredDoc]:
         jfields = JHashMap()
         for (field, boost) in fields.items():
             jfields.put(field, JFloat(boost))
@@ -450,7 +450,7 @@ class SlimSearcher(LuceneImpactSearcher):
         return hits
     
     def batch_search(self, queries: List[str], qids: List[str],
-                     k: int = 10, threads: int = 1, fields=dict()) -> Dict[str, List[JImpactSearcherResult]]:
+                     k: int = 10, threads: int = 1, fields=dict()) -> Dict[str, List[JScoredDoc]]:
         query_lst = JArrayList()
         qid_lst = JArrayList()
         sparse_encoded_queries = {}

--- a/pyserini/search/lucene/_searcher.py
+++ b/pyserini/search/lucene/_searcher.py
@@ -33,8 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 # Wrappers around Anserini classes
-JLuceneSearcher = autoclass('io.anserini.search.SimpleSearcher')
-JLuceneSearcherResult = autoclass('io.anserini.search.SimpleSearcher$Result')
+JSimpleSearcher = autoclass('io.anserini.search.SimpleSearcher')
+JScoredDoc = autoclass('io.anserini.search.ScoredDoc')
 
 
 class LuceneSearcher:
@@ -48,7 +48,7 @@ class LuceneSearcher:
 
     def __init__(self, index_dir: str, prebuilt_index_name=None):
         self.index_dir = index_dir
-        self.object = JLuceneSearcher(index_dir)
+        self.object = JSimpleSearcher(index_dir)
         self.num_docs = self.object.get_total_num_docs()
         # Keep track if self is a known pre-built index.
         self.prebuilt_index_name = prebuilt_index_name
@@ -102,7 +102,7 @@ class LuceneSearcher:
         get_sparse_indexes_info()
 
     def search(self, q: Union[str, JQuery], k: int = 10, query_generator: JQueryGenerator = None,
-               fields=dict(), strip_segment_id=False, remove_dups=False) -> List[JLuceneSearcherResult]:
+               fields=dict(), strip_segment_id=False, remove_dups=False) -> List[JScoredDoc]:
         """Search the collection.
 
         Parameters
@@ -171,7 +171,7 @@ class LuceneSearcher:
         return filtered_hits
 
     def batch_search(self, queries: List[str], qids: List[str], k: int = 10, threads: int = 1,
-                     query_generator: JQueryGenerator = None, fields = dict()) -> Dict[str, List[JLuceneSearcherResult]]:
+                     query_generator: JQueryGenerator = None, fields = dict()) -> Dict[str, List[JScoredDoc]]:
         """Search the collection concurrently for multiple queries, using multiple threads.
 
         Parameters
@@ -450,7 +450,7 @@ class LuceneFusionSearcher:
     def get_searchers(self) -> List[LuceneSearcher]:
         return self.searchers
 
-    def search(self, q: Union[str, JQuery], k: int = 10, query_generator: JQueryGenerator = None, strip_segment_id=False, remove_dups=False) -> List[JLuceneSearcherResult]:
+    def search(self, q: Union[str, JQuery], k: int = 10, query_generator: JQueryGenerator = None, strip_segment_id=False, remove_dups=False) -> List[JScoredDoc]:
         trec_runs, docid_to_search_result = list(), dict()
 
         for searcher in self.searchers:
@@ -473,7 +473,7 @@ class LuceneFusionSearcher:
         return self.convert_to_search_result(fused_run, docid_to_search_result)
 
     @staticmethod
-    def convert_to_search_result(run: TrecRun, docid_to_search_result: Dict[str, JLuceneSearcherResult]) -> List[JLuceneSearcherResult]:
+    def convert_to_search_result(run: TrecRun, docid_to_search_result: Dict[str, JScoredDoc]) -> List[JScoredDoc]:
         search_results = []
 
         for _, _, docid, _, score, _ in run.to_numpy():

--- a/pyserini/search/lucene/_searcher.py
+++ b/pyserini/search/lucene/_searcher.py
@@ -191,7 +191,7 @@ class LuceneSearcher:
 
         Returns
         -------
-        Dict[str, List[JLuceneSearcherResult]]
+        Dict[str, List[JScoredDoc]]
             Dictionary holding the search results, with the query ids as keys and the corresponding lists of search
             results as the values.
         """

--- a/tests/test_index_otf.py
+++ b/tests/test_index_otf.py
@@ -21,7 +21,7 @@ import random
 from typing import List
 
 from pyserini.index.lucene import LuceneIndexer, IndexReader, JacksonObjectMapper
-from pyserini.search.lucene import JLuceneSearcherResult, LuceneSearcher
+from pyserini.search.lucene import JScoredDoc, LuceneSearcher
 
 
 class TestIndexOTF(unittest.TestCase):
@@ -51,7 +51,7 @@ class TestIndexOTF(unittest.TestCase):
         hits = searcher.search('semantic networks')
 
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(1, len(hits))
         self.assertEqual('CACM-2274', hits[0].docid)
         self.assertAlmostEqual(1.53650, hits[0].score, places=5)
@@ -73,7 +73,7 @@ class TestIndexOTF(unittest.TestCase):
         hits = searcher.search('semantic networks')
 
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(1, len(hits))
         self.assertEqual('CACM-2274', hits[0].docid)
         self.assertAlmostEqual(1.53650, hits[0].score, places=5)
@@ -89,7 +89,7 @@ class TestIndexOTF(unittest.TestCase):
         hits = searcher.search('semantic networks')
 
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(1, len(hits))
         self.assertEqual('CACM-2274', hits[0].docid)
         self.assertAlmostEqual(1.53650, hits[0].score, places=5)
@@ -105,7 +105,7 @@ class TestIndexOTF(unittest.TestCase):
         hits = searcher.search('semantic networks')
 
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(1, len(hits))
         self.assertEqual('CACM-2274', hits[0].docid)
         self.assertAlmostEqual(1.53650, hits[0].score, places=5)
@@ -121,7 +121,7 @@ class TestIndexOTF(unittest.TestCase):
         hits = searcher.search('semantic networks')
 
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(1, len(hits))
         self.assertEqual('CACM-2274', hits[0].docid)
         self.assertAlmostEqual(1.53650, hits[0].score, places=5)
@@ -141,7 +141,7 @@ class TestIndexOTF(unittest.TestCase):
         hits = searcher.search('semantic networks')
 
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(1, len(hits))
         self.assertEqual('CACM-2274', hits[0].docid)
         self.assertAlmostEqual(0.62610, hits[0].score, places=5)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -22,7 +22,7 @@ from random import randint
 from typing import List, Dict
 from urllib.request import urlretrieve
 
-from pyserini.search.lucene import LuceneSearcher, JLuceneSearcherResult
+from pyserini.search.lucene import LuceneSearcher, JScoredDoc
 from pyserini.index.lucene import Document
 
 
@@ -73,30 +73,30 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
 
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(hits[0].docid, 'CACM-3134')
         self.assertEqual(hits[0].lucene_docid, 3133)
-        self.assertEqual(len(hits[0].contents), 1500)
-        self.assertEqual(len(hits[0].raw), 1532)
         self.assertAlmostEqual(hits[0].score, 4.76550, places=5)
 
         # Test accessing the raw Lucene document and fetching fields from it:
         self.assertEqual(hits[0].lucene_document.getField('id').stringValue(), 'CACM-3134')
-        self.assertEqual(hits[0].lucene_document.get('id'), 'CACM-3134')  # simpler call, same result as above
+        self.assertEqual(hits[0].lucene_document.get('id'), 'CACM-3134')      # simpler call, same result as above
+        self.assertEqual(len(hits[0].lucene_document.getField('contents').stringValue()), 1500)
+        self.assertEqual(len(hits[0].lucene_document.get('contents')), 1500)  # simpler call, same result as above
         self.assertEqual(len(hits[0].lucene_document.getField('raw').stringValue()), 1532)
-        self.assertEqual(len(hits[0].lucene_document.get('raw')), 1532)   # simpler call, same result as above
+        self.assertEqual(len(hits[0].lucene_document.get('raw')), 1532)       # simpler call, same result as above
 
-        self.assertTrue(isinstance(hits[9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[9], JScoredDoc))
         self.assertEqual(hits[9].docid, 'CACM-2516')
         self.assertAlmostEqual(hits[9].score, 4.21740, places=5)
 
         hits = self.searcher.search('search')
 
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(hits[0].docid, 'CACM-3058')
         self.assertAlmostEqual(hits[0].score, 2.85760, places=5)
 
-        self.assertTrue(isinstance(hits[9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[9], JScoredDoc))
         self.assertEqual(hits[9].docid, 'CACM-3040')
         self.assertAlmostEqual(hits[9].score, 2.68780, places=5)
 
@@ -107,20 +107,20 @@ class TestSearch(unittest.TestCase):
         self.assertTrue(isinstance(results, Dict))
 
         self.assertTrue(isinstance(results['q1'], List))
-        self.assertTrue(isinstance(results['q1'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][0], JScoredDoc))
         self.assertEqual(results['q1'][0].docid, 'CACM-3134')
         self.assertAlmostEqual(results['q1'][0].score, 4.76550, places=5)
 
-        self.assertTrue(isinstance(results['q1'][9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][9], JScoredDoc))
         self.assertEqual(results['q1'][9].docid, 'CACM-2516')
         self.assertAlmostEqual(results['q1'][9].score, 4.21740, places=5)
 
         self.assertTrue(isinstance(results['q2'], List))
-        self.assertTrue(isinstance(results['q2'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][0], JScoredDoc))
         self.assertEqual(results['q2'][0].docid, 'CACM-3058')
         self.assertAlmostEqual(results['q2'][0].score, 2.85760, places=5)
 
-        self.assertTrue(isinstance(results['q2'][9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][9], JScoredDoc))
         self.assertEqual(results['q2'][9].docid, 'CACM-3040')
         self.assertAlmostEqual(results['q2'][9].score, 2.68780, places=5)
 
@@ -133,20 +133,20 @@ class TestSearch(unittest.TestCase):
         self.assertTrue(isinstance(results, Dict))
 
         self.assertTrue(isinstance(results['q1'], List))
-        self.assertTrue(isinstance(results['q1'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][0], JScoredDoc))
         self.assertEqual(results['q1'][0].docid, 'CACM-3134')
         self.assertAlmostEqual(results['q1'][0].score, 7.18830, places=5)
 
-        self.assertTrue(isinstance(results['q1'][9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][9], JScoredDoc))
         self.assertEqual(results['q1'][9].docid, 'CACM-2140')
         self.assertAlmostEqual(results['q1'][9].score, 5.57970, places=5)
 
         self.assertTrue(isinstance(results['q2'], List))
-        self.assertTrue(isinstance(results['q2'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][0], JScoredDoc))
         self.assertEqual(results['q2'][0].docid, 'CACM-3041')
         self.assertAlmostEqual(results['q2'][0].score, 6.14870, places=5)
 
-        self.assertTrue(isinstance(results['q2'][9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][9], JScoredDoc))
         self.assertEqual(results['q2'][9].docid, 'CACM-2251')
         self.assertAlmostEqual(results['q2'][9].score, 4.97380, places=5)
 
@@ -155,7 +155,7 @@ class TestSearch(unittest.TestCase):
 
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(len(hits), 100)
 
     def test_batch_k(self):
@@ -164,10 +164,10 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(results, Dict))
         self.assertTrue(isinstance(results['q1'], List))
-        self.assertTrue(isinstance(results['q1'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][0], JScoredDoc))
         self.assertEqual(len(results['q1']), 100)
         self.assertTrue(isinstance(results['q2'], List))
-        self.assertTrue(isinstance(results['q2'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][0], JScoredDoc))
         self.assertEqual(len(results['q2']), 100)
 
     def test_basic_fields(self):
@@ -176,7 +176,7 @@ class TestSearch(unittest.TestCase):
 
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(len(hits), 42)
 
     def test_batch_fields(self):
@@ -187,10 +187,10 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(results, Dict))
         self.assertTrue(isinstance(results['q1'], List))
-        self.assertTrue(isinstance(results['q1'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][0], JScoredDoc))
         self.assertEqual(len(results['q1']), 42)
         self.assertTrue(isinstance(results['q2'], List))
-        self.assertTrue(isinstance(results['q2'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][0], JScoredDoc))
         self.assertEqual(len(results['q2']), 42)
 
     def test_different_similarity(self):

--- a/tests/test_search_lucene8.py
+++ b/tests/test_search_lucene8.py
@@ -22,7 +22,7 @@ from random import randint
 from typing import List, Dict
 from urllib.request import urlretrieve
 
-from pyserini.search.lucene import LuceneSearcher, JLuceneSearcherResult
+from pyserini.search.lucene import LuceneSearcher, JScoredDoc
 
 
 class TestSearch(unittest.TestCase):
@@ -54,30 +54,30 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
 
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(hits[0].docid, 'CACM-3134')
         self.assertEqual(hits[0].lucene_docid, 3133)
-        self.assertEqual(len(hits[0].contents), 1500)
-        self.assertEqual(len(hits[0].raw), 1532)
         self.assertAlmostEqual(hits[0].score, 4.7655, places=4)
 
         # Test accessing the raw Lucene document and fetching fields from it:
         self.assertEqual(hits[0].lucene_document.getField('id').stringValue(), 'CACM-3134')
-        self.assertEqual(hits[0].lucene_document.get('id'), 'CACM-3134')  # simpler call, same result as above
+        self.assertEqual(hits[0].lucene_document.get('id'), 'CACM-3134')      # simpler call, same result as above
+        self.assertEqual(len(hits[0].lucene_document.getField('contents').stringValue()), 1500)
+        self.assertEqual(len(hits[0].lucene_document.get('contents')), 1500)  # simpler call, same result as above
         self.assertEqual(len(hits[0].lucene_document.getField('raw').stringValue()), 1532)
-        self.assertEqual(len(hits[0].lucene_document.get('raw')), 1532)   # simpler call, same result as above
+        self.assertEqual(len(hits[0].lucene_document.get('raw')), 1532)       # simpler call, same result as above
 
-        self.assertTrue(isinstance(hits[9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[9], JScoredDoc))
         self.assertEqual(hits[9].docid, 'CACM-2516')
         self.assertAlmostEqual(hits[9].score, 4.2174, places=4)
 
         hits = self.searcher.search('search')
 
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(hits[0].docid, 'CACM-3058')
         self.assertAlmostEqual(hits[0].score, 2.8576, places=4)
 
-        self.assertTrue(isinstance(hits[9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[9], JScoredDoc))
         self.assertEqual(hits[9].docid, 'CACM-3040')
         self.assertAlmostEqual(hits[9].score, 2.6878, places=4)
 
@@ -88,20 +88,20 @@ class TestSearch(unittest.TestCase):
         self.assertTrue(isinstance(results, Dict))
 
         self.assertTrue(isinstance(results['q1'], List))
-        self.assertTrue(isinstance(results['q1'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][0], JScoredDoc))
         self.assertEqual(results['q1'][0].docid, 'CACM-3134')
         self.assertAlmostEqual(results['q1'][0].score, 4.7655, places=4)
 
-        self.assertTrue(isinstance(results['q1'][9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][9], JScoredDoc))
         self.assertEqual(results['q1'][9].docid, 'CACM-2516')
         self.assertAlmostEqual(results['q1'][9].score, 4.2174, places=4)
 
         self.assertTrue(isinstance(results['q2'], List))
-        self.assertTrue(isinstance(results['q2'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][0], JScoredDoc))
         self.assertEqual(results['q2'][0].docid, 'CACM-3058')
         self.assertAlmostEqual(results['q2'][0].score, 2.8576, places=4)
 
-        self.assertTrue(isinstance(results['q2'][9], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][9], JScoredDoc))
         self.assertEqual(results['q2'][9].docid, 'CACM-3040')
         self.assertAlmostEqual(results['q2'][9].score, 2.6878, places=4)
 
@@ -110,7 +110,7 @@ class TestSearch(unittest.TestCase):
 
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(len(hits), 100)
 
     def test_batch_k(self):
@@ -119,10 +119,10 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(results, Dict))
         self.assertTrue(isinstance(results['q1'], List))
-        self.assertTrue(isinstance(results['q1'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][0], JScoredDoc))
         self.assertEqual(len(results['q1']), 100)
         self.assertTrue(isinstance(results['q2'], List))
-        self.assertTrue(isinstance(results['q2'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][0], JScoredDoc))
         self.assertEqual(len(results['q2']), 100)
 
     def test_basic_fields(self):
@@ -131,7 +131,7 @@ class TestSearch(unittest.TestCase):
 
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(hits, List))
-        self.assertTrue(isinstance(hits[0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(hits[0], JScoredDoc))
         self.assertEqual(len(hits), 42)
 
     def test_batch_fields(self):
@@ -142,10 +142,10 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(3204, self.searcher.num_docs)
         self.assertTrue(isinstance(results, Dict))
         self.assertTrue(isinstance(results['q1'], List))
-        self.assertTrue(isinstance(results['q1'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q1'][0], JScoredDoc))
         self.assertEqual(len(results['q1']), 42)
         self.assertTrue(isinstance(results['q2'], List))
-        self.assertTrue(isinstance(results['q2'][0], JLuceneSearcherResult))
+        self.assertTrue(isinstance(results['q2'][0], JScoredDoc))
         self.assertEqual(len(results['q2']), 42)
 
     def test_different_similarity(self):


### PR DESCRIPTION
Counterpart of https://github.com/castorini/anserini/pull/2310

+ Major change is the introduction of `ScoredDoc`: Searchers now use ScoredDoc instead of class-specific Result objects.
+ Introduced simple bindings to Lucene HNSW searcher.