### PR TITLE
Onboarding add to reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -381,3 +381,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@robro612](https://github.com/robro612) on 2025-01-05 (commit [`9268591`](https://github.com/castorini/pyserini/commit/9268591dd32df7e19c3c0e476eecbd8bae684e2f))
 + Results reproduced by [@nourj98](https://github.com/nourj98) on 2025-01-07 (commit [`6ac07cc`](https://github.com/castorini/pyserini/commit/6ac07ccfa864220022722f328e074b9078bdb122))
 + Results reproduced by [@mithildamani256](https://github.com/mithildamani256) on 2025-01-13 (commit [`ad41512`](https://github.com/castorini/pyserini/commit/ad4151203c30ab4363dfa3150a37a376d66bd7b7))
++ Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-15 (commit [`e1a3386`](https://github.com/castorini/pyserini/commit/e1a33865b4d5e767758f59e320f3b3888fc36346))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -637,3 +637,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@robro612](https://github.com/robro612) on 2025-01-05 (commit [`9268591`](https://github.com/castorini/pyserini/commit/9268591dd32df7e19c3c0e476eecbd8bae684e2f))
 + Results reproduced by [@nourj98](https://github.com/nourj98) on 2025-01-07 (commit [`6ac07cc`](https://github.com/castorini/pyserini/commit/6ac07ccfa864220022722f328e074b9078bdb122))
 + Results reproduced by [@mithildamani256](https://github.com/mithildamani256) on 2025-01-13 (commit [`ad41512`](https://github.com/castorini/pyserini/commit/ad4151203c30ab4363dfa3150a37a376d66bd7b7))
++ Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-15 (commit [`e1a3386`](https://github.com/castorini/pyserini/commit/e1a33865b4d5e767758f59e320f3b3888fc36346))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -419,3 +419,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@robro612](https://github.com/robro612) on 2025-01-05 (commit [`9268591`](https://github.com/castorini/pyserini/commit/9268591dd32df7e19c3c0e476eecbd8bae684e2f))
 + Results reproduced by [@nourj98](https://github.com/nourj98) on 2025-01-07 (commit [`6ac07cc`](https://github.com/castorini/pyserini/commit/6ac07ccfa864220022722f328e074b9078bdb122))
 + Results reproduced by [@mithildamani256](https://github.com/mithildamani256) on 2025-01-13 (commit [`ad41512`](https://github.com/castorini/pyserini/commit/ad4151203c30ab4363dfa3150a37a376d66bd7b7))
++ Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-15 (commit [`e1a3386`](https://github.com/castorini/pyserini/commit/e1a33865b4d5e767758f59e320f3b3888fc36346))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -420,3 +420,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@robro612](https://github.com/robro612) on 2025-01-05 (commit [`9268591`](https://github.com/castorini/pyserini/commit/9268591dd32df7e19c3c0e476eecbd8bae684e2f))
 + Results reproduced by [@nourj98](https://github.com/nourj98) on 2025-01-07 (commit [`6ac07cc`](https://github.com/castorini/pyserini/commit/6ac07ccfa864220022722f328e074b9078bdb122))
 + Results reproduced by [@mithildamani256](https://github.com/mithildamani256) on 2025-01-13 (commit [`ad41512`](https://github.com/castorini/pyserini/commit/ad4151203c30ab4363dfa3150a37a376d66bd7b7))
++ Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-15 (commit [`e1a3386`](https://github.com/castorini/pyserini/commit/e1a33865b4d5e767758f59e320f3b3888fc36346))


### PR DESCRIPTION
System: Apple Macbook Pro 2020
OS: MacOS Sonoma 14.7.2
Python: 3.10.13
Maven: 3.9.9
Java: openjdk 21.0.5

---

A Minor Problem in [FAISS Retrieval](https://github.com/castorini/pyserini/blob/master/docs/experiments-nfcorpus.md#retrieval):

When retrieving via FAISS, the process frequently froze partway through at various progress points initially at 4% with the default given `--batch 128 --threads 8`, then as I adjusted thread and batch combinations multiple times, it froze again at different points (e.g., 2%, 4%, 32%, or 86%). 

Due to these challenges, I was only able to evaluate 2,800 out of 3,237 queries for that step.

Error Message that came up during this run:
```bash
$ python -m pyserini.search.faiss \
>   --encoder-class auto --encoder BAAI/bge-base-en-v1.5 --l2-norm \
>   --pooling mean \
>   --index indexes/nfcorpus.bge-base-en-v1.5 \
>   --topics collections/nfcorpus/queries.tsv \
>   --output runs/run.beir.bge-base-en-v1.5.nfcorpus.txt \
>   --batch 128 --threads 8 \
>   --hits 1000

WARNING: Using incubator modules: jdk.incubator.vector
Running collections/nfcorpus/queries.tsv topics, saving to runs/run.beir.bge-base-en-v1.5.nfcorpus.txt...
  0%|                                                                                                                                                                    | 0/3237 [00:00<?, ?it/s][thread 41987 also had an error]
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000000017922c961, pid=3090, tid=34819
#
# JRE version: OpenJDK Runtime Environment Homebrew (21.0.5) (build 21.0.5)
# Java VM: OpenJDK 64-Bit Server VM Homebrew (21.0.5, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, bsd-amd64)
# Problematic frame:
# C  [libomp.dylib+0x71961]  void __kmp_suspend_64<false, true>(int, kmp_flag_64<false, true>*)+0x21
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/zaza/Documents/Projects/Castorini - Jimmy Lin/pyserini/hs_err_pid3090.log
#
# If you would like to submit a bug report, please visit:
#   https://github.com/Homebrew/homebrew-core/issues
#
Abort trap: 6

```






