### PR TITLE
Refactoring documentation for some dense models

### DIFF
--- a/docs/experiments-ance.md
+++ b/docs/experiments-ance.md
@@ -17,9 +17,9 @@ python -m pyserini.search.faiss \
   --index msmarco-v1-passage.ance \
   --topics msmarco-passage-dev-subset \
   --encoded-queries ance-msmarco-passage-dev-subset \
-  --output runs/run.msmarco-passage.ance.bf.tsv \
+  --output runs/run.msmarco-passage.ance.tsv \
   --output-format msmarco \
-  --batch-size 36 --threads 12
+  --batch-size 512 --threads 16
 ```
 
 The option `--encoded-queries` specifies the use of encoded queries (i.e., queries that have already been converted into dense vectors and cached).
@@ -28,9 +28,13 @@ As an alternative, replace with `--encoder castorini/ance-msmarco-passage` to pe
 To evaluate:
 
 ```bash
-$ python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset \
-    runs/run.msmarco-passage.ance.bf.tsv
+python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset \
+  runs/run.msmarco-passage.ance.tsv
+```
 
+Results:
+
+```
 #####################
 MRR @10: 0.3302
 QueriesRanked: 6980
@@ -41,14 +45,18 @@ We can also use the official TREC evaluation tool `trec_eval` to compute other m
 For that we first need to convert runs and qrels files to the TREC format:
 
 ```bash
-$ python -m pyserini.eval.convert_msmarco_run_to_trec_run \
-    --input runs/run.msmarco-passage.ance.bf.tsv \
-    --output runs/run.msmarco-passage.ance.bf.trec
+python -m pyserini.eval.convert_msmarco_run_to_trec_run \
+  --input runs/run.msmarco-passage.ance.tsv \
+  --output runs/run.msmarco-passage.ance.trec
 
-$ python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap msmarco-passage-dev-subset \
-    runs/run.msmarco-passage.ance.bf.trec
+python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap msmarco-passage-dev-subset \
+    runs/run.msmarco-passage.ance.trec
+```
 
-map                   	all	0.3362
+Results:
+
+```
+map                   	all	0.3363
 recall_1000           	all	0.9584
 ```
 
@@ -63,7 +71,7 @@ python -m pyserini.search.faiss \
   --encoded-queries ance_maxp-msmarco-doc-dev \
   --output runs/run.msmarco-doc.passage.ance-maxp.txt \
   --output-format msmarco \
-  --batch-size 36 --threads 12 \
+  --batch-size 512 --threads 16 \
   --hits 1000 --max-passage --max-passage-hits 100
 ```
 
@@ -72,12 +80,16 @@ Same as above, replace `--encoded-queries` with `--encoder castorini/ance-msmarc
 To evaluate:
 
 ```bash
-$ python -m pyserini.eval.msmarco_doc_eval \
-    --judgments msmarco-doc-dev \
-    --run runs/run.msmarco-doc.passage.ance-maxp.txt
+python -m pyserini.eval.msmarco_doc_eval \
+  --judgments msmarco-doc-dev \
+  --run runs/run.msmarco-doc.passage.ance-maxp.txt
+```
 
+Results:
+
+```
 #####################
-MRR @100: 0.3796
+MRR @100: 0.3795
 QueriesRanked: 5193
 #####################
 ```
@@ -86,14 +98,18 @@ We can also use the official TREC evaluation tool `trec_eval` to compute other m
 For that we first need to convert runs and qrels files to the TREC format:
 
 ```bash
-$ python -m pyserini.eval.convert_msmarco_run_to_trec_run \
-    --input runs/run.msmarco-doc.passage.ance-maxp.txt \
-    --output runs/run.msmarco-doc.passage.ance-maxp.trec
+python -m pyserini.eval.convert_msmarco_run_to_trec_run \
+  --input runs/run.msmarco-doc.passage.ance-maxp.txt \
+  --output runs/run.msmarco-doc.passage.ance-maxp.trec
 
-$ python -m pyserini.eval.trec_eval -c -mrecall.100 -mmap msmarco-doc-dev \
-    runs/run.msmarco-doc.passage.ance-maxp.trec
+python -m pyserini.eval.trec_eval -c -mrecall.100 -mmap msmarco-doc-dev \
+  runs/run.msmarco-doc.passage.ance-maxp.trec
+```
 
-map                   	all	0.3796
+Results:
+
+```
+map                   	all	0.3794
 recall_100            	all	0.9033
 ```
 
@@ -106,8 +122,8 @@ python -m pyserini.search.faiss \
   --index wikipedia-dpr-100w.ance-multi \
   --topics dpr-nq-test \
   --encoded-queries ance_multi-nq-test \
