### PR TITLE
Onboarding: Successful Pyserini Reproduction 

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -377,3 +377,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zdann15](https://github.com/zdann15) on 2024-12-04 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@sherloc512](https://github.com/sherloc512) on 2024-12-05 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@Alireza-Zwolf](https://github.com/Alireza-Zwolf) on 2024-12-18 (commit [`6cc23d5`](https://github.com/castorini/pyserini/commit/6cc23d5de4a8f4952156c45d13381a3764640f06))
++ Results reproduced by [@Linsen-gao-457](https://github.com/Linsen-gao-457) on 2024-12-20 (commit [`10606f0`](https://github.com/castorini/pyserini/commit/10606f03de23978877c9b130caf1b2e49c0dc853))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -633,3 +633,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zdann15](https://github.com/zdann15) on 2024-12-04 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@sherloc512](https://github.com/sherloc512) on 2024-12-05 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@Alireza-Zwolf](https://github.com/Alireza-Zwolf) on 2024-12-18 (commit [`6cc23d5`](https://github.com/castorini/pyserini/commit/6cc23d5de4a8f4952156c45d13381a3764640f06))
++ Results reproduced by [@Linsen-gao-457](https://github.com/Linsen-gao-457) on 2024-12-20 (commit [`10606f0`](https://github.com/castorini/pyserini/commit/10606f03de23978877c9b130caf1b2e49c0dc853))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -415,3 +415,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + + Results reproduced by [@zdann15](https://github.com/zdann15) on 2024-12-04 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@sherloc512](https://github.com/sherloc512) on 2024-12-05 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@Alireza-Zwolf](https://github.com/Alireza-Zwolf) on 2024-12-18 (commit [`6cc23d5`](https://github.com/castorini/pyserini/commit/6cc23d5de4a8f4952156c45d13381a3764640f06))
++ Results reproduced by [@Linsen-gao-457](https://github.com/Linsen-gao-457) on 2024-12-19 (commit [`10606f0`](https://github.com/castorini/pyserini/commit/10606f03de23978877c9b130caf1b2e49c0dc853))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -260,7 +260,8 @@ PLAIN-3074 Q0 MED-2939 10 0.674647 Faiss
 Here's the snippet of Python code that does what we want:
 
 ```python
-from pyserini.search.faiss import FaissSearcher, AutoQueryEncoder
+from pyserini.search.faiss import FaissSearcher
+from pyserini.encode import AutoQueryEncoder
 
 encoder = AutoQueryEncoder('facebook/contriever-msmarco', device='cpu', pooling='mean')
 searcher = FaissSearcher('indexes/faiss.nfcorpus.contriever-msmacro', encoder)

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -415,3 +415,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zdann15](https://github.com/zdann15) on 2024-12-04 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@sherloc512](https://github.com/sherloc512) on 2024-12-05 (commit [`5e66e98`](https://github.com/castorini/pyserini/commit/5e66e98863b5929b137bd2eb39d8e4abf6633f23))
 + Results reproduced by [@Alireza-Zwolf](https://github.com/Alireza-Zwolf) on 2024-12-18 (commit [`6cc23d5`](https://github.com/castorini/pyserini/commit/6cc23d5de4a8f4952156c45d13381a3764640f06))
++ Results reproduced by [@Linsen-gao-457](https://github.com/Linsen-gao-457) on 2024-12-20 (commit [`10606f0`](https://github.com/castorini/pyserini/commit/10606f03de23978877c9b130caf1b2e49c0dc853))


### PR DESCRIPTION
Hi~ My onbroading journey finish!

My window computer
Operating System: Windows 10 Home Chinese Version
Java Version: 21.0.4 2024-07-16 LTS
Apache Maven Version: 3.9.9
Python Version : 3.8.10
Outcome: : Encountered issues with trec_eval and unit tests

Issues Encountered:
1. some errors occurred during the Development Installation when ensuring everything works by running the unit tests using python -m unittest. There are about 66 errors 2 failure (total 345 tests).
2. all trec_eval fail. error shows below:
Exception in thread "main" java.lang.UnsupportedOperationException: Unsupported os/arch: trec_eval/trec_eval-win-amd64
        at trec_eval.getTrecEvalBinary(trec_eval.java:93)
        at trec_eval.<init>(trec_eval.java:141)
        at trec_eval.main(trec_eval.java:283)

i think both of the issues happen because window system does not support the trec_eval(in Aserin, i can use compilation in MINGW and run .exe in window) but for python, it's different(don't need compile).

The easy solution is to use WSL. However, i think there may be some problems about my computer hardware(internet adapter). So my WSL cannot connect to the internet. Previously, my computer has problems to connect Uwaterloo VPN. After contacting IT support and attempting multiple fixes, we failed to repair it and concluded the issue was irreparable without: 1. reinstall system 2. purchase a new device. So...Sorry, I cannot use the solution now.

Now, i point it may be a problem.
in Contriever Baseline for NFCorpus](https://github.com/castorini/pyserini/blob/master/docs/experiments-nfcorpus.md)
In Interactive Retrieval section, i have an import error. 
from pyserini.search.faiss import FaissSearcher, AutoQueryEncoder
i got an ImportError: cannot import name 'AutoQueryEncoder' from 'pyserini.search.faiss' 
so i replace the code with from pyserini.search.faiss import FaissSearcher and from pyserini.encode import AutoQueryEncoder. After adjustment, the code run successfully.