### PR TITLE
Added missing 2crs for dl23 passage and doc

### DIFF
--- a/docs/2cr/msmarco-v2-doc.html
+++ b/docs/2cr/msmarco-v2-doc.html
@@ -1465,9 +1465,9 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-v2-doc-dev2 run.msma
 <td>0.4165</td>
 <td>0.4779</td>
 <td></td>
-<td>-</td>
-<td>-</td>
-<td>-</td>
+<td>0.1413</td>
+<td>0.3898</td>
+<td>0.5462</td>
 <td></td>
 <td>0.2231</td>
 <td>0.8987</td>
@@ -1545,7 +1545,26 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 dl22-doc run.msmarco-v2-doc.
 
   </div>
   <div class="tab-pane fade" id="row9-tab3" role="tabpanel" aria-labelledby="row9-tab3">
-    Not available.</div>
+    Command to generate run on TREC 2023 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v2-doc-segmented-unicoil-noexp-0shot \
+  --topics dl23-unicoil-noexp \
+  --output run.msmarco-v2-doc.unicoil-noexp.dl23.txt \
+  --impact --hits 10000 --max-passage-hits 1000 --max-passage
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -M 100 -m map dl23-doc run.msmarco-v2-doc.unicoil-noexp.dl23.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl23-doc run.msmarco-v2-doc.unicoil-noexp.dl23.txt
+python -m pyserini.eval.trec_eval -c -m recall.1000 dl23-doc run.msmarco-v2-doc.unicoil-noexp.dl23.txt
+</code></pre>
+  </blockquote>
+
+  </div>
   <div class="tab-pane fade" id="row9-tab4" role="tabpanel" aria-labelledby="row9-tab4">
     Command to generate run on dev queries:
 
@@ -1604,9 +1623,9 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-v2-doc-dev2 run.msma
 <td>0.4451</td>
 <td>0.5235</td>
 <td></td>
-<td>-</td>
-<td>-</td>
-<td>-</td>
+<td>0.1554</td>
+<td>0.4149</td>
+<td>0.5753</td>
 <td></td>
 <td>0.2419</td>
 <td>0.9122</td>
@@ -1684,7 +1703,26 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 dl22-doc run.msmarco-v2-doc.
 
   </div>
   <div class="tab-pane fade" id="row10-tab3" role="tabpanel" aria-labelledby="row10-tab3">
-    Not available.</div>
+    Command to generate run on TREC 2023 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v2-doc-segmented-unicoil-0shot \
+  --topics dl23-unicoil \
+  --output run.msmarco-v2-doc.unicoil.dl23.txt \
+  --impact --hits 10000 --max-passage-hits 1000 --max-passage
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -M 100 -m map dl23-doc run.msmarco-v2-doc.unicoil.dl23.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl23-doc run.msmarco-v2-doc.unicoil.dl23.txt
+python -m pyserini.eval.trec_eval -c -m recall.1000 dl23-doc run.msmarco-v2-doc.unicoil.dl23.txt
+</code></pre>
+  </blockquote>
+
+  </div>
   <div class="tab-pane fade" id="row10-tab4" role="tabpanel" aria-labelledby="row10-tab4">
     Command to generate run on dev queries:
 

--- a/docs/2cr/msmarco-v2-passage.html
+++ b/docs/2cr/msmarco-v2-passage.html
@@ -1465,9 +1465,9 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-v2-passage-dev2 run.
 <td>0.4077</td>
 <td>0.4423</td>
 <td></td>
-<td>-</td>
-<td>-</td>
-<td>-</td>
+<td>0.1112</td>
+<td>0.3262</td>
+<td>0.5070</td>
 <td></td>
 <td>0.1342</td>
 <td>0.7010</td>
@@ -1545,7 +1545,26 @@ python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl22-passage run.msmarc
 
   </div>
   <div class="tab-pane fade" id="row9-tab3" role="tabpanel" aria-labelledby="row9-tab3">
-    Not available.</div>
+    Command to generate run on TREC 2023 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v2-passage-unicoil-noexp-0shot \
+  --topics dl23-unicoil-noexp \
+  --output run.msmarco-v2-passage.unicoil-noexp.dl23.txt \
+  --hits 1000 --impact
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -M 100 -m map dl23-passage run.msmarco-v2-passage.unicoil-noexp.dl23.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl23-passage run.msmarco-v2-passage.unicoil-noexp.dl23.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl23-passage run.msmarco-v2-passage.unicoil-noexp.dl23.txt
+</code></pre>
+  </blockquote>
+
+  </div>
   <div class="tab-pane fade" id="row9-tab4" role="tabpanel" aria-labelledby="row9-tab4">
     Command to generate run on dev queries:
 
@@ -1604,9 +1623,9 @@ python -m pyserini.eval.trec_eval -c -m recall.1000 msmarco-v2-passage-dev2 run.
 <td>0.4614</td>
 <td>0.5253</td>
 <td></td>
-<td>-</td>
-<td>-</td>
-<td>-</td>
+<td>0.1437</td>
+<td>0.3855</td>
+<td>0.5541</td>
 <td></td>
 <td>0.1499</td>
 <td>0.7616</td>
@@ -1684,7 +1703,26 @@ python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl22-passage run.msmarc
 
   </div>
   <div class="tab-pane fade" id="row10-tab3" role="tabpanel" aria-labelledby="row10-tab3">
