### PR TITLE
Fixing pgvector benchmark

### DIFF
--- a/benchmark_duckdb.py
+++ b/benchmark_duckdb.py
@@ -1,0 +1,105 @@
+import json
+import duckdb
+import numpy as np
+import subprocess
+
+# Paths to embedding, query, and output files
+DOCUMENT_JSONL_FILE_PATH = 'indexes/non-faiss-nfcorpus/documents/embeddings.jsonl'
+QUERY_JSONL_FILE_PATH = 'indexes/non-faiss-nfcorpus/queries/embeddings.jsonl'
+TREC_DOT_PRODUCT_OUTPUT_FILE_PATH = 'runs/.run-non-faiss-nfcorpus-result_dot_product.txt'
+TREC_COSINE_OUTPUT_FILE_PATH = 'runs/.run-non-faiss-nfcorpus-result_cosine.txt'
+TREC_L2SQ_OUTPUT_FILE_PATH = 'runs/.run-non-faiss-nfcorpus-result_l2sq.txt'
+K = 10  # Number of nearest neighbors to retrieve
+RUN_ID = "DuckDBHNSW"  # Identifier for the run
+
+def get_vector_size(jsonl_file_path):
+    """Determines the size of the vector, assuming vectors all have the same dimension."""
+    with open(jsonl_file_path, 'r') as file:
+        for line in file:
+            data = json.loads(line)
+            vector = data.get('vector', [])
+            return len(vector)
+    return 0
+
+def insert_data_into_table(con, id, content, vector, table):
+    """Inserts data into the DuckDB table."""
+    con.execute(f"INSERT INTO {table} (id, content, vector) VALUES (?, ?, ?)", (id, content, vector))
+
+def setup_database():
+    """Sets up the DuckDB database and inserts document data."""
+    con = duckdb.connect(database=':memory:')
+    con.execute("INSTALL vss")
+    con.execute("LOAD vss")
+    con.execute("PRAGMA temp_directory='/tmp/duckdb_temp'")
+    con.execute("PRAGMA memory_limit='4GB'")
+    
+    vector_size = get_vector_size(DOCUMENT_JSONL_FILE_PATH)
+    print(f"Vector size: {vector_size}")
+
+    # Create documents table
+    con.execute(f"""
+        CREATE TABLE documents (
+            id STRING,
+            content STRING,
+            vector FLOAT[{vector_size}]
+        )
+    """)
+
+    # Insert data from JSONL file
+    with open(DOCUMENT_JSONL_FILE_PATH, 'r') as file:
+        for line in file:
+            data = json.loads(line)
+            insert_data_into_table(con, data['id'], data['contents'], data['vector'], 'documents')
+
+    # Create HNSW indices with different metrics
+    con.execute("CREATE INDEX l2sq_idx ON documents USING HNSW(vector) WITH (metric = 'l2sq')")
+    con.execute("CREATE INDEX cos_idx ON documents USING HNSW(vector) WITH (metric = 'cosine')")
+    con.execute("CREATE INDEX ip_idx ON documents USING HNSW(vector) WITH (metric = 'ip')")
+
+    return con
+
+def run_trec_eval(trec_output_file_path):
+    """Runs TREC evaluation and prints ndcg@10."""
+    command = [
+        "python", "-m", "pyserini.eval.trec_eval",
+        "-c", "-m", "ndcg_cut.10",
+        "collections/nfcorpus/qrels/test.qrels",
+        trec_output_file_path
+    ]
+    print("ndcg@10 for ", trec_output_file_path)
+    subprocess.run(command)
+
+def run_benchmark(con, trec_output_file_path, metric):
+    """Runs the benchmark and writes results in TREC format."""
+    with open(trec_output_file_path, 'w') as trec_file:
+        with open(QUERY_JSONL_FILE_PATH, 'r') as query_file:
+            for line in query_file:
+                data = json.loads(line)
+                query_id = data['id']
+                vector = data['vector']
+
+                # Select appropriate SQL query based on the metric
+                if metric == 'l2sq':
+                    evaluation_metric = 'array_distance'
+                elif metric == 'cosine':
+                    evaluation_metric = 'array_cosine_similarity'
+                elif metric == 'ip':
+                    evaluation_metric = 'array_inner_product'
+
+                sql_query = f"SELECT id, {evaluation_metric}(vector, ?::FLOAT[{len(vector)}]) as score FROM documents ORDER BY score DESC LIMIT ?"
+                results = con.execute(sql_query, (vector, K)).fetchall()
+
+                # Write results in TREC format
+                for rank, (doc_id, score) in enumerate(results, start=1):
+                    trec_file.write(f"{query_id} Q0 {doc_id} {rank} {score} {RUN_ID}\n")
+
+    print(f"TREC results written to {trec_output_file_path}")
+    run_trec_eval(trec_output_file_path)
+
+if __name__ == "__main__":
+    con = setup_database()
+
+    # Running the benchmarks
+    run_benchmark(con, TREC_L2SQ_OUTPUT_FILE_PATH, 'l2sq')
+    run_benchmark(con, TREC_COSINE_OUTPUT_FILE_PATH, 'cosine')
+    run_benchmark(con, TREC_DOT_PRODUCT_OUTPUT_FILE_PATH, 'ip')

