### PR TITLE
Sort as string if not all the same type

### DIFF
--- a/pyserini/query_iterator.py
+++ b/pyserini/query_iterator.py
@@ -41,7 +41,16 @@ class QueryIterator(ABC):
                         'msmarco-passage-test-subset'}
 
     def __init__(self, topics: dict, order: list = None):
-        self.order = order if order else sorted(topics.keys())
+        if order:
+            self.order = order
+        else:
+            try:
+                self.order = sorted(topics.keys())
+            except:
+                # if not all topic ids are integers neither are all string,
+                # sort them by string representation
+                self.order = sorted(topics.keys(), key=str)
+       
         self.topics = topics
 
     @abstractmethod

--- a/tests/test_topics_order.py
+++ b/tests/test_topics_order.py
@@ -15,7 +15,7 @@
 #
 
 import unittest
-
+import tempfile
 from pyserini.query_iterator import DefaultQueryIterator
 
 
@@ -38,5 +38,49 @@ class TestEncodedQueries(unittest.TestCase):
         self.assertTrue(topic_ids[1], 2)
         self.assertTrue(topic_ids[-1], 524332)
 
+    def test_topics_as_int(self):
+        topics_int = (
+            "1999\tA simple query\n"
+            "1998\tAnother simple query\n"
+        )
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.tsv') as tmpfile:
+            tmpfile.write(topics_int)
+            tmpfile_path = tmpfile.name
+    
+        query_iterator = DefaultQueryIterator.from_topics(tmpfile_path)
+        topic_ids, _ = zip(*list(query_iterator))
+        self.assertEqual(topic_ids[0], 1998)
+        self.assertEqual(topic_ids[1], 1999)
+        
+    def test_topics_as_str(self):
+        topics_str = (
+            "B\tAnother simple query\n"
+            "A\tA simple query\n"
+        )
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.tsv') as tmpfile:
+            tmpfile.write(topics_str)
+            tmpfile_path = tmpfile.name
+
+        query_iterator = DefaultQueryIterator.from_topics(tmpfile_path)
+        topic_ids, _ = zip(*list(query_iterator))
+        self.assertEqual(topic_ids[0], "A")
+        self.assertEqual(topic_ids[1], "B")
+
+    def test_topics_as_int_str(self):
+        topics_int_string = (
+            "B\tAnother simple query\n"
+            "1998\tA simple query\n"
+        )
+        
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.tsv') as tmpfile:
+            tmpfile.write(topics_int_string)
+            tmpfile_path = tmpfile.name
+    
+        query_iterator = DefaultQueryIterator.from_topics(tmpfile_path)
+        topic_ids, _ = zip(*list(query_iterator))
+        self.assertEqual(topic_ids[0], 1998)
+        self.assertEqual(topic_ids[1], "B")
+            
+            
     def tearDown(self):
         pass


### PR DESCRIPTION
This PR aims to document what I did to address the situation described in [discussion #2119](https://github.com/castorini/pyserini/discussions/2119#discussion-8345321) where the code wasn't handling certain edge cases. This caused the process to break instead of continuing execution.

```python
def safe_sort(lst):
    try:
        return sorted(lst)
    except:
        return sorted(lst, key=str)

# tests
assert safe_sort([3, 2, 1]) == [1, 2, 3]
assert safe_sort(["A", "C", "B"]) == ["A", "B", "C"]
assert safe_sort([1, 2, "A", "B", 3, "C"]) == [1, 2, 3, "A", "B", "C"]
```