### PR TITLE
Updated reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -307,3 +307,4 @@ Results reproduced by [@AndreSlavescu](https://github.com/AndreSlavescu) on 2023
 + Results reproduced by [@saharsamr](https://github.com/saharsamr) on 2023-12-14 (commit [`039c137`](https://github.com/castorini/pyserini/commit/039c137055c429d662544303546d8e225d159be8))
 + Results reproduced by [@Panizghi](https://github.com/Panizghi) on 2023-12-17 (commit [`0f5db95`](https://github.com/castorini/pyserini/commit/0f5db95dbd5ed6b983ac4f638b486a70bc5ea99a))
 + Results reproduced by [@AreelKhan](https://github.com/AreelKhan) on 2023-12-22 (commit [`f75adca`](https://github.com/castorini/pyserini/commit/f75adca8c410e64b3ff1375e181a0ea3af1ddb28))
++ Results reproduced by [@wu-ming233](https://github.com/wu-ming233) on 2023-12-31 (commit [`38a571f`](https://github.com/castorini/pyserini/commit/38a571fb2a61d61d9245997b5d0f8cd64550912c))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -411,3 +411,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@saharsamr](https://github.com/saharsamr) on 2023-12-14 (commit [`039c137`](https://github.com/castorini/pyserini/commit/039c137055c429d662544303546d8e225d159be8))
 + Results reproduced by [@Panizghi](https://github.com/Panizghi) on 2023-12-17 (commit [`0f5db95`](https://github.com/castorini/pyserini/commit/0f5db95dbd5ed6b983ac4f638b486a70bc5ea99a))
 + Results reproduced by [@AreelKhan](https://github.com/AreelKhan) on 2023-12-22 (commit [`f75adca`](https://github.com/castorini/pyserini/commit/f75adca8c410e64b3ff1375e181a0ea3af1ddb28))
++ Results reproduced by [@wu-ming233](https://github.com/wu-ming233) on 2023-12-31 (commit [`38a571f`](https://github.com/castorini/pyserini/commit/38a571fb2a61d61d9245997b5d0f8cd64550912c))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -249,7 +249,7 @@ $ grep 1048585 runs/run.msmarco-passage.bm25tuned.trec | head -10
 To pull up the actual contents of a hit:
 
 ```python
-hits[0].raw
+hits[0].lucene_document.get('raw')
 ```
 
 And you should get:

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -345,3 +345,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@saharsamr](https://github.com/saharsamr) on 2023-12-14 (commit [`039c137`](https://github.com/castorini/pyserini/commit/039c137055c429d662544303546d8e225d159be8))
 + Results reproduced by [@Panizghi](https://github.com/Panizghi) on 2023-12-17 (commit [`0f5db95`](https://github.com/castorini/pyserini/commit/0f5db95dbd5ed6b983ac4f638b486a70bc5ea99a))
 + Results reproduced by [@AreelKhan](https://github.com/AreelKhan) on 2023-12-22 (commit [`f75adca`](https://github.com/castorini/pyserini/commit/f75adca8c410e64b3ff1375e181a0ea3af1ddb28))
++ Results reproduced by [@wu-ming233](https://github.com/wu-ming233) on 2023-12-31 (commit [`38a571f`](https://github.com/castorini/pyserini/commit/38a571fb2a61d61d9245997b5d0f8cd64550912c))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -234,3 +234,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@saharsamr](https://github.com/saharsamr) on 2023-12-14 (commit [`039c137`](https://github.com/castorini/pyserini/commit/039c137055c429d662544303546d8e225d159be8))
 + Results reproduced by [@Panizghi](https://github.com/Panizghi) on 2023-12-17 (commit [`0f5db95`](https://github.com/castorini/pyserini/commit/0f5db95dbd5ed6b983ac4f638b486a70bc5ea99a))
 + Results reproduced by [@AreelKhan](https://github.com/AreelKhan) on 2023-12-22 (commit [`f75adca`](https://github.com/castorini/pyserini/commit/f75adca8c410e64b3ff1375e181a0ea3af1ddb28))
++ Results reproduced by [@wu-ming233](https://github.com/wu-ming233) on 2023-12-31 (commit [`38a571f`](https://github.com/castorini/pyserini/commit/38a571fb2a61d61d9245997b5d0f8cd64550912c))


### PR DESCRIPTION
Everything worked, except one minor issue encountered in the [last line of BM25 Baseline for MS MARCO Passage Ranking in Pyserini / Interactive Retrieval](https://github.com/castorini/pyserini/blob/master/docs/experiments-msmarco-passage.md#interactive-retrieval), the line `hits[0].raw` would error: 
```
AttributeError: 'io.anserini.search.ScoredDoc' object has no attribute 'raw'
```

The output from the builtin `dir(hits[0])` gives:

```py
['_JavaClass__cls_storage', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__javaclass__', '__javaconstructor__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__pyx_vtable__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setstate__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_class', 'clone', 'docid', 'equals', 'finalize', 'getClass', 'hashCode', 'lucene_docid', 'lucene_document', 'notify', 'notifyAll', 'registerNatives', 'score', 'toString', 'wait']
```
which includes attributes like `docid` and `score`, but not `raw`.

However, the command
```py
searcher.doc(hits[0].docid).raw()
```
does give the desired output:
```
'{\n  "id" : "7187158",\n  "contents" : "Paula Deen and her brother Earl W. Bubba Hiers are being sued by a former general manager at Uncle Bubba\'sâ\x80¦ Paula Deen and her brother Earl W. Bubba Hiers are being sued by a former general manager at Uncle Bubba\'sâ\x80¦"\n}'
```
Or, alternatively, the command
```py
hits[0].lucene_document.get('raw')
```
also gives the desired output.

I apologize in advance if the cause of this issue was that I didn't set up my environment or follow the instructions correctly. However, it appears to be the case that the class `ScoredDoc` (or `JScoredDoc`), returned by `LuceneSearcher.search()`, does not have the `raw` attribute; on the other hand, the class `Document`, returned by `LuceneSearcher.doc()`, does have the `raw()` method implemented to access the `raw` attribute of its underlying Lucene Document.

---
#### Operating System
WSL 2 running Ubuntu 22.04.3 LTS on a Windows 10 machine
#### Environment
- Python 3.10.12
- Java 11.0.21
#### Hardware
- i7-9700 CPU
- 16 GB RAM
- NVIDIA GeForce RTX 2070 SUPER

All the unit tests were passed after setting up my environment. Please let me know if there's any other information I can give about the setup or configurations to help with the situation.
