### PR TITLE
Onboarding tasks billycz8

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -334,3 +334,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@DanielKohn1208](https://github.com/DanielKohn1208) on 2024-04-22 (commit [`184a212`](https://github.com/castorini/pyserini/commit/184a212e7d578fac453ead64f7f796bc2e44bcf2))
 + Results reproduced by [@emadahmed19](https://github.com/emadahmed19) on 2024-04-28 (commit [`9db2584`](https://github.com/castorini/pyserini/commit/9db25847829a656d1c9eacb267bf745f7522dd14))
 + Results reproduced by [@CheranMahalingam](https://github.com/CheranMahalingam) on 2024-05-05 (commit [`f817186`](https://github.com/castorini/pyserini/commit/f8171863df833ac02ff427d4823a1085e63094bf))
++ Results reproduced by [@billycz8](https://github.com/billycz8) on 2024-05-08 (commit [`c945c50`](https://github.com/castorini/pyserini/commit/c945c50c3e22e3c6ecae50a55aed48853617acc0))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -575,3 +575,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@DanielKohn1208](https://github.com/DanielKohn1208) on 2024-04-22 (commit [`184a212`](https://github.com/castorini/pyserini/commit/184a212e7d578fac453ead64f7f796bc2e44bcf2))
 + Results reproduced by [@emadahmed19](https://github.com/emadahmed19) on 2024-04-28 (commit [`9db2584`](https://github.com/castorini/pyserini/commit/9db25847829a656d1c9eacb267bf745f7522dd14))
 + Results reproduced by [@CheranMahalingam](https://github.com/CheranMahalingam) on 2024-05-05 (commit [`f817186`](https://github.com/castorini/pyserini/commit/f8171863df833ac02ff427d4823a1085e63094bf))
++ Results reproduced by [@billycz8](https://github.com/billycz8) on 2024-05-08 (commit [`c945c50`](https://github.com/castorini/pyserini/commit/c945c50c3e22e3c6ecae50a55aed48853617acc0))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -372,3 +372,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@DanielKohn1208](https://github.com/DanielKohn1208) on 2024-04-22 (commit [`184a212`](https://github.com/castorini/pyserini/commit/184a212e7d578fac453ead64f7f796bc2e44bcf2))
 + Results reproduced by [@emadahmed19](https://github.com/emadahmed19) on 2024-04-28 (commit [`9db2584`](https://github.com/castorini/pyserini/commit/9db25847829a656d1c9eacb267bf745f7522dd14))
 + Results reproduced by [@CheranMahalingam](https://github.com/CheranMahalingam) on 2024-05-05 (commit [`f817186`](https://github.com/castorini/pyserini/commit/f8171863df833ac02ff427d4823a1085e63094bf))
++ Results reproduced by [@billycz8](https://github.com/billycz8) on 2024-05-08 (commit [`c945c50`](https://github.com/castorini/pyserini/commit/c945c50c3e22e3c6ecae50a55aed48853617acc0))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -71,7 +71,7 @@ This command-line invocation does the trick:
 tail -n +2 collections/nfcorpus/qrels/test.tsv | sed 's/\t/\tQ0\t/' > collections/nfcorpus/qrels/test.qrels
 ```
 
-Q0 instead of 0 (historical artifact mentioned in [Anserini: Start Here](https://github.com/castorini/anserini/blob/master/docs/start-here.md)) marks as trec format in pyserini to avoid extraneous conversion from msmarco in [trec_eval.py](https://github.com/castorini/pyserini/blob/c945c50c3e22e3c6ecae50a55aed48853617acc0/pyserini/eval/trec_eval.py#L67).
+Q0 instead of 0 (historical artifact mentioned in [Anserini: Start Here](https://github.com/castorini/anserini/blob/master/docs/start-here.md)) marks as trec format in pyserini to avoid extraneous conversion from msmarco in [trec_eval.py](https://github.com/castorini/pyserini/blob/master/pyserini/eval/trec_eval.py).
 
 Okay, the data are ready now.
 

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -71,6 +71,8 @@ This command-line invocation does the trick:
 tail -n +2 collections/nfcorpus/qrels/test.tsv | sed 's/\t/\tQ0\t/' > collections/nfcorpus/qrels/test.qrels
 ```
 
+Q0 instead of 0 (historical artifact mentioned in [Anserini: Start Here](https://github.com/castorini/anserini/blob/master/docs/start-here.md)) marks as trec format in pyserini to avoid extraneous conversion from msmarco in [trec_eval.py](https://github.com/castorini/pyserini/blob/c945c50c3e22e3c6ecae50a55aed48853617acc0/pyserini/eval/trec_eval.py#L67).
+
 Okay, the data are ready now.
 
 ## Indexing
@@ -370,3 +372,5 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@DanielKohn1208](https://github.com/DanielKohn1208) on 2024-04-22 (commit [`184a212`](https://github.com/castorini/pyserini/commit/184a212e7d578fac453ead64f7f796bc2e44bcf2))
 + Results reproduced by [@emadahmed19](https://github.com/emadahmed19) on 2024-04-28 (commit [`9db2584`](https://github.com/castorini/pyserini/commit/9db25847829a656d1c9eacb267bf745f7522dd14))
 + Results reproduced by [@CheranMahalingam](https://github.com/CheranMahalingam) on 2024-05-05 (commit [`f817186`](https://github.com/castorini/pyserini/commit/f8171863df833ac02ff427d4823a1085e63094bf))
++ Results reproduced by [@billycz8](https://github.com/billycz8) on 2024-05-08 (commit [`c945c50`](https://github.com/castorini/pyserini/commit/c945c50c3e22e3c6ecae50a55aed48853617acc0))
+

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -71,8 +71,6 @@ This command-line invocation does the trick:
 tail -n +2 collections/nfcorpus/qrels/test.tsv | sed 's/\t/\tQ0\t/' > collections/nfcorpus/qrels/test.qrels
 ```
 
-Q0 instead of 0 (historical artifact mentioned in [Anserini: Start Here](https://github.com/castorini/anserini/blob/master/docs/start-here.md)) marks as trec format in pyserini to avoid extraneous conversion from msmarco in [trec_eval.py](https://github.com/castorini/pyserini/blob/master/pyserini/eval/trec_eval.py).
-
 Okay, the data are ready now.
 
 ## Indexing


### PR DESCRIPTION
System setup:

OS: macOS Ventura 13.4
Memory: 16GB
Chip: Apple M1 Pro
Python Version: 3.10.13
Java Version: 21.0.3
Maven: 3.9.2

Everything worked perfectly!

Suggestion: When I went through Pyserini: BGE-base Baseline for NFCorpus / Data Prep, I was curious why we added Q0 instead of 0 as the artifact in Anserini. It seems to be used in trec_eval.py, and I think explaining it would be helpful for others to understand the reason of the change. (I have added the change in the PR, we could reword or ignore that change if it is not useful.)

