### PR TITLE
Fix bug with selecting correct topic reader for CACM topics

### DIFF
--- a/pyserini/query_iterator.py
+++ b/pyserini/query_iterator.py
@@ -87,6 +87,8 @@ class DefaultQueryIterator(QueryIterator):
                     topics = json.load(f)
             elif 'beir' in topics_path:
                 topics = get_topics_with_reader('io.anserini.search.topicreader.TsvStringTopicReader', topics_path)
+            elif 'cacm' in topics_path:
+                topics = get_topics_with_reader('io.anserini.search.topicreader.CacmTopicReader', topics_path)
             # If extension is tsv or txt we just assume file contains (qid, query) pairs.
             elif topics_path.endswith('.tsv') or topics_path.endswith('.tsv.gz') or topics_path.endswith('.txt') or topics_path.endswith('.txt.gz'):
                 try:
@@ -95,8 +97,6 @@ class DefaultQueryIterator(QueryIterator):
                     topics = get_topics_with_reader('io.anserini.search.topicreader.TsvStringTopicReader', topics_path)
             elif topics_path.endswith('.trec'):
                 topics = get_topics_with_reader('io.anserini.search.topicreader.TrecTopicReader', topics_path)
-            elif 'cacm' in topics_path:
-                topics = get_topics_with_reader('io.anserini.search.topicreader.CacmTopicReader', topics_path)
             elif topics_path.endswith('.jsonl'):
                 topics = get_topics_with_reader('io.anserini.search.topicreader.JsonStringTopicReader', topics_path)
             else:


### PR DESCRIPTION
CACM topics end in `.txt`, so we want to move that branch of the if statement up to select the right topic reader.