### PR TITLE
Add bindings for MS MARCO V2.1 doc: prebuilt indexes, topics, qrels

### DIFF
--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -200,6 +200,30 @@ Detailed configuration information for the pre-built indexes are stored in [`pys
 [<a href="../pyserini/resources/index-metadata/lucene-inverted.msmarco-v2-passage-augmented.d2q-t5.20220808.4d6d2a.README.md">readme</a>]
 <dd>Lucene index (+docvectors) of the MS MARCO V2 augmented passage corpus with doc2query-T5 expansions.
 </dd>
+<dt></dt><b><code>msmarco-v2.1-doc</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md">readme</a>]
+<dd>Lucene index of the MS MARCO V2.1 document corpus.
+</dd>
+<dt></dt><b><code>msmarco-v2.1-doc-slim</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md">readme</a>]
+<dd>Lucene index of the MS MARCO V2.1 document corpus ('slim' version).
+</dd>
+<dt></dt><b><code>msmarco-v2.1-doc-full</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md">readme</a>]
+<dd>Lucene index of the MS MARCO V2.1 document corpus ('full' version).
+</dd>
+<dt></dt><b><code>msmarco-v2.1-doc-segmented</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md">readme</a>]
+<dd>Lucene index of the MS MARCO V2.1 segmented document corpus.
+</dd>
+<dt></dt><b><code>msmarco-v2.1-doc-segmented-slim</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md">readme</a>]
+<dd>Lucene index of the MS MARCO V2.1 segmented document corpus ('slim' version).
+</dd>
+<dt></dt><b><code>msmarco-v2.1-doc-segmented-full</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md">readme</a>]
+<dd>Lucene index of the MS MARCO V2.1 segmented document corpus ('full' version).
+</dd>
 </dl>
 </details>
 <details>

--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -1,8 +1,8 @@
 
 # Pyserini: Prebuilt Indexes
 
-Pyserini provides a number of pre-built Lucene indexes.
-To list what's available in code:
+Pyserini provides a number of prebuilt Lucene indexes.
+To list what's available:
 
 ```python
 from pyserini.search.lucene import LuceneSearcher
@@ -12,13 +12,13 @@ from pyserini.index.lucene import IndexReader
 IndexReader.list_prebuilt_indexes()
 ```
 
-It's easy initialize a searcher from a pre-built index:
+It's easy initialize a searcher from a prebuilt index:
 
 ```python
 searcher = LuceneSearcher.from_prebuilt_index('robust04')
 ```
 
-You can use this simple Python one-liner to download the pre-built index:
+You can use this simple Python one-liner to download the prebuilt index:
 
 ```
 python -c "from pyserini.search.lucene import LuceneSearcher; LuceneSearcher.from_prebuilt_index('robust04')"
@@ -26,7 +26,7 @@ python -c "from pyserini.search.lucene import LuceneSearcher; LuceneSearcher.fro
 
 The downloaded index will be in `~/.cache/pyserini/indexes/`.
 
-It's similarly easy initialize an index reader from a pre-built index:
+It's similarly easy initialize an index reader from a prebuilt index:
 
 ```python
 index_reader = IndexReader.from_prebuilt_index('robust04')
@@ -42,8 +42,22 @@ The output will be:
 Note that unless the underlying index was built with the `-optimize` option (i.e., merging all index segments into a single segment), `unique_terms` will show -1.
 Nope, that's not a bug.
 
-Below is a summary of the pre-built indexes that are currently available.
-Detailed configuration information for the pre-built indexes are stored in [`pyserini/prebuilt_index_info.py`](../pyserini/prebuilt_index_info.py).
+Pyserini also provides a number of prebuilt Faiss indexes.
+To list what's available:
+
+```python
+from pyserini.search.faiss import FaissSearcher
+FaissSearcher.list_prebuilt_indexes()
+```
+
+And to initialize a specific Faiss index:
+
+```python
+searcher = FaissSearcher.from_prebuilt_index('msmarco-v1-passage.bge-base-en-v1.5', None)
+```
+
+Below is a summary of the prebuilt indexes that are currently available.
+Detailed configuration information for the prebuilt indexes are stored in [`pyserini/prebuilt_index_info.py`](../pyserini/prebuilt_index_info.py).
 
 
 

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -561,6 +561,94 @@ TF_INDEX_INFO_MSMARCO = {
         "documents": 138364198,
         "unique_terms": 41177061,
         "downloaded": False
+    },
+
+    # MS MARCO V2.1 document corpus, three indexes with different amounts of information (and sizes).
+    "msmarco-v2.1-doc": {
+        "description": "Lucene index of the MS MARCO V2.1 document corpus.",
+        "filename": "lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.tar.gz",
+        "readme": "lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.tar.gz",
+        ],
+        "md5": "cecd55856c34afa82f1a499705c9df02",
+        "size compressed (bytes)": 54190811494,
+        "total_terms": 14165667143,
+        "documents": 11959635,
+        "unique_terms": 44860768,
+        "downloaded": False
+    },
+    "msmarco-v2.1-doc-slim": {
+        "description": "Lucene index of the MS MARCO V2.1 document corpus ('slim' version).",
+        "filename": "lucene-inverted.msmarco-v2.1-doc-slim.20240418.4f9675.tar.gz",
+        "readme": "lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2.1-doc-slim.20240418.4f9675.tar.gz",
+        ],
+        "md5": "2c31a8c0a7133eb6ea04c91ceffa7e08",
+        "size compressed (bytes)": 6191736133,
+        "total_terms": 14165667143,
+        "documents": 11959635,
+        "unique_terms": 44860768,
+        "downloaded": False
+    },
+    "msmarco-v2.1-doc-full": {
+        "description": "Lucene index of the MS MARCO V2.1 document corpus ('full' version).",
+        "filename": "lucene-inverted.msmarco-v2.1-doc-full.20240418.4f9675.tar.gz",
+        "readme": "lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2.1-doc-full.20240418.4f9675.tar.gz",
+        ],
+        "md5": "794708c9cf8fc6eafff07c5485e934b9",
+        "size compressed (bytes)": 102997532522,
+        "total_terms": 14165667143,
+        "documents": 11959635,
+        "unique_terms": 44860768,
+        "downloaded": False
+    },
+
+    # MS MARCO V2.1 segmented document corpus, three indexes with different amounts of information (and sizes).
+    "msmarco-v2.1-doc-segmented": {
+        "description": "Lucene index of the MS MARCO V2.1 segmented document corpus.",
+        "filename": "lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.tar.gz",
+        "readme": "lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.tar.gz"
+        ],
+        "md5": "6ec4cd595c9fe1ad91b43eabb39a637c",
+        "size compressed (bytes)": 60071133069,
+        "total_terms": 24780918039,
+        "documents": 124131414,
+        "unique_terms": 29265408,
+        "downloaded": False
+    },
+    "msmarco-v2.1-doc-segmented-slim": {
+        "description": "Lucene index of the MS MARCO V2.1 segmented document corpus ('slim' version).",
+        "filename": "lucene-inverted.msmarco-v2.1-doc-segmented-slim.20240418.4f9675.tar.gz",
+        "readme": "lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2.1-doc-segmented-slim.20240418.4f9675.tar.gz"
+        ],
+        "md5": "3c6c946c722a201b65903a92f082ea4f",
+        "size compressed (bytes)": 15374492909,
+        "total_terms": 24780918039,
+        "documents": 124131414,
+        "unique_terms": 29265408,
+        "downloaded": False
+    },
+    "msmarco-v2.1-doc-segmented-full": {
+        "description": "Lucene index of the MS MARCO V2.1 segmented document corpus ('full' version).",
+        "filename": "lucene-inverted.msmarco-v2.1-doc-segmented-full.20240418.4f9675.tar.gz",
+        "readme": "lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2.1-doc-segmented-full.20240418.4f9675.tar.gz"
+        ],
+        "md5": "a43d09d31ae4e5dac81f5cfde1a810a7",
+        "size compressed (bytes)": 146130406504,
+        "total_terms": 24780918039,
+        "documents": 124131414,
+        "unique_terms": 29265408,
+        "downloaded": False
     }
 }
 

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -573,9 +573,9 @@ TF_INDEX_INFO_MSMARCO = {
         ],
         "md5": "cecd55856c34afa82f1a499705c9df02",
         "size compressed (bytes)": 54190811494,
-        "total_terms": 14165667143,
-        "documents": 11959635,
-        "unique_terms": 44860768,
+        "total_terms": 12710796540,
+        "documents": 10960555,
+        "unique_terms": 44599151,
         "downloaded": False
     },
     "msmarco-v2.1-doc-slim": {
@@ -587,9 +587,9 @@ TF_INDEX_INFO_MSMARCO = {
         ],
         "md5": "2c31a8c0a7133eb6ea04c91ceffa7e08",
         "size compressed (bytes)": 6191736133,
-        "total_terms": 14165667143,
-        "documents": 11959635,
-        "unique_terms": 44860768,
+        "total_terms": 12710796540,
+        "documents": 10960555,
+        "unique_terms": 44599151,
         "downloaded": False
     },
     "msmarco-v2.1-doc-full": {
@@ -601,9 +601,9 @@ TF_INDEX_INFO_MSMARCO = {
         ],
         "md5": "794708c9cf8fc6eafff07c5485e934b9",
         "size compressed (bytes)": 102997532522,
-        "total_terms": 14165667143,
-        "documents": 11959635,
-        "unique_terms": 44860768,
+        "total_terms": 12710796540,
+        "documents": 10960555,
+        "unique_terms": 44599151,
         "downloaded": False
     },
 
@@ -617,9 +617,9 @@ TF_INDEX_INFO_MSMARCO = {
         ],
         "md5": "6ec4cd595c9fe1ad91b43eabb39a637c",
         "size compressed (bytes)": 60071133069,
-        "total_terms": 24780918039,
-        "documents": 124131414,
-        "unique_terms": 29265408,
+        "total_terms": 22707699649,
+        "documents": 113520750,
+        "unique_terms": 29040364,
         "downloaded": False
     },
     "msmarco-v2.1-doc-segmented-slim": {
@@ -631,9 +631,9 @@ TF_INDEX_INFO_MSMARCO = {
         ],
         "md5": "3c6c946c722a201b65903a92f082ea4f",
         "size compressed (bytes)": 15374492909,
-        "total_terms": 24780918039,
-        "documents": 124131414,
-        "unique_terms": 29265408,
+        "total_terms": 22707699649,
+        "documents": 113520750,
+        "unique_terms": 29040364,
         "downloaded": False
     },
     "msmarco-v2.1-doc-segmented-full": {
@@ -645,9 +645,9 @@ TF_INDEX_INFO_MSMARCO = {
         ],
         "md5": "a43d09d31ae4e5dac81f5cfde1a810a7",
         "size compressed (bytes)": 146130406504,
-        "total_terms": 24780918039,
-        "documents": 124131414,
-        "unique_terms": 29265408,
+        "total_terms": 22707699649,
+        "documents": 113520750,
+        "unique_terms": 29040364,
         "downloaded": False
     }
 }

--- a/pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md
+++ b/pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675.README.md
@@ -1,0 +1,34 @@
+# msmarco-v2.1-doc-segmented
+
+Lucene inverted index of the MS MARCO V2.1 segmented document corpus.
+
+Note that there are three variants of this index:
+
++ `msmarco-v2.1-doc-segmented` (56G uncompressed): the "default" version, which stores term frequencies and the raw text. This supports bag-of-words queries, but no phrase queries and no relevance feedback (unless the documents are parsed on the fly).
++ `msmarco-v2.1-doc-segmented-slim` (15G uncompressed): the "slim" version, which stores term frequencies only. This supports bag-of-words queries, but no phrase queries and no relevance feedback. There is no way to fetch the raw text from this index.
++ `msmarco-v2.1-doc-segmented-full` (137G uncompressed): the "full" version, which stores term frequencies, term positions, document vectors, and the raw text. This supports bag-of-words queries, phrase queries, and relevance feedback.
+
+These indexes were generated on 2024/04/19 at Anserini commit [`4f9675`](https://github.com/castorini/anserini/commit/4f967519baa1bc634f7dd2998d7a408c27120b1c) on `tuna` with the following commands:
+
+```bash
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection MsMarcoV2DocCollection \
+  -input /mnt/collections/msmarco/msmarco_v2.1_doc_segmented/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.20240418.4f9675/ \
+  -threads 8 -storeRaw -optimize >& logs/log.msmarco-v2.1-doc-segmented.20240418.4f9675.txt &
+
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection MsMarcoV2DocCollection \
+  -input /mnt/collections/msmarco/msmarco_v2.1_doc_segmented/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented-slim.20240418.4f9675/ \
+  -threads 8 -optimize >& logs/log.msmarco-v2.1-doc-segmented-slim.20240418.4f9675.txt &
+
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection MsMarcoV2DocCollection \
+  -input /mnt/collections/msmarco/msmarco_v2.1_doc_segmented/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented-full.20240418.4f9675/ \
+  -threads 8 -storePositions -storeDocvectors -storeRaw -optimize >& logs/log.msmarco-v2.1-doc-segmented-full.20240418.4f9675.txt &
+```

--- a/pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md
+++ b/pyserini/resources/index-metadata/lucene-inverted.msmarco-v2.1-doc.20240418.4f9675.README.md
@@ -1,0 +1,34 @@
+# msmarco-v2.1-doc
+
+Lucene inverted index of the MS MARCO V2.1 document corpus.
+
+Note that there are three variants of this index:
+
++ `msmarco-v2.1-doc` (51G uncompressed): the "default" version, which stores term frequencies and the raw text. This supports bag-of-words queries, but no phrase queries and no relevance feedback (unless the documents are parsed on the fly).
++ `msmarco-v2.1-doc-slim` (5.8G uncompressed): the "slim" version, which stores term frequencies only. This supports bag-of-words queries, but no phrase queries and no relevance feedback. There is no way to fetch the raw text from this index.
++ `msmarco-v2.1-doc-full` (96G uncompressed): the "full" version, which stores term frequencies, term positions, document vectors, and the raw text. This supports bag-of-words queries, phrase queries, and relevance feedback.
+
+These indexes were generated on 2024/04/19 at Anserini commit [`4f9675`](https://github.com/castorini/anserini/commit/4f967519baa1bc634f7dd2998d7a408c27120b1c) on `tuna` with the following commands:
+
+```bash
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection MsMarcoV2DocCollection \
+  -input /mnt/collections/msmarco/msmarco_v2.1_doc/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc.20240418.4f9675/ \
+  -threads 8 -storeRaw -optimize >& logs/log.msmarco-v2.1-doc.20240418.4f9675.txt &
+
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection MsMarcoV2DocCollection \
+  -input /mnt/collections/msmarco/msmarco_v2.1_doc/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-slim.20240418.4f9675/ \
+  -threads 8 -optimize >& logs/log.msmarco-v2.1-doc-slim.20240418.4f9675.txt &
+
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection MsMarcoV2DocCollection \
+  -input /mnt/collections/msmarco/msmarco_v2.1_doc/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-full.20240418.4f9675/ \
+  -threads 8 -storePositions -storeDocvectors -storeRaw -optimize >& logs/log.msmarco-v2.1-doc-full.20240418.4f9675.txt &
+```

--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -82,14 +82,18 @@ topics_mapping = {
     'dl20-unicoil': 'TREC2020_DL_UNICOIL',
     'dl20-unicoil-noexp': 'TREC2020_DL_UNICOIL_NOEXP',
     'dl21': 'TREC2021_DL',
+    'dl21-doc': 'TREC2021_DL',
     'dl21-unicoil': 'TREC2021_DL_UNICOIL',
     'dl21-unicoil-noexp': 'TREC2021_DL_UNICOIL_NOEXP',
     'dl22': 'TREC2022_DL',
+    'dl22-doc': 'TREC2022_DL',
     'dl22-unicoil': 'TREC2022_DL_UNICOIL',
     'dl22-unicoil-noexp': 'TREC2022_DL_UNICOIL_NOEXP',
     'dl23': 'TREC2023_DL',
+    'dl23-doc': 'TREC2023_DL',
     'dl23-unicoil': 'TREC2023_DL_UNICOIL',
     'dl23-unicoil-noexp': 'TREC2023_DL_UNICOIL_NOEXP',
+    'rag24.raggy-dev': 'TREC2024_RAG_RAGGY_DEV',
     'msmarco-doc-dev': 'MSMARCO_DOC_DEV',
     'msmarco-doc-dev-unicoil': 'MSMARCO_DOC_DEV_UNICOIL',
     'msmarco-doc-dev-unicoil-noexp': 'MSMARCO_DOC_DEV_UNICOIL_NOEXP',
@@ -102,9 +106,11 @@ topics_mapping = {
     'msmarco-passage-dev-subset-distill-splade-max': 'MSMARCO_PASSAGE_DEV_SUBSET_DISTILL_SPLADE_MAX',
     'msmarco-passage-test-subset': 'MSMARCO_PASSAGE_TEST_SUBSET',
     'msmarco-v2-doc-dev': 'MSMARCO_V2_DOC_DEV',
+    'msmarco-v2-doc.dev': 'MSMARCO_V2_DOC_DEV',
     'msmarco-v2-doc-dev-unicoil': 'MSMARCO_V2_DOC_DEV_UNICOIL',
     'msmarco-v2-doc-dev-unicoil-noexp': 'MSMARCO_V2_DOC_DEV_UNICOIL_NOEXP',
     'msmarco-v2-doc-dev2': 'MSMARCO_V2_DOC_DEV2',
+    'msmarco-v2-doc.dev2': 'MSMARCO_V2_DOC_DEV2',
     'msmarco-v2-doc-dev2-unicoil': 'MSMARCO_V2_DOC_DEV2_UNICOIL',
     'msmarco-v2-doc-dev2-unicoil-noexp': 'MSMARCO_V2_DOC_DEV2_UNICOIL_NOEXP',
     'msmarco-v2-passage-dev': 'MSMARCO_V2_PASSAGE_DEV',
@@ -419,12 +425,18 @@ qrels_mapping = {
     'dl22-passage': 'TREC2022_DL_PASSAGE',
     'dl23-doc': 'TREC2023_DL_DOC',
     'dl23-passage': 'TREC2023_DL_PASSAGE',
+    'dl21-doc-msmarco-v2.1': 'TREC2021_DL_DOC_MSMARCO_V21',
+    'dl22-doc-msmarco-v2.1': 'TREC2022_DL_DOC_MSMARCO_V21',
+    'dl23-doc-msmarco-v2.1': 'TREC2023_DL_DOC_MSMARCO_V21',
+    'rag24.raggy-dev': 'TREC2024_RAG_RAGGY_DEV',
     'msmarco-doc-dev': 'MSMARCO_DOC_DEV',
     'msmarco-passage-dev-subset': 'MSMARCO_PASSAGE_DEV_SUBSET',
     'msmarco-v2-doc-dev': 'MSMARCO_V2_DOC_DEV',
     'msmarco-v2-doc-dev2': 'MSMARCO_V2_DOC_DEV2',
     'msmarco-v2-passage-dev': 'MSMARCO_V2_PASSAGE_DEV',
     'msmarco-v2-passage-dev2': 'MSMARCO_V2_PASSAGE_DEV2',
+    'msmarco-v2.1-doc.dev': 'MSMARCO_V21_DOC_DEV',
+    'msmarco-v2.1-doc.dev2': 'MSMARCO_V21_DOC_DEV2',
     'ntcir8-zh': 'NTCIR8_ZH',
     'clef2006-fr': 'CLEF2006_FR',
     'trec2002-ar': 'TREC2002_AR',
@@ -564,6 +576,7 @@ for qrel in qrels_mapping:
 
 topics_mapping = {k: v for k, v in topics_mapping.items() if v is not None}
 qrels_mapping = {k: v for k, v in qrels_mapping.items() if v is not None}
+
 
 def get_topics(collection_name):
     """

--- a/scripts/generate_docs_from_prebuilt_indexes.py
+++ b/scripts/generate_docs_from_prebuilt_indexes.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 #
 
-import os
-import sys
-
-# Use Pyserini in this repo (as opposed to pip install)
-sys.path.insert(0, './')
 
 from pyserini.prebuilt_index_info import *
 
@@ -26,8 +21,8 @@ from pyserini.prebuilt_index_info import *
 __boilerplate__ = '''
 # Pyserini: Prebuilt Indexes
 
-Pyserini provides a number of pre-built Lucene indexes.
-To list what's available in code:
+Pyserini provides a number of prebuilt Lucene indexes.
+To list what's available:
 
 ```python
 from pyserini.search.lucene import LuceneSearcher
@@ -37,13 +32,13 @@ from pyserini.index.lucene import IndexReader
 IndexReader.list_prebuilt_indexes()
 ```
 
-It's easy initialize a searcher from a pre-built index:
+It's easy initialize a searcher from a prebuilt index:
 
 ```python
 searcher = LuceneSearcher.from_prebuilt_index('robust04')
 ```
 
-You can use this simple Python one-liner to download the pre-built index:
+You can use this simple Python one-liner to download the prebuilt index:
 
 ```
 python -c "from pyserini.search.lucene import LuceneSearcher; LuceneSearcher.from_prebuilt_index('robust04')"
@@ -51,7 +46,7 @@ python -c "from pyserini.search.lucene import LuceneSearcher; LuceneSearcher.fro
 
 The downloaded index will be in `~/.cache/pyserini/indexes/`.
 
-It's similarly easy initialize an index reader from a pre-built index:
+It's similarly easy initialize an index reader from a prebuilt index:
 
 ```python
 index_reader = IndexReader.from_prebuilt_index('robust04')
@@ -67,8 +62,22 @@ The output will be:
 Note that unless the underlying index was built with the `-optimize` option (i.e., merging all index segments into a single segment), `unique_terms` will show -1.
 Nope, that's not a bug.
 
-Below is a summary of the pre-built indexes that are currently available.
-Detailed configuration information for the pre-built indexes are stored in [`pyserini/prebuilt_index_info.py`](../pyserini/prebuilt_index_info.py).
+Pyserini also provides a number of prebuilt Faiss indexes.
+To list what's available:
+
+```python
+from pyserini.search.faiss import FaissSearcher
+FaissSearcher.list_prebuilt_indexes()
+```
+
+And to initialize a specific Faiss index:
+
+```python
+searcher = FaissSearcher.from_prebuilt_index('msmarco-v1-passage.bge-base-en-v1.5', None)
+```
+
+Below is a summary of the prebuilt indexes that are currently available.
+Detailed configuration information for the prebuilt indexes are stored in [`pyserini/prebuilt_index_info.py`](../pyserini/prebuilt_index_info.py).
 
 '''
 

--- a/tests/test_load_qrels.py
+++ b/tests/test_load_qrels.py
@@ -333,6 +333,16 @@ class TestLoadQrels(unittest.TestCase):
         self.assertEqual(len(qrels), 5000)
         self.assertTrue(isinstance(next(iter(qrels.keys())), int))
 
+        qrels = search.get_qrels('msmarco-v2.1-doc.dev')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 4552)
+        self.assertTrue(isinstance(next(iter(qrels.keys())), int))
+
+        qrels = search.get_qrels('msmarco-v2.1-doc.dev2')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 5000)
+        self.assertTrue(isinstance(next(iter(qrels.keys())), int))
+
     def test_msmarco_v2_passage(self):
         qrels = search.get_qrels('msmarco-v2-passage-dev')
         self.assertIsNotNone(qrels)
@@ -351,6 +361,12 @@ class TestLoadQrels(unittest.TestCase):
         self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 13058)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
+        qrels = search.get_qrels('dl21-doc-msmarco-v2.1')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 57)
+        self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 10973)
+        self.assertFalse(isinstance(next(iter(qrels.keys())), str))
+
         qrels = search.get_qrels('dl21-passage')
         self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 53)
@@ -362,6 +378,12 @@ class TestLoadQrels(unittest.TestCase):
         self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 76)
         self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 369638)
+        self.assertFalse(isinstance(next(iter(qrels.keys())), str))
+
+        qrels = search.get_qrels('dl22-doc-msmarco-v2.1')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 76)
+        self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 349541)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
         qrels = search.get_qrels('dl22-passage')
@@ -377,10 +399,23 @@ class TestLoadQrels(unittest.TestCase):
         self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 18034)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
+        qrels = search.get_qrels('dl23-doc-msmarco-v2.1')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 82)
+        self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 15995)
+        self.assertFalse(isinstance(next(iter(qrels.keys())), str))
+
         qrels = search.get_qrels('dl23-passage')
         self.assertIsNotNone(qrels)
         self.assertEqual(len(qrels), 82)
         self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 22327)
+        self.assertFalse(isinstance(next(iter(qrels.keys())), str))
+
+    def test_rag24(self):
+        qrels = search.get_qrels('rag24.raggy-dev')
+        self.assertIsNotNone(qrels)
+        self.assertEqual(len(qrels), 120)
+        self.assertEqual(sum([len(qrels[topic_id]) for topic_id in qrels]), 147328)
         self.assertFalse(isinstance(next(iter(qrels.keys())), str))
 
     # Various multi-lingual test collections

--- a/tests/test_load_queries.py
+++ b/tests/test_load_queries.py
@@ -288,6 +288,12 @@ class TestLoadTopics(unittest.TestCase):
         self.assertEqual(len(topics), 4552)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
+        # This is an alias used by Anserini fatjar regressions, making sure it works in Pyserini also.
+        topics = search.get_topics('msmarco-v2-doc.dev')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 4552)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
         topics = search.get_topics('msmarco-v2-doc-dev-unicoil')
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 4552)
@@ -299,6 +305,12 @@ class TestLoadTopics(unittest.TestCase):
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
 
         topics = search.get_topics('msmarco-v2-doc-dev2')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 5000)
+        self.assertTrue(isinstance(next(iter(topics.keys())), int))
+
+        # This is an alias used by Anserini fatjar regressions, making sure it works in Pyserini also.
+        topics = search.get_topics('msmarco-v2-doc.dev2')
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 5000)
         self.assertTrue(isinstance(next(iter(topics.keys())), int))
@@ -355,6 +367,12 @@ class TestLoadTopics(unittest.TestCase):
         self.assertEqual(len(topics), 477)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
 
+        # This is an alias used by Anserini fatjar regressions, making sure it works in Pyserini also.
+        topics = search.get_topics('dl21-doc')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 477)
+        self.assertFalse(isinstance(next(iter(topics.keys())), str))
+
         topics = search.get_topics('dl21-unicoil')
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 477)
@@ -367,6 +385,12 @@ class TestLoadTopics(unittest.TestCase):
 
     def test_dl22(self):
         topics = search.get_topics('dl22')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 500)
+        self.assertFalse(isinstance(next(iter(topics.keys())), str))
+
+        # This is an alias used by Anserini fatjar regressions, making sure it works in Pyserini also.
+        topics = search.get_topics('dl22-doc')
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 500)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
@@ -387,6 +411,12 @@ class TestLoadTopics(unittest.TestCase):
         self.assertEqual(len(topics), 700)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
 
+        # This is an alias used by Anserini fatjar regressions, making sure it works in Pyserini also.
+        topics = search.get_topics('dl23-doc')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 700)
+        self.assertFalse(isinstance(next(iter(topics.keys())), str))
+
         topics = search.get_topics('dl23-unicoil')
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 700)
@@ -395,6 +425,12 @@ class TestLoadTopics(unittest.TestCase):
         topics = search.get_topics('dl23-unicoil-noexp')
         self.assertIsNotNone(topics)
         self.assertEqual(len(topics), 700)
+        self.assertFalse(isinstance(next(iter(topics.keys())), str))
+
+    def test_rag24(self):
+        topics = search.get_topics('rag24.raggy-dev')
+        self.assertIsNotNone(topics)
+        self.assertEqual(len(topics), 120)
         self.assertFalse(isinstance(next(iter(topics.keys())), str))
 
     # Various multi-lingual test collections


### PR DESCRIPTION
This works:

```bash
export OUTPUT_DIR="runs"

# doc condition
TOPICS=(msmarco-v2-doc.dev msmarco-v2-doc.dev2 dl21-doc dl22-doc dl23-doc rag24.raggy-dev); for t in "${TOPICS[@]}"
do
    python -m pyserini.search.lucene --threads 16 --batch-size 128 --index msmarco-v2.1-doc --topics $t --output $OUTPUT_DIR/run.msmarco-v2.1.doc.${t}.txt --bm25
done

# doc-segmented condition
TOPICS=(msmarco-v2-doc.dev msmarco-v2-doc.dev2 dl21-doc dl22-doc dl23-doc rag24.raggy-dev); for t in "${TOPICS[@]}"
do
    python -m pyserini.search.lucene --threads 16 --batch-size 128 --index msmarco-v2.1-doc-segmented --topics $t --output $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.${t}.txt --bm25 --hits 10000 --max-passage-hits 1000 --max-passage
done
```