### PR TITLE
Update installation.md to fix nmslib installation error on Apple M-series

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,10 @@ If you're on a Mac with an M-series (i.e., ARM) processor, the following recipe 
 ```bash
 conda install wget -y
 conda install -c conda-forge openjdk=11 maven -y
-conda install -c conda-forge lightgbm nmslib -y
+conda install -c conda-forge lightgbm -y
+
+# from https://github.com/nmslib/nmslib/issues/476#issuecomment-1594889437
+CFLAGS="-mavx -DWARN(a)=(a)" pip install --use-pep517 nmslib
 
 # from https://github.com/facebookresearch/faiss/blob/main/INSTALL.md
 conda install -c pytorch faiss-cpu=1.7.4 blas=1.0 -y


### PR DESCRIPTION
In the installation guide to install Pyserini on Apple M-series, `conda install -c conda-forge nmslib -y` throws the following error (as of Jan 2024):

```
PackagesNotFoundError: The following packages are not available from current channels
```

Following [here](https://github.com/nmslib/nmslib/issues/476#issuecomment-1594889437), the command to install `nmslib` on Apple M-series is fixed in this PR.