### PR TITLE
Update trec_eval.py for Python 3.12 regression

### DIFF
--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -41,7 +41,7 @@ import jnius_config
 import pandas as pd
 
 # Don't use the jdk.incubator.vector module.
-jar_directory = str(importlib.resources.files("pyserini.resources.jars").joinpath(''))
+jar_directory = str((importlib.resources.files("pyserini.resources.jars") / "dummy").parent)
 jar_path = glob.glob(os.path.join(jar_directory, '*.jar'))[0]
 jnius_config.add_classpath(jar_path)
 


### PR DESCRIPTION
Fixes Python 3.12 incompatibility as described in: https://github.com/python/cpython/issues/106614