### PR TITLE
Bind anserini server application

### DIFF
--- a/pyserini/server/AnseriniApplication/__main__.py
+++ b/pyserini/server/AnseriniApplication/__main__.py
@@ -1,0 +1,29 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+import time
+
+from pyserini.pyclass import autoclass
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+
+    JServer = autoclass('io.anserini.server.Application')
+    JServer.main(args)
+
+    while True:
+        time.sleep(60)


### PR DESCRIPTION
Binded [anserini server and web application](https://github.com/castorini/anserini/blob/master/docs/fatjar-regressions/fatjar-regressions-v0.36.1.md#webapp-and-rest-api)

Run with `python -m pyserini.server.AnseriniApplication --server.port=8081`