-  --output runs/run.ance.nq-test.multi.bf.trec \
-  --batch-size 36 --threads 12
+  --output runs/run.ance.nq-test.multi.trec \
+  --batch-size 512 --threads 16
 ```
 
 Same as above, replace `--encoded-queries` with `--encoder castorini/ance-dpr-question-multi` for on-the-fly query encoding.
@@ -115,16 +131,20 @@ Same as above, replace `--encoded-queries` with `--encoder castorini/ance-dpr-qu
 To evaluate, first convert the TREC output format to DPR's `json` format:
 
 ```bash
-$ python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
-    --topics dpr-nq-test \
-    --index wikipedia-dpr-100w \
-    --input runs/run.ance.nq-test.multi.bf.trec \
-    --output runs/run.ance.nq-test.multi.bf.json
+python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-nq-test \
+  --index wikipedia-dpr \
+  --input runs/run.ance.nq-test.multi.trec \
+  --output runs/run.ance.nq-test.multi.json
 
-$ python -m pyserini.eval.evaluate_dpr_retrieval \
-    --retrieval runs/run.ance.nq-test.multi.bf.json \
-    --topk 20 100
+python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.ance.nq-test.multi.json \
+  --topk 20 100
+```
 
+Results:
+
+```
 Top20	accuracy: 0.8224
 Top100	accuracy: 0.8787
 ```
@@ -138,8 +158,8 @@ python -m pyserini.search.faiss \
   --index wikipedia-dpr-100w.ance-multi \
   --topics dpr-trivia-test \
   --encoded-queries ance_multi-trivia-test \
-  --output runs/run.ance.trivia-test.multi.bf.trec \
-  --batch-size 36 --threads 12
+  --output runs/run.ance.trivia-test.multi.trec \
+  --batch-size 512 --threads 16
 ```
 
 Same as above, replace `--encoded-queries` with `--encoder castorini/ance-dpr-question-multi` for on-the-fly query encoding.
@@ -147,16 +167,20 @@ Same as above, replace `--encoded-queries` with `--encoder castorini/ance-dpr-qu
 To evaluate, first convert the TREC output format to DPR's `json` format:
 
 ```bash
-$ python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
-    --topics dpr-trivia-test \
-    --index wikipedia-dpr-100w \
-    --input runs/run.ance.trivia-test.multi.bf.trec \
-    --output runs/run.ance.trivia-test.multi.bf.json
+python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --topics dpr-trivia-test \
+  --index wikipedia-dpr \
+  --input runs/run.ance.trivia-test.multi.trec \
+  --output runs/run.ance.trivia-test.multi.json
 
-$ python -m pyserini.eval.evaluate_dpr_retrieval \
-    --retrieval runs/run.ance.trivia-test.multi.bf.json \
-    --topk 20 100
+python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.ance.trivia-test.multi.json \
+  --topk 20 100
+```
 
+Results:
+
+```
 Top20	accuracy: 0.8010
 Top100	accuracy: 0.8522
 ```

--- a/docs/experiments-bpr.md
+++ b/docs/experiments-bpr.md
@@ -28,7 +28,7 @@ python -m pyserini.search.faiss \
   --topics dpr-nq-test \
   --encoded-queries bpr_single_nq-nq-test \
   --output runs/run.bpr.rerank.nq-test.nq.hash.trec \
-  --batch-size 36 --threads 12 \
+  --batch-size 512 --threads 16 \
   --hits 100 --binary-hits 1000 \
   --searcher bpr --rerank
 ```
@@ -38,18 +38,22 @@ The option `--encoded-queries` specifies the use of encoded queries (i.e., queri
 To evaluate, first convert the TREC output format to DPR's `json` format:
 
 ```bash
-$ python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
-    --index wikipedia-dpr-100w \
-    --topics dpr-nq-test \
-    --input runs/run.bpr.rerank.nq-test.nq.hash.trec \
-    --output runs/run.bpr.rerank.nq-test.nq.hash.json
+python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --index wikipedia-dpr \
+  --topics dpr-nq-test \
+  --input runs/run.bpr.rerank.nq-test.nq.hash.trec \
+  --output runs/run.bpr.rerank.nq-test.nq.hash.json
 
-$ python -m pyserini.eval.evaluate_dpr_retrieval \
-    --retrieval runs/run.bpr.rerank.nq-test.nq.hash.json \
-    --topk 20 100
+python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.bpr.rerank.nq-test.nq.hash.json \
+  --topk 20 100
+```
 
+Results:
+
+```
 Top20  accuracy: 0.7792
