### PR TITLE
support multimodal retrieval and cleanup redundant codes

### DIFF
--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -150,7 +150,9 @@ class JsonlCollectionIterator:
 
                     for i in range(len(fields_info)):
                         if 'path' in self.fields[i]:
-                            fields_info[i] = os.path.join(self.collection_dir, fields_info[i])
+                            _info = fields_info[i]
+                            if not _info.startswith(("http://", "https://")):
+                                fields_info[i] = os.path.join(self.collection_dir, fields_info[i])
                         all_info[self.fields[i]].append(fields_info[i])
         return all_info
 

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -59,7 +59,7 @@ class ClipImageEncoder(BaseClipEncoder):
                 processed_images.append(img)
             except Exception as e:
                 print(f"Error loading image {image}: {e}")
-                
+
         inputs = self.processor(images=processed_images, return_tensors="pt").to(self.device)
 
         with torch.no_grad():

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -10,9 +10,8 @@ from pyserini.encode import DocumentEncoder, QueryEncoder
 
 os.environ['OPENBLAS_NUM_THREADS'] = '1'
 
-def prepare_inputs(inputs: dict, device: str):
-    """Prepare model inputs by moving them to the specified device."""
-    return {k: v.to(device) for k, v in inputs.items()}
+
+
 
 def load_pil_image(image, format='RGB'):
     if isinstance(image, str) or os.path.isfile(image):
@@ -32,6 +31,7 @@ def load_pil_image(image, format='RGB'):
 
     return image
 
+
 class BaseClipEncoder:
     """Base class for encoding using a CLIP model."""
     def __init__(self, model_name, device='cuda:0', l2_norm=True):
@@ -44,25 +44,30 @@ class BaseClipEncoder:
         """Apply L2 normalization to embeddings if required."""
         return normalize(embeddings, axis=1, norm='l2') if self.l2_norm else embeddings
 
+
 class ClipImageEncoder(BaseClipEncoder):
     """Encodes images using a CLIP model."""
     def encode(self, paths, **kwargs):
         processed_images = []
+
+        if isinstance(paths, str):
+            paths = [paths]
+            
         for image in paths:
             try:
                 img = load_pil_image(image)
                 processed_images.append(img)
             except Exception as e:
                 print(f"Error loading image {image}: {e}")
-
+                
         inputs = self.processor(images=processed_images, return_tensors="pt").to(self.device)
-        # inputs = prepare_inputs(inputs, self.device)
 
         with torch.no_grad():
             image_features = self.model.get_image_features(**inputs)
 
         embeddings = image_features.detach().cpu().numpy()
         return self.normalize_embeddings(embeddings)
+
 
 class ClipTextEncoder(BaseClipEncoder):
     """Encodes text using a CLIP model."""
@@ -71,6 +76,10 @@ class ClipTextEncoder(BaseClipEncoder):
         self.prefix = prefix
 
     def encode(self, texts, max_length=77, **kwargs):
+
+        if isinstance(texts, str):
+            texts = [texts]
+            
         if self.prefix:
             texts = [f"{self.prefix} {text}" for text in texts]
 
@@ -88,15 +97,16 @@ class ClipTextEncoder(BaseClipEncoder):
         embeddings = text_features.detach().cpu().numpy()
         return self.normalize_embeddings(embeddings)
     
+    
 class ClipDocumentEncoder(DocumentEncoder):
     """Encodes documents using a CLIP model, supporting both images and texts."""
     def __init__(self, model_name, device='cuda:0', l2_norm=False, prefix=None, multimodal=False):
         super().__init__()
-        print(multimodal)
         self.encoder = ClipImageEncoder(model_name, device, l2_norm) if multimodal else ClipTextEncoder(model_name, device, l2_norm, prefix)
 
     def encode(self, *args, **kwargs):
         return self.encoder.encode(*args, **kwargs)
+
 
 class ClipEncoder(QueryEncoder):
     """Encodes queries using a CLIP model, supporting both images and texts."""

--- a/pyserini/index/faiss.py
+++ b/pyserini/index/faiss.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
                         f_out.write(f'{docid}\n')
                         vectors.append(vector)
     vectors = np.array(vectors, dtype='float32')
-    print(vectors.shape)
+    print(f"Vector Shape: {vectors.shape}")
 
     if args.hnsw and args.pq:
         index = faiss.IndexHNSWPQ(args.dim, args.pq_m, args.M)
