### PR TITLE
Add metadata loading from Anserini

### DIFF
--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -31,6 +31,10 @@ def add_lucene_index_info(enum, info, name=None, readme=None):
             enum.urls[0]
         ],
         "md5": enum.md5,
+        "size compressed (bytes)": enum.size,
+        "total_terms": enum.totalTerms,
+        "documents": enum.documents,
+        "unique_terms": enum.uniqueTerms,
         "downloaded": False
     }
 


### PR DESCRIPTION
The metadata removed from Pyserini in #2159 has been added to Anserini as of castorini/anserini#2853 as part of .castorini/anserini#2852. This PR makes it so the additional metadata actually gets loaded into Pyserini from Anserini.