-Top100 accuracy: 0.8573
+Top100 accuracy: 0.8571
 ```
 
 ## Reproduction Log[*](reproducibility.md)

--- a/docs/experiments-distilbert_kd.md
+++ b/docs/experiments-distilbert_kd.md
@@ -15,9 +15,9 @@ python -m pyserini.search.faiss \
   --index msmarco-v1-passage.distilbert-dot-margin-mse-t2 \
   --topics msmarco-passage-dev-subset \
   --encoded-queries distilbert_kd-msmarco-passage-dev-subset \
-  --output runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.bf.tsv \
+  --output runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.tsv \
   --output-format msmarco \
-  --batch-size 36 --threads 12
+  --batch-size 512 --threads 16
 ```
 
 Replace `--encoded-queries` with `--encoder sebastian-hofstaetter/distilbert-dot-margin_mse-T2-msmarco` for on-the-fly query encoding.
@@ -25,11 +25,15 @@ Replace `--encoded-queries` with `--encoder sebastian-hofstaetter/distilbert-dot
 To evaluate:
 
 ```bash
-$ python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset \
-    runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.bf.tsv
+python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset \
+  runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.tsv
+```
 
+Results:
+
+```
 #####################
-MRR @10: 0.3250
+MRR @10: 0.3251
 QueriesRanked: 6980
 #####################
 ```
@@ -38,14 +42,18 @@ We can also use the official TREC evaluation tool `trec_eval` to compute other m
 For that we first need to convert runs and qrels files to the TREC format:
 
 ```bash
-$ python -m pyserini.eval.convert_msmarco_run_to_trec_run \
-    --input runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.bf.tsv \
-    --output runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.bf.trec
+python -m pyserini.eval.convert_msmarco_run_to_trec_run \
+  --input runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.tsv \
+  --output runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.trec
 
-$ python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap msmarco-passage-dev-subset \
-    runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.bf.trec
+python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap msmarco-passage-dev-subset \
+  runs/run.msmarco-passage.distilbert-dot-margin_mse-t2.trec
+```
 
-map                     all     0.3308
+Results:
+
+```
+map                     all     0.3309
 recall_1000             all     0.9553
 ```
 

--- a/docs/experiments-distilbert_tasb.md
+++ b/docs/experiments-distilbert_tasb.md
@@ -15,22 +15,25 @@ python -m pyserini.search.faiss \
   --index msmarco-v1-passage.distilbert-dot-tas_b-b256 \
   --topics msmarco-passage-dev-subset \
   --encoded-queries distilbert_tas_b-msmarco-passage-dev-subset \
-  --output runs/run.msmarco-passage.distilbert-dot-tas_b-b256.bf.tsv \
+  --output runs/run.msmarco-passage.distilbert-dot-tas_b-b256.tsv \
   --output-format msmarco \
-  --batch-size 36 --threads 12
+  --batch-size 512 --threads 16
 ```
 
 Replace `--encoded-queries` with `--encoder sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco` for on-the-fly query encoding.
 
 To evaluate:
 
-
 ```bash
-$ python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset \
-    runs/run.msmarco-passage.distilbert-dot-tas_b-b256.bf.tsv
+python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset \
+  runs/run.msmarco-passage.distilbert-dot-tas_b-b256.tsv
+```
 
+Results:
+
+```
 #####################
-MRR @10: 0.3443
+MRR @10: 0.3444
 QueriesRanked: 6980
 #####################
 ```
@@ -39,14 +42,18 @@ We can also use the official TREC evaluation tool `trec_eval` to compute other m
 For that we first need to convert runs and qrels files to the TREC format:
 
 ```bash
-$ python -m pyserini.eval.convert_msmarco_run_to_trec_run \
-    --input runs/run.msmarco-passage.distilbert-dot-tas_b-b256.bf.tsv \
-    --output runs/run.msmarco-passage.distilbert-dot-tas_b-b256.bf.trec
+python -m pyserini.eval.convert_msmarco_run_to_trec_run \
+  --input runs/run.msmarco-passage.distilbert-dot-tas_b-b256.tsv \
+  --output runs/run.msmarco-passage.distilbert-dot-tas_b-b256.trec
 
-$ python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap msmarco-passage-dev-subset \
-    runs/run.msmarco-passage.distilbert-dot-tas_b-b256.bf.trec
+python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap msmarco-passage-dev-subset \
+  runs/run.msmarco-passage.distilbert-dot-tas_b-b256.trec
+```
 
-map                     all     0.3514
+Results:
+
+```
+map                     all     0.3515
 recall_1000             all     0.9771
 ```
 