--- a/benchmark_pg_vector.py
+++ b/benchmark_pg_vector.py
@@ -1,0 +1,103 @@
+import psycopg2
+import json
+import subprocess
+
+# Paths to embedding, query, and output files
+DOCUMENT_JSONL_FILE_PATH = 'indexes/non-faiss-nfcorpus/documents/embeddings.jsonl'
+QUERY_JSONL_FILE_PATH = 'indexes/non-faiss-nfcorpus/queries/embeddings.jsonl'
+TREC_DOT_PRODUCT_OUTPUT_FILE_PATH = 'runs/.run-non-faiss-nfcorpus-result_dot_product.txt'
+TREC_COSINE_OUTPUT_FILE_PATH = 'runs/.run-non-faiss-nfcorpus-result_cosine.txt'
+TREC_L2SQ_OUTPUT_FILE_PATH = 'runs/.run-non-faiss-nfcorpus-result_l2sq.txt'
+VECTOR_SIZE = 768
+K = 10  # Number of nearest neighbors to retrieve
+RUN_ID = "PostgresHNSW"
+
+def insert_data_into_table(cur, id, content, vector):
+    """Inserts data into the PostgreSQL table."""
+    cur.execute("INSERT INTO documents (id, content, vector) VALUES (%s, %s, %s)", (id, content, vector))
+
+def setup_database():
+    """Sets up the PostgreSQL database and inserts document data."""
+    conn = psycopg2.connect(
+        dbname='main_database',
+        user='mainuser',
+        password='password',
+        host='localhost',
+        port='5432'
+    )
+    cur = conn.cursor()
+
+    # Create documents table
+    cur.execute(f"""
+        CREATE TABLE documents (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            vector VECTOR({VECTOR_SIZE})
+        )
+    """)
+    conn.commit()
+
+    # Insert data from JSONL file
+    with open(DOCUMENT_JSONL_FILE_PATH, 'r') as file:
+        for line in file:
+            data = json.loads(line)
+            insert_data_into_table(cur, data['id'], data['contents'], data['vector'])
+    conn.commit()
+
+    # Create indexes with pgvector
+    cur.execute("CREATE INDEX ON documents USING ivfflat (vector vector_l2_ops);")
+    cur.execute("CREATE INDEX ON documents USING ivfflat (vector vector_cosine_ops);")
+    cur.execute("CREATE INDEX ON documents USING ivfflat (vector vector_ip_ops);")
+    conn.commit()
+
+    return cur, conn
+
+def run_trec_eval(trec_output_file_path):
+    """Runs TREC evaluation and prints ndcg@10."""
+    command = [
+        "python", "-m", "pyserini.eval.trec_eval",
+        "-c", "-m", "ndcg_cut.10",
+        "collections/nfcorpus/qrels/test.qrels",
+        trec_output_file_path
+    ]
+    print("ndcg@10 for ", trec_output_file_path)
+    subprocess.run(command)
+
+def run_benchmark(cur, trec_output_file_path, metric):
+    """Runs the benchmark and writes results in TREC format."""
+    with open(trec_output_file_path, 'w') as trec_file:
+        with open(QUERY_JSONL_FILE_PATH, 'r') as query_file:
+            for line in query_file:
+                data = json.loads(line)
+                query_id = data['id']
+                vector = data['vector']
+
+                # Select appropriate SQL query based on the metric
+                if metric == 'l2sq':
+                    sql_query = "SELECT id, vector <-> %s::vector AS score FROM documents ORDER BY vector <-> %s::vector LIMIT %s"
+                elif metric == 'ip':
+                    sql_query = "SELECT id, vector <#> %s::vector AS score FROM documents ORDER BY vector <#> %s::vector LIMIT %s"
+                elif metric == 'cosine':
+                    sql_query = "SELECT id, vector <=> %s::vector AS score FROM documents ORDER BY vector <=> %s::vector DESC LIMIT %s"
+
+                cur.execute(sql_query, (vector, vector, K))
+                results = cur.fetchall()
+
+                # Write results in TREC format
+                for rank, (doc_id, score) in enumerate(results, start=1):
+                    trec_file.write(f"{query_id} Q0 {doc_id} {rank} {score} {RUN_ID}\n")
+
+    print(f"TREC results written to {trec_output_file_path}")
+    run_trec_eval(trec_output_file_path)
+
+if __name__ == "__main__":
+    cur, conn = setup_database()
+
+    # Running the benchmarks
+    run_benchmark(cur, TREC_L2SQ_OUTPUT_FILE_PATH, 'l2sq')
+    run_benchmark(cur, TREC_COSINE_OUTPUT_FILE_PATH, 'cosine')
+    run_benchmark(cur, TREC_DOT_PRODUCT_OUTPUT_FILE_PATH, 'ip')
+
+    # Close PostgreSQL connection
+    cur.close()
+    conn.close()

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,40 @@
+# Encoding and Benchmarking Process
+
+## 1. Encode the Corpus
+Create a directory for document embeddings and encode the corpus using the specified encoder.
+
+```bash
+mkdir indexes/non-faiss-nfcorpus/documents
+python -m pyserini.encode \
+  input   --corpus collections/nfcorpus/corpus.jsonl \
+          --fields title text \
+  output  --embeddings indexes/non-faiss-nfcorpus/documents \
+  encoder --encoder BAAI/bge-base-en-v1.5 --l2-norm \
+          --device cpu \
+          --pooling mean \
+          --fields title text \
+          --batch 32
+```
+
+## 2. Encode the Queries
+Create a directory for query embeddings and encode the queries using the specified encoder.
+
+```bash
+mkdir indexes/non-faiss-nfcorpus/queries
+python -m pyserini.encode \
+  input   --corpus collections/nfcorpus/queries.jsonl \
+          --fields title text \
+  output  --embeddings indexes/non-faiss-nfcorpus/queries \
+  encoder --encoder BAAI/bge-base-en-v1.5 --l2-norm \
+          --device cpu \
+          --pooling mean \
+          --fields title text \
+          --batch 32
+```
+
+## 3. Run Benchmarks
+
+```bash
+python3 benchmark_duckdb.py 
+python3 benchmark_pgvector.py
+


### PR DESCRIPTION
- Replaced ivfflat to hnsw indices.
- The <#> operator returns negative inner product, fixed the inner product query.
- The cosine similarity should be used by subtracting it from 1 i.e. 1 - (vector <=> '[3,1,2]') as score.