@@ -78,5 +78,5 @@ if __name__ == '__main__':
         index.train(vectors)
 
     index.add(vectors)
-    print(index.ntotal)
+    print(f"Number of indexed vectors: {index.ntotal}")
     faiss.write_index(index, os.path.join(args.output, 'index'))

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -16,14 +16,10 @@
 
 import os
 import shutil
-import tarfile
 import unittest
-from random import randint
 from typing import List, Dict
-from urllib.request import urlretrieve
 
-from pyserini.search.lucene import LuceneSearcher, JScoredDoc
-from pyserini.index.lucene import Document
+from pyserini.search.lucene import LuceneSearcher
 from pyserini.search.faiss import FaissSearcher, AutoQueryEncoder
 from pyserini.search.hybrid import HybridSearcher
 
@@ -38,9 +34,6 @@ class TestHybridSearch(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # Download pre-built CACM index built using Lucene 9; append a random value to avoid filename clashes.
-        r = randint(0, 10000000)
-        
         cls.s_index_name = 'beir-v1.0.0-arguana.flat'
         cls.d_searcher_name = 'facebook/contriever-msmarco'
         cls.d_index_name = 'beir-v1.0.0-arguana.contriever-msmarco'

--- a/tests/test_multimodal_search.py
+++ b/tests/test_multimodal_search.py
@@ -97,6 +97,13 @@ class TestMultimodalSearch(unittest.TestCase):
         self.assertTrue(isinstance(hits, List))
         self.assertEqual(hits[0].docid, '00a3019b-c47c-3a97-8132-81896ab92dfc')
         self.assertAlmostEqual(hits[0].score, 0.9999999, places=5)
+    
+    def test_imageurl2text_search(self):
+        searcher = FaissSearcher(f'{self.index_dir}/texts', self.image_encoder)
+        hits = searcher.search('https://raw.githubusercontent.com/castorini/pyserini/master/docs/pyserini-logo.png')
+        self.assertTrue(isinstance(hits, List))
+        self.assertEqual(hits[0].docid, 'doc3')
+        self.assertAlmostEqual(hits[0].score, 0.20829172, places=5)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_multimodal_search.py
+++ b/tests/test_multimodal_search.py
@@ -1,0 +1,108 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import shutil
+import unittest
+from typing import List, Dict
+
+from pyserini.search.faiss import FaissSearcher, ClipQueryEncoder
+import pathlib as pl
+
+
+
+class TestMultimodalSearch(unittest.TestCase):
+    tarball_name = None
+    collection_url = None
+    searcher = None
+    searcher_index_dir = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text_file = 'tests/resources/sample_collection_jsonl/documents.jsonl'
+        cls.image_file = 'tests/resources/sample_collection_jsonl_image/images.small.jsonl'
+
+        pretrained_model_name = 'openai/clip-vit-base-patch32'
+        dim = 512
+        cls.emb_dir = 'temp_embeddings'
+        pl.Path(cls.emb_dir).mkdir(exist_ok=True)
+        cls.index_dir = 'temp_indexes'
+        pl.Path(cls.index_dir).mkdir(exist_ok=True)
+        cmd1 = f'python -m pyserini.encode \
+                  input   --corpus {cls.text_file} \
+                          --fields text \
+                  output  --embeddings {cls.emb_dir}/texts --to-faiss \
+                  encoder --encoder {pretrained_model_name} \
+                          --fields text \
+                          --batch 1 \
+                          --max-length 77 \
+                          --l2-norm --dimension {dim}\
+                          --device cpu'
+        status = os.system(cmd1)
+        cmd2 = f'python -m pyserini.encode \
+                  input   --corpus {cls.image_file} \
+                          --fields path \
+                  output  --embeddings {cls.emb_dir}/images --to-faiss \
+                  encoder --encoder {pretrained_model_name} \
+                          --fields path \
+                          --batch 1 \
+                          --multimodal --l2-norm --dimension {dim} \
+                          --device cpu'
+        status = os.system(cmd2)
+        cmd3 = f'python -m pyserini.index.faiss --input {cls.emb_dir}/texts --output {cls.index_dir}/texts --dim {dim}'
+        status = os.system(cmd3)
+        cmd4 = f'python -m pyserini.index.faiss --input {cls.emb_dir}/images --output {cls.index_dir}/images --dim {dim}'
+        status = os.system(cmd4)
+
+        cls.text_encoder = ClipQueryEncoder(pretrained_model_name, l2_norm=True, prefix='A picture of', multimodal=False, device='cpu')
+        cls.image_encoder = ClipQueryEncoder(pretrained_model_name, l2_norm=True, prefix=None, multimodal=True, device='cpu')
+        
+    def test_text2image_search(self):
+        searcher = FaissSearcher(f'{self.index_dir}/images', self.text_encoder)
+        hits = searcher.search('information retrieval')
+        self.assertTrue(isinstance(hits, List))
+        self.assertEqual(hits[0].docid, '01c79307-76fb-3b82-a96f-8ba1c1b6fa09')
+        self.assertAlmostEqual(hits[0].score, 0.20057034, places=5)
+    
+    def test_image2text_search(self):
+        searcher = FaissSearcher(f'{self.index_dir}/texts', self.image_encoder)
+        hits = searcher.search('tests/resources/sample_collection_jsonl_image/images.small/00a3019b-c47c-3a97-8132-81896ab92dfc.webp')
+        self.assertTrue(isinstance(hits, List))
+        self.assertEqual(hits[0].docid, 'doc1')
+        self.assertAlmostEqual(hits[0].score, 0.2340512, places=5)
+    
+    def test_text2text_search(self):
+        searcher = FaissSearcher(f'{self.index_dir}/texts', self.text_encoder)
+        hits = searcher.search('information retrieval')
+        self.assertTrue(isinstance(hits, List))
+        self.assertEqual(hits[0].docid, 'doc3')
+        self.assertAlmostEqual(hits[0].score, 0.8558732, places=5)
+    
+    def test_image2image_search(self):
+        searcher = FaissSearcher(f'{self.index_dir}/images', self.image_encoder)
+        hits = searcher.search('tests/resources/sample_collection_jsonl_image/images.small/00a3019b-c47c-3a97-8132-81896ab92dfc.webp')
+        self.assertTrue(isinstance(hits, List))
+        self.assertEqual(hits[0].docid, '00a3019b-c47c-3a97-8132-81896ab92dfc')
+        self.assertAlmostEqual(hits[0].score, 0.9999999, places=5)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.emb_dir)
+        shutil.rmtree(cls.index_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Changes
- Support multimodal retrieval settings: T2I, I2T, I2I, T2T
- Support jsonl format for indexing and query
- Add MultimodalQueryIterator
- Add test case
- Clean some redundant codes

## Usage

### Python interface
See [test case](https://github.com/justram/pyserini/blob/5d25c8905119e7e83a07c7a138cb2ae5dea474ce/tests/test_multimodal_search.py#L73-L99)
 
### CLI:
#### Image2Text
```shell
echo "Encoding..."
python -m pyserini.encode \
 input   --corpus $CORPUS \
         --fields text \
 output  --embeddings $EMB_PATH \
         --to-faiss \
 encoder --encoder $CKPT \
         --fields text \
         --dimension $EMB_DIM \
         --l2-norm \
         --batch 128 \
	  --max-length 77 \
         --device cpu

echo "Indexing..."
python -m pyserini.index.faiss \
   --input $EMB_PATH --output $INDEX_PATH --dim $EMB_DIM

echo "Searching..."
python -m pyserini.search.faiss \
    --index $INDEX_PATH \
    --topics $TOPICS --topics-format multimodal \
    --encoder $CKPT --multimodal \
    --output $RUN_PATH \
    --output-format trec \
    --l2-norm \
    --batch-size 36 --threads 12 --device CPU
```

#### Text2Image
```
echo "Encoding..."
python -m pyserini.encode \
  input   --corpus $CORPUS \
          --fields path \
  output  --embeddings $EMB_PATH \
          --to-faiss \
  encoder --encoder $CKPT \
          --fields path \
          --multimodal \
          --dimension $EMB_DIM \
          --l2-norm \
          --batch 32 \
          --device cpu

echo "Indexing..."
python -m pyserini.index.faiss \
    --input $EMB_PATH --output $INDEX_PATH --dim $EMB_DIM

echo "Searching..."
python -m pyserini.search.faiss \
    --index $INDEX_PATH \
    --topics $TOPICS \
    --encoder $CKPT \
    --output $RUN_PATH \
    --output-format trec \
    --l2-norm --max-length 77 \
    --batch-size 36 --threads 12 --device CPU
```