--- a/docs/experiments-dkrr.md
+++ b/docs/experiments-dkrr.md
@@ -15,20 +15,20 @@ Running DKRR retrieval on `dpr-nq-dev` and `nq-test` of the Natural Questions da
 
 ```bash
 python -m pyserini.search.faiss \
-  --index wikipedia-dpr-dkrr-nq \
+  --index wikipedia-dpr-100w.dkrr-nq \
   --topics dpr-nq-dev \
   --encoded-queries dkrr-dpr-nq-retriever-dpr-nq-dev \
   --output runs/run.dpr-dkrr-nq.dev.trec \
   --query-prefix question: \
-  --batch-size 36 --threads 12
+  --batch-size 512 --threads 16
 
 python -m pyserini.search.faiss \
-  --index wikipedia-dpr-dkrr-nq \
+  --index wikipedia-dpr-100w.dkrr-nq \
   --topics nq-test \
   --encoded-queries dkrr-dpr-nq-retriever-nq-test \
   --output runs/run.dpr-dkrr-nq.test.trec \
   --query-prefix question: \
-  --batch-size 36 --threads 12
+  --batch-size 512 --threads 16
 ```
 
 Alternatively, replace `--encoded-queries ...` with `--encoder castorini/dkrr-dpr-nq-retriever` for on-the-fly query encoding.
@@ -79,20 +79,20 @@ Running DKRR retrieval on `dpr-trivia-dev` and `dpr-trivia-test` of the TriviaQA
 
 ```bash
 python -m pyserini.search.faiss \
-  --index wikipedia-dpr-dkrr-tqa \
+  --index wikipedia-dpr-100w.dkrr-tqa \
   --topics dpr-trivia-dev \
   --encoded-queries dkrr-dpr-tqa-retriever-dpr-tqa-dev \
   --output runs/run.dpr-dkrr-trivia.dev.trec \
   --query-prefix question: \
-  --batch-size 36 --threads 12
+  --batch-size 512 --threads 16
 
 python -m pyserini.search.faiss \
-  --index wikipedia-dpr-dkrr-tqa \
+  --index wikipedia-dpr-100w.dkrr-tqa \
   --topics dpr-trivia-test \
   --encoded-queries dkrr-dpr-tqa-retriever-dpr-tqa-test \
   --output runs/run.dpr-dkrr-trivia.test.trec \
   --query-prefix question: \
-  --batch-size 36 --threads 12
+  --batch-size 512 --threads 16
 ```
 Alternatively, replace `--encoded-queries ...` with `--encoder castorini/dkrr-dpr-tqa-retriever` for on-the-fly query encoding.
 

--- a/pyserini/search/faiss/_searcher.py
+++ b/pyserini/search/faiss/_searcher.py
@@ -746,7 +746,7 @@ class BinaryDenseSearcher(FaissSearcher):
             sorted_indices = np.argsort(-distances, axis=1)
 
             indexes = indexes[np.arange(num_queries)[:, None], sorted_indices]
-            indexes = np.array([self.index.id_map.at(int(id_)) for id_ in indexes.reshape(-1)], dtype=np.int)
+            indexes = np.array([self.index.id_map.at(int(id_)) for id_ in indexes.reshape(-1)], dtype=np.int32)
             indexes = indexes.reshape(num_queries, -1)[:, :k]
             distances = distances[np.arange(num_queries)[:, None], sorted_indices][:, :k]
         return distances, indexes


### PR DESCRIPTION
+ Fixed the following: ance, sbert, bpr, distillbert-tasb, distillbert-kd, dkrr
+ At numpy 1.26.4, fixed following issue:

```
Traceback (most recent call last):
  File "/home/jimmylin/.conda/envs/pyserini-dev7/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/jimmylin/.conda/envs/pyserini-dev7/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tuna1/scratch/jimmylin/pyserini/pyserini/search/faiss/__main__.py", line 296, in <module>
    results = searcher.batch_search(batch_topics, batch_topic_ids, args.hits, threads=args.threads,
  File "/tuna1/scratch/jimmylin/pyserini/pyserini/search/faiss/_searcher.py", line 723, in batch_search
    D, I = self.binary_dense_search(k, binary_k, rerank, dense_q_embs, sparse_q_embs)
  File "/tuna1/scratch/jimmylin/pyserini/pyserini/search/faiss/_searcher.py", line 749, in binary_dense_search
    indexes = np.array([self.index.id_map.at(int(id_)) for id_ in indexes.reshape(-1)], dtype=np.int)
  File "/home/jimmylin/.conda/envs/pyserini-dev7/lib/python3.10/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.
```
