### PR TITLE
Fixed broken tests 

### DIFF
--- a/integrations/lucenesearcher_anserini_checker.py
+++ b/integrations/lucenesearcher_anserini_checker.py
@@ -28,7 +28,7 @@ class LuceneSearcherAnseriniMatchChecker:
         self.pyserini_topics = pyserini_topics
 
         self.anserini_base_cmd = os.path.join(self.anserini_root,
-                                              'target/appassembler/bin/SearchCollection -topicreader Trec')
+                                              'target/appassembler/bin/SearchCollection -topicReader Trec')
         self.pyserini_base_cmd = 'python -m pyserini.search.lucene'
 
         self.eval_base_cmd = os.path.join(eval_root, 'tools/eval/trec_eval.9.0.4/trec_eval -m map -m P.30')

--- a/pyserini/search/hybrid/__main__.py
+++ b/pyserini/search/hybrid/__main__.py
@@ -109,8 +109,10 @@ if __name__ == '__main__':
                                        args.run.topics,
                                        args.dense.encoded_queries,
                                        args.dense.device,
-                                       args.dense.query_prefix,
-                                       args.dense.max_length)
+                                       args.dense.max_length,
+                                       args.dense.pooling,
+                                       args.dense.l2_norm,
+                                       args.dense.query_prefix)
 
     if os.path.exists(args.dense.index):
         # create searcher from index directory

--- a/scripts/repro_matrix/run_all_odqa.py
+++ b/scripts/repro_matrix/run_all_odqa.py
@@ -1,3 +1,19 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import argparse
 import os
 
@@ -9,11 +25,11 @@ if __name__ == '__main__':
     parser.add_argument('--display-commands', action='store_true', default=False, help='Display command.')
     parser.add_argument('--full-topk', action='store_true', default=False, help='Run topk 5-1000, default is topk 5-100')
     args = parser.parse_args()
-    
+
     cmd = f'python -m pyserini.2cr.odqa ' + \
-                f'--topic {args.topics} ' + \
-                f'--all '
-    
+          f'--topic {args.topics} ' + \
+          f'--all '
+
     if args.dry_run:
         cmd += f'--dry-run '
     if args.display_commands:
@@ -22,5 +38,5 @@ if __name__ == '__main__':
         cmd += f'--full-topk '
     if args.skip_eval:
         cmd += f'--skip-eval '
-    
+
     os.system(cmd)


### PR DESCRIPTION
+ from Anserini refactoring (renamed args)
+ from pooling and l2norm config for autoencoder (https://github.com/castorini/pyserini/pull/1722/)