-    Not available.</div>
+    Command to generate run on TREC 2023 queries:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.search.lucene \
+  --threads 16 --batch-size 128 \
+  --index msmarco-v2-passage-unicoil-0shot \
+  --topics dl23-unicoil \
+  --output run.msmarco-v2-passage.unicoil.dl23.txt \
+  --hits 1000 --impact
+</code></pre></blockquote>
+Evaluation commands:
+
+  <blockquote class="mycode">
+<pre><code>python -m pyserini.eval.trec_eval -c -l 2 -M 100 -m map dl23-passage run.msmarco-v2-passage.unicoil.dl23.txt
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl23-passage run.msmarco-v2-passage.unicoil.dl23.txt
+python -m pyserini.eval.trec_eval -c -l 2 -m recall.1000 dl23-passage run.msmarco-v2-passage.unicoil.dl23.txt
+</code></pre>
+  </blockquote>
+
+  </div>
   <div class="tab-pane fade" id="row10-tab4" role="tabpanel" aria-labelledby="row10-tab4">
     Command to generate run on dev queries:
 

--- a/pyserini/2cr/msmarco-v2-doc.yaml
+++ b/pyserini/2cr/msmarco-v2-doc.yaml
@@ -302,9 +302,9 @@ conditions:
       - topic_key: dl23-unicoil-noexp
         eval_key: dl23-doc
         scores:
-          - MAP@100: 0
-            nDCG@10: 0
-            R@1K: 0
+          - MAP@100: 0.1413
+            nDCG@10: 0.3898
+            R@1K: 0.5462
   - name: unicoil
     display: "uniCOIL (w/ doc2query-T5): pre-encoded"
     display-html: "uniCOIL (w/ doc2query-T5): pre-encoded queries"
@@ -336,9 +336,9 @@ conditions:
       - topic_key: dl23-unicoil
         eval_key: dl23-doc
         scores:
-          - MAP@100: 0
-            nDCG@10: 0
-            R@1K: 0
+          - MAP@100: 0.1554
+            nDCG@10: 0.4149
+            R@1K: 0.5753
   - name: unicoil-noexp-otf
     display: "uniCOIL (noexp): query inference with PyTorch"
     display-html: "uniCOIL (noexp): query inference with PyTorch"

--- a/pyserini/2cr/msmarco-v2-passage.yaml
+++ b/pyserini/2cr/msmarco-v2-passage.yaml
@@ -302,9 +302,9 @@ conditions:
       - topic_key: dl23-unicoil-noexp
         eval_key: dl23-passage
         scores:
-          - MAP@100: 0
-            nDCG@10: 0
-            R@1K: 0
+          - MAP@100: 0.1112
+            nDCG@10: 0.3262
+            R@1K: 0.5070
   - name: unicoil
     display: "uniCOIL (w/ doc2query-T5): pre-encoded"
     display-html: "uniCOIL (w/ doc2query-T5): pre-encoded queries"
@@ -336,9 +336,9 @@ conditions:
       - topic_key: dl23-unicoil
         eval_key: dl23-passage
         scores:
-          - MAP@100: 0
-            nDCG@10: 0
-            R@1K: 0
+          - MAP@100: 0.1437
+            nDCG@10: 0.3855
+            R@1K: 0.5541
   - name: unicoil-noexp-otf
     display: "uniCOIL (noexp): query inference with PyTorch"
     display-html: "uniCOIL (noexp): query inference with PyTorch"

--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -88,6 +88,8 @@ topics_mapping = {
     'dl22-unicoil': 'TREC2022_DL_UNICOIL',
     'dl22-unicoil-noexp': 'TREC2022_DL_UNICOIL_NOEXP',
     'dl23': 'TREC2023_DL',
+    'dl23-unicoil': 'TREC2023_DL_UNICOIL',
+    'dl23-unicoil-noexp': 'TREC2023_DL_UNICOIL_NOEXP',
     'msmarco-doc-dev': 'MSMARCO_DOC_DEV',
     'msmarco-doc-dev-unicoil': 'MSMARCO_DOC_DEV_UNICOIL',
     'msmarco-doc-dev-unicoil-noexp': 'MSMARCO_DOC_DEV_UNICOIL_NOEXP',

--- a/tests/test_load_queries.py
+++ b/tests/test_load_queries.py
@@ -386,7 +386,7 @@ class TestLoadTopics(unittest.TestCase):
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 700)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
-    
+
         topics = search.get_topics('dl23-unicoil')
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 700)

--- a/tests/test_load_queries.py
+++ b/tests/test_load_queries.py
@@ -386,6 +386,16 @@ class TestLoadTopics(unittest.TestCase):
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 700)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
+    
+        topics = search.get_topics('dl23-unicoil')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 700)
+        self.assertFalse(isinstance(next(iter(topics.keys())), str))
+
+        topics = search.get_topics('dl23-unicoil-noexp')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 700)
+        self.assertFalse(isinstance(next(iter(topics.keys())), str))
 
     # Various multi-lingual test collections
     def test_ntcir8_zh(self):


### PR DESCRIPTION
This cl adds `dl23-unicoil*` entries to pyserini and populates the missing 2crs
TESTED=the existing unittest updated,  manully viewed the generated report