### PR TITLE
Refactored/ Corrected a part of  Documentation 

### DIFF
--- a/docs/usage-index.md
+++ b/docs/usage-index.md
@@ -256,14 +256,14 @@ The output will be stored in jsonl format. Each line contains following info:
 }
 ```
 
-Once the collections are [encoded](usage-encode.md) into vectors,
+Once the collections are encoded into vectors,
 we can start to build the index.
 
 Pyserini supports four types of index so far:
 1. [HNSWPQ](https://faiss.ai/cpp_api/struct/structfaiss_1_1IndexHNSWPQ.html#struct-faiss-indexhnswpq)
 ```bash
 python -m pyserini.index.faiss \
-  --input path/to/encoded/corpus \  # either in the Faiss or the jsonl format
+  --input path/to/encoded/corpus \  # Folder containing file either in the Faiss or the jsonl format
   --output path/to/output/index \
   --hnsw \
   --pq
@@ -272,7 +272,7 @@ python -m pyserini.index.faiss \
 2. [HNSW](https://faiss.ai/cpp_api/struct/structfaiss_1_1IndexHNSW.html#struct-faiss-indexhnsw)
 ```bash
 python -m pyserini.index.faiss \
-  --input path/to/encoded/corpus \  # either in the Faiss or the jsonl format
+  --input path/to/encoded/corpus \  # The folder containing file either in the Faiss or the jsonl format
   --output path/to/output/index \
   --hnsw
 ```
@@ -280,7 +280,7 @@ python -m pyserini.index.faiss \
 3. [PQ](https://faiss.ai/cpp_api/struct/structfaiss_1_1IndexPQ.html)
 ```bash
 python -m pyserini.index.faiss \
-  --input path/to/encoded/corpus \  # either in the Faiss or the jsonl format
+  --input path/to/encoded/corpus \  # The folder containing file either in the Faiss or the jsonl format
   --output path/to/output/index \
   --pq
 ```
@@ -290,8 +290,8 @@ This command is for converting the `.jsonl` format into Faiss flat format,
 and generates the same files with `pyserini.encode` with `--to-faiss` specified.
 ```bash
 python -m pyserini.index.faiss \
-  --input path/to/encoded/corpus \  # in jsonl format
-  --output path/to/output/index \
+  --input path/to/encoded/corpus \  # The folder containing file in jsonl format
+  --output path/to/output/index
 ```
 
 Once the index is built, you can use `FaissSearcher` to search in the collection:

--- a/docs/usage-index.md
+++ b/docs/usage-index.md
@@ -242,7 +242,7 @@ python -m pyserini.encode \
   input   --corpus tests/resources/simple_cacm_corpus.json \
           --fields text \
   output  --embeddings path/to/output/dir \
-  encoder --encoder castorini/unicoil-d2q-msmarco-passage \
+  encoder --encoder castorini/unicoil-msmarco-passage \
           --fields text \
           --batch 32 \
           --fp16 # if inference with autocast()


### PR DESCRIPTION
- At line 259 : no such file (usage-encode.md) exists.
- At line 266, 275, 283,293 : 
Below is the screenshot of [pyserini/index/faiss.py](https://github.com/castorini/pyserini/blob/master/pyserini/index/faiss.py) file
<img width="716" alt="Screenshot 2024-04-03 at 10 44 59 PM" src="https://github.com/castorini/pyserini/assets/86063242/1764d931-7ece-48dd-a7bc-9b1d1f6003d1">

It expects a Folder containing the file, not the file path.

- At line 294 : Extra 'slash' which gives error in python terminal.
- At line 245 : The model repository name changed the actual one available on [huggingface](https://huggingface.co/castorini/unicoil-msmarco-passage) 
This change resolves issue number #1767

I have other suggestions as well. Starting from this small contribution. More can be expected soon as I'm actively using this. Thank you