### PR TITLE
Add prebuilt indexes for newswire collections

### DIFF
--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -643,9 +643,21 @@ Detailed configuration information for the prebuilt indexes are stored in [`pyse
 <dt></dt><b><code>cacm</code></b>
 <dd>Lucene index of the CACM corpus.
 </dd>
-<dt></dt><b><code>robust04</code></b>
-[<a href="../pyserini/resources/index-metadata/lucene-index.robust04.20221005.252b5e.README.md">readme</a>]
+<dt></dt><b><code>disk45</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.disk45.20240803.36f7e3.README.md">readme</a>]
 <dd>Lucene index of TREC Disks 4 & 5 (minus Congressional Records), used in the TREC 2004 Robust Track.
+</dd>
+<dt></dt><b><code>aquaint</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.aquaint.20240803.36f7e3.README.md">readme</a>]
+<dd>Lucene index of the AQUAINT collection, used in the TREC 2005 Robust Track.
+</dd>
+<dt></dt><b><code>nyt</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.nyt.20240803.36f7e3.README.md">readme</a>]
+<dd>Lucene index of the New York Times Annotated Corpus, used in the TREC 2017 Common Core Track.
+</dd>
+<dt></dt><b><code>wapo.v2</code></b>
+[<a href="../pyserini/resources/index-metadata/lucene-inverted.wapo.v2.20240803.36f7e3.README.md">readme</a>]
+<dd>Lucene index of the TREC Washington Post Corpus, used in the TREC 2018 Common Core Track.
 </dd>
 <dt></dt><b><code>enwiki-paragraphs</code></b>
 <dd>Lucene index of English Wikipedia for BERTserini

--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -2039,18 +2039,57 @@ TF_INDEX_INFO_OTHER = {
         "documents": 3204,
         "unique_terms": 14363,
     },
-    "robust04": {
+    "disk45": {
         "description": "Lucene index of TREC Disks 4 & 5 (minus Congressional Records), used in the TREC 2004 Robust Track.",
-        "filename": "lucene-index.robust04.20221005.252b5e.tar.gz",
-        "readme": "lucene-index.robust04.20221005.252b5e.README.md",
+        "filename": "lucene-inverted.disk45.20240803.36f7e3.tar.gz",
+        "readme": "lucene-inverted.disk45.20240803.36f7e3.README.md",
         "urls": [
-            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene-index.robust04.20221005.252b5e.tar.gz",
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.disk45.20240803.36f7e3.tar.gz",
         ],
-        "md5": "a1abd5437394956b7ec8bea4699b5e46",
-        "size compressed (bytes)": 1806776535,
+        "md5": "0bb7f40c88a9246d068bbda86a6b90d5",
+        "size compressed (bytes)": 1782067062,
         "total_terms": 174540872,
         "documents": 528030,
         "unique_terms": 923436,
+    },
+    "aquaint": {
+        "description": "Lucene index of the AQUAINT collection, used in the TREC 2005 Robust Track.",
+        "filename": "lucene-inverted.aquaint.20240803.36f7e3.tar.gz",
+        "readme": "lucene-inverted.aquaint.20240803.36f7e3.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.aquaint.20240803.36f7e3.tar.gz",
+        ],
+        "md5": "3adbc54b7fcaaf568e741797e407199c",
+        "size compressed (bytes)": 3185164151,
+        "total_terms": 317246296,
+        "documents": 1031455,
+        "unique_terms": 966312,
+    },
+    "nyt": {
+        "description": "Lucene index of the New York Times Annotated Corpus, used in the TREC 2017 Common Core Track.",
+        "filename": "lucene-inverted.nyt.20240803.36f7e3.tar.gz",
+        "readme": "lucene-inverted.nyt.20240803.36f7e3.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.nyt.20240803.36f7e3.tar.gz",
+        ],
+        "md5": "0db100878ee9556515cf2acf3a9f1ac5",
+        "size compressed (bytes)": 7622623345,
+        "total_terms": 751047962,
+        "documents": 1855650,
+        "unique_terms": 1730963,
+    },
+    "wapo.v2": {
+        "description": "Lucene index of the TREC Washington Post Corpus, used in the TREC 2018 Common Core Track.",
+        "filename": "lucene-inverted.wapo.v2.20240803.36f7e3.tar.gz",
+        "readme": "lucene-inverted.wapo.v2.20240803.36f7e3.README.md",
+        "urls": [
+            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.wapo.v2.20240803.36f7e3.tar.gz",
+        ],
+        "md5": "fbe8fa7a7f0dcae2bae9b8fe1dd7ab07",
+        "size compressed (bytes)": 3994471983,
+        "total_terms": 318219870,
+        "documents": 595031,
+        "unique_terms": 835854,
     },
 
     "enwiki-paragraphs": {
@@ -2580,6 +2619,12 @@ TF_INDEX_INFO_OTHER = {
 TF_INDEX_INFO_OTHER_ALIASES = {
     # To preserve working commands in published papers: integrations/papers/test_sigir2021.py
     "wikipedia-dpr": TF_INDEX_INFO_OTHER["wikipedia-dpr-100w"],
+
+    # Common names mapping to corpora
+    "robust04": TF_INDEX_INFO_OTHER["disk45"],
+    "robust05": TF_INDEX_INFO_OTHER["aquaint"],
+    "core17": TF_INDEX_INFO_OTHER["nyt"],
+    "core18": TF_INDEX_INFO_OTHER["wapo.v2"],
 }
 
 TF_INDEX_INFO = {**TF_INDEX_INFO_MSMARCO,

--- a/pyserini/resources/index-metadata/index-robust04-20191213-readme.txt
+++ b/pyserini/resources/index-metadata/index-robust04-20191213-readme.txt
@@ -1,7 +1,0 @@
-This index was generated on 12/13/2019 with Anserini v0.7.0, with the following command:
-
-sh target/appassembler/bin/IndexCollection -collection TrecCollection \
- -input /tuna1/collections/newswire/disk45/ -index index-robust04-20191213 \
- -generator JsoupGenerator -threads 16 -storePositions -storeDocvectors -storeRawDocs -optimize
-
-index-robust04-20191213.tar.gz MD5 checksum = 15f3d001489c97849a010b0a4734d018

--- a/pyserini/resources/index-metadata/lucene-inverted.aquaint.20240803.36f7e3.README.md
+++ b/pyserini/resources/index-metadata/lucene-inverted.aquaint.20240803.36f7e3.README.md
@@ -1,0 +1,14 @@
+# aquaint
+
+Lucene index of the [AQUAINT collection](https://tac.nist.gov//data/data_desc.html#AQUAINT), used in the TREC 2005 Robust Track.
+This index was built on 2024/08/03 at Anserini commit [`36f7e3`](https://github.com/castorini/anserini/commit/36f7e314d6c07f6cc4a23ce30cd1821c920ba231) on `orca` with the following command:
+
+```bash
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection TrecCollection \
+  -input /store/collections/newswire/AQUAINT \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.aquaint/ \
+  -threads 16 -storePositions -storeDocvectors -storeRaw -optimize \
+  >& logs/log.aquaint &
+```

--- a/pyserini/resources/index-metadata/lucene-inverted.disk45.20240803.36f7e3.README.md
+++ b/pyserini/resources/index-metadata/lucene-inverted.disk45.20240803.36f7e3.README.md
@@ -1,0 +1,14 @@
+# disk45
+
+Lucene index of [TREC Disks 4 & 5](https://trec.nist.gov/data/cd45/index.html) (minus Congressional Records), used in the TREC 2004 Robust Track.
+This index was built on 2024/08/03 at Anserini commit [`36f7e3`](https://github.com/castorini/anserini/commit/36f7e314d6c07f6cc4a23ce30cd1821c920ba231) on `orca` with the following command:
+
+```bash
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection TrecCollection \
+  -input /store/collections/newswire/disk45 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.disk45/ \
+  -threads 16 -storePositions -storeDocvectors -storeRaw -optimize \
+  >& logs/log.disk45 &
+```

--- a/pyserini/resources/index-metadata/lucene-inverted.nyt.20240803.36f7e3.README.md
+++ b/pyserini/resources/index-metadata/lucene-inverted.nyt.20240803.36f7e3.README.md
@@ -1,0 +1,14 @@
+# nyt
+
+Lucene index of the [New York Times Annotated Corpus](https://catalog.ldc.upenn.edu/LDC2008T19), used in the TREC 2017 Common Core Track.
+This index was built on 2024/08/03 at Anserini commit [`36f7e3`](https://github.com/castorini/anserini/commit/36f7e314d6c07f6cc4a23ce30cd1821c920ba231) on `orca` with the following command:
+
+```bash
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection NewYorkTimesCollection \
+  -input /store/collections/newswire/NYTcorpus/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.nyt/ \
+  -threads 16 -storePositions -storeDocvectors -storeRaw -optimize \
+  >& logs/log.nyt &
+```

--- a/pyserini/resources/index-metadata/lucene-inverted.wapo.v2.20240803.36f7e3.README.md
+++ b/pyserini/resources/index-metadata/lucene-inverted.wapo.v2.20240803.36f7e3.README.md
@@ -1,0 +1,14 @@
+# wapo.v2
+
+Lucene index of the [TREC Washington Post Corpus](https://trec.nist.gov/data/wapost/), used in the TREC 2018 Common Core Track.
+This index was built on 2024/08/03 at Anserini commit [`36f7e3`](https://github.com/castorini/anserini/commit/36f7e314d6c07f6cc4a23ce30cd1821c920ba231) on `orca` with the following command:
+
+```bash
+nohup bin/run.sh io.anserini.index.IndexCollection \
+  -collection WashingtonPostCollection \
+  -input /store/collections/newswire/WashingtonPost.v2/data/ \
+  -generator WashingtonPostGenerator \
+  -index indexes/lucene-inverted.wapo.v2/ \
+  -threads 1 -storePositions -storeDocvectors -storeRaw -optimize \
+  >& logs/log.wapo.v2 &
+```


### PR DESCRIPTION
disk45 (robust04), aquaint (robust05), nyt (core17), wapo.v2 (core18)

These commands work:

```
python -m pyserini.search.lucene --index robust04 --topics robust04 --output runs/run.robust04 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 robust04 runs/run.robust04
map                   	all	0.2531
P_30                  	all	0.3102

python -m pyserini.search.lucene --index robust05 --topics robust05 --output runs/run.robust05 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 robust05 runs/run.robust05
map                   	all	0.2032
P_30                  	all	0.3693

python -m pyserini.search.lucene --index core17 --topics core17 --output runs/run.core17 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 core17 runs/run.core17
map                   	all	0.2087
P_30                  	all	0.4293

python -m pyserini.search.lucene --index core18 --topics core18 --output runs/run.core18 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 core18 runs/run.core18
map                   	all	0.2496
P_30                  	all	0.3573

---

python -m pyserini.search.lucene --index disk45 --topics robust04 --output runs/run.robust04 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 robust04 runs/run.robust04
map                   	all	0.2531
P_30                  	all	0.3102

python -m pyserini.search.lucene --index aquaint --topics robust04 --output runs/run.robust05 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 robust05 runs/run.robust05
map                   	all	0.2032
P_30                  	all	0.3693

python -m pyserini.search.lucene --index nyt --topics core17 --output runs/run.core17 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 core17 runs/run.core17
map                   	all	0.2087
P_30                  	all	0.4293

python -m pyserini.search.lucene --index wapo.v2 --topics core18 --output runs/run.core18 --bm25

python -m pyserini.eval.trec_eval -c -m map -m P.30 core18 runs/run.core18
map                   	all	0.2496
P_30                  	all	0.3573
```
