### PR TITLE
Fix unittest warning

### DIFF
--- a/pyserini/trectools/_base.py
+++ b/pyserini/trectools/_base.py
@@ -107,7 +107,7 @@ class TrecRun:
         self.run_data = pd.DataFrame(columns=TrecRun.columns)
 
     def read_run(self, filepath: str, resort: bool = False) -> None:
-        self.run_data = pd.read_csv(filepath, sep='\s+', names=TrecRun.columns, dtype={'docid': 'str'})
+        self.run_data = pd.read_csv(filepath, sep='\s+', names=TrecRun.columns, dtype={'docid': 'str', 'score': 'float'})
         if resort:
             self.run_data.sort_values(["topic", "score"], inplace=True, ascending=[True, False])
             self.run_data["rank"] = self.run_data.groupby("topic")["score"].rank(ascending=False,method='first')


### PR DESCRIPTION
To clear the warning:
```
FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[1.0, 0.0]' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  self.run_data.loc[self.run_data['topic'] == topic, 'score'] = scores
  ```