### PR TITLE
Add support to search all indexes for MCPyserini

### DIFF
--- a/pyserini/prebuilt_index_info.py
+++ b/pyserini/prebuilt_index_info.py
@@ -35,7 +35,8 @@ def add_lucene_index_info(enum, info, name=None, readme=None):
         "total_terms": enum.totalTerms,
         "documents": enum.documents,
         "unique_terms": enum.uniqueTerms,
-        "downloaded": False
+        "downloaded": False,
+        "texts": enum.invertedIndex
     }
 
 

--- a/pyserini/server/mcp/tools.py
+++ b/pyserini/server/mcp/tools.py
@@ -19,8 +19,7 @@
 Register tools for the MCP server.
 """
 
-from typing import Dict, List, Optional, Any
-
+from typing import Any
 
 from fastmcp import FastMCP
 from pyserini.server.search_controller import SearchController
@@ -40,7 +39,7 @@ def register_tools(mcp: FastMCP, controller: SearchController):
         ef_search: int = 100,
         encoder: str = None,
         query_generator: str = None
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Search the Pyserini index with BM25 and return top-k hits
         Args:
@@ -83,7 +82,7 @@ def register_tools(mcp: FastMCP, controller: SearchController):
         Returns:
             Dictionary of index names to their metadata.
         """
-        return controller.get_indexes(index_type)
+        return {"tf": controller.get_indexes(index_type)}
     
     @mcp.tool(
         name='get_index_status',

--- a/pyserini/server/models.py
+++ b/pyserini/server/models.py
@@ -23,18 +23,21 @@ Models and configuration classes for Pyserini FastAPI and MCP server.
 from dataclasses import dataclass
 from typing import List
 
-from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher
-from pyserini.prebuilt_index_info import TF_INDEX_INFO, LUCENE_HNSW_INDEX_INFO
+from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher, LuceneFlatDenseSearcher, LuceneImpactSearcher
+from pyserini.search.faiss import FaissSearcher
+from pyserini.prebuilt_index_info import TF_INDEX_INFO, LUCENE_FLAT_INDEX_INFO, LUCENE_HNSW_INDEX_INFO, IMPACT_INDEX_INFO, FAISS_INDEX_INFO
 
 
 @dataclass
 class IndexConfig:
     """Configuration for a search index."""
     name: str
-    searcher: LuceneSearcher | LuceneHnswDenseSearcher | None = None
-    ef_search: int | None = None
-    encoder: str | None = None
+    searcher: LuceneSearcher | LuceneHnswDenseSearcher | LuceneFlatDenseSearcher | LuceneImpactSearcher | FaissSearcher| None = None
+    ef_search: int | None = 100
+    encoder: str | None = ""
     query_generator: str | None = None
+    base_index: str | None = None
+    index_type: str | None = ""
 
 @dataclass
 class QueryInfo:
@@ -80,5 +83,8 @@ SHARDS = {
 
 INDEX_TYPE = {
     "tf": TF_INDEX_INFO,
-    "sharded-msmarco": SHARDS
+    "lucene_flat": LUCENE_FLAT_INDEX_INFO,
+    "lucene_hnsw": LUCENE_HNSW_INDEX_INFO,
+    "impact": IMPACT_INDEX_INFO,
+    "faiss": FAISS_INDEX_INFO
 }

--- a/pyserini/server/models.py
+++ b/pyserini/server/models.py
@@ -21,7 +21,6 @@ Models and configuration classes for Pyserini FastAPI and MCP server.
 """
 
 from dataclasses import dataclass
-from typing import List
 
 from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher, LuceneFlatDenseSearcher, LuceneImpactSearcher
 from pyserini.search.faiss import FaissSearcher
@@ -53,7 +52,7 @@ class Candidate:
 @dataclass
 class Hits: 
     query: QueryInfo
-    candidates: List[Candidate]
+    candidates: list[Candidate]
 
 @dataclass
 class Document:

--- a/pyserini/server/models.py
+++ b/pyserini/server/models.py
@@ -56,11 +56,6 @@ class Hits:
     candidates: List[Candidate]
 
 @dataclass
-class ShardHit:
-    docid: str
-    score: float
-
-@dataclass 
 class Document:
     docid: str
     text: str

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -123,7 +123,7 @@ class SearchController:
             if index_config.index_type == "tf":
                 raw = json.loads(hit.lucene_document.get('raw'))
             else:
-raw = self.get_document(hit.docid, index_config.base_index).get('text') if index_config.base_index else None 
+                raw = self.get_document(hit.docid, index_config.base_index).get('text') if index_config.base_index else None
             candidates.append(
                 {
                     'docid': hit.docid,

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -123,7 +123,7 @@ class SearchController:
             if index_config.index_type == "tf":
                 raw = json.loads(hit.lucene_document.get('raw'))
             else:
-                raw = self.get_document(hit.docid, index_config.base_index).get('text') if index_config.base_index != None else None
+raw = self.get_document(hit.docid, index_config.base_index).get('text') if index_config.base_index else None 
             candidates.append(
                 {
                     'docid': hit.docid,

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -25,18 +25,15 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 from typing import Any, List
 
-from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher
-from pyserini.prebuilt_index_info import TF_INDEX_INFO
+from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher, LuceneFlatDenseSearcher, LuceneImpactSearcher
+from pyserini.search.faiss import FaissSearcher
+from pyserini.encode import AutoQueryEncoder
+from pyserini.prebuilt_index_info import TF_INDEX_INFO, LUCENE_FLAT_INDEX_INFO, LUCENE_HNSW_INDEX_INFO, IMPACT_INDEX_INFO, FAISS_INDEX_INFO
 from pyserini.util import check_downloaded
 
-from pyserini.server.models import IndexConfig, INDEX_TYPE, Hits, ShardHit, Document, IndexSetting
+from pyserini.server.models import IndexConfig, INDEX_TYPE, Hits, SHARDS, Document, IndexSetting
 
 DEFAULT_INDEX = 'msmarco-v1-passage'
-
-SHARDS = [
-    f'msmarco-v2.1-doc-segmented-shard0{i}.arctic-embed-l.hnsw-int8'
-    for i in range(10)
-]
 
 class SearchController:
     """Core functionality controller."""
@@ -56,14 +53,30 @@ class SearchController:
 
     def _add_index(self, config: IndexConfig) -> IndexConfig:
         """Add a new index to the manager."""
-        
-        if config.name in SHARDS:
+
+        if config.name in TF_INDEX_INFO.keys():
+            config.searcher = LuceneSearcher.from_prebuilt_index(config.name) 
+            config.base_index = config.name
+            config.index_type = "tf"
+        elif config.name in LUCENE_FLAT_INDEX_INFO.keys():
+            config.searcher = LuceneFlatDenseSearcher.from_prebuilt_index(config.name, encoder=config.encoder)
+            config.base_index = LUCENE_FLAT_INDEX_INFO.get(config.name).get("texts")
+            config.index_type = "lucene_flat"
+        elif config.name in LUCENE_HNSW_INDEX_INFO.keys():
             config.searcher = LuceneHnswDenseSearcher.from_prebuilt_index(config.name, ef_search=config.ef_search, encoder=config.encoder, verbose=True)
-        elif config.name in TF_INDEX_INFO.keys():   
-            config.searcher = LuceneSearcher.from_prebuilt_index(config.name)         
+            config.base_index = LUCENE_HNSW_INDEX_INFO.get(config.name).get("texts")
+            config.index_type = "lucene_hnsw"
+        elif config.name in IMPACT_INDEX_INFO.keys():
+            config.searcher = LuceneImpactSearcher.from_prebuilt_index(config.name, config.encoder)
+            config.base_index = IMPACT_INDEX_INFO.get(config.name).get("texts")
+            config.index_type = "impact"
+        elif config.name in FAISS_INDEX_INFO.keys():
+            config.searcher = FaissSearcher.from_prebuilt_index(config.name, query_encoder=AutoQueryEncoder(encoder_dir=config.encoder))
+            config.base_index = FAISS_INDEX_INFO.get(config.name).get("texts")
+            config.index_type = "faiss"
         else:
             raise ValueError(f'Index {config.name} not currently supported in prebuilt indexes.')
-
+        
         self.indexes[config.name] = config
         return config
 
@@ -87,28 +100,34 @@ class SearchController:
     ) -> Hits:
         """Perform search on specified index."""
         hits = []
-        
-        index_config = self.indexes.get(index_name)
-        if not index_config or not index_config.searcher:
-            index_config = self._add_index(
-                IndexConfig(
-                    name=index_name,
-                    ef_search=ef_search,
-                    encoder=encoder,
-                    query_generator=query_generator
+        if "shard" in index_name and "msmarco" in index_name:
+            hits = self.sharded_search(query, k, ef_search, encoder if encoder is not None else "ArcticEmbedL")
+        else:
+            index_config = self.indexes.get(index_name)
+            if not index_config or not index_config.searcher:
+                index_config = self._add_index(
+                    IndexConfig(
+                        name=index_name,
+                        ef_search=ef_search,
+                        encoder=encoder,
+                        query_generator=query_generator
+                    )
                 )
-            )
-            
-        hits = index_config.searcher.search(query, k)
+
+            hits = index_config.searcher.search(query, k)
+
         results: dict[str, Any] = {'query': {'qid': qid, 'text': query}}
         candidates: list[dict[str, Any]] = []
 
         for hit in hits:
-            raw = json.loads(hit.lucene_document.get('raw'))
+            if index_config.index_type == "tf":
+                raw = json.loads(hit.lucene_document.get('raw'))
+            else:
+                raw = self.get_document(hit.docid, index_config.base_index).get('text') 
             candidates.append(
                 {
                     'docid': hit.docid,
-                    'score': hit.score,
+                    'score': float(hit.score),
                     'doc': raw,
                 }
             )
@@ -123,7 +142,7 @@ class SearchController:
         k: int,
         ef_search: int,
         encoder: str,
-    ) -> List[ShardHit]:   
+    ) -> List:   
                 
         executor = ThreadPoolExecutor(max_workers=len(SHARDS))
 
@@ -151,10 +170,13 @@ class SearchController:
            
     def get_document(self, docid: str, index_name: str) -> Document:
         """Retrieve full document by document ID."""
-        index_config = self.indexes[index_name]
-
-        if not index_config.searcher:       
-            index_config.searcher = LuceneSearcher.from_prebuilt_index(index_config.name)
+        index_config = self.indexes.get(index_name)
+        if index_config == None:
+            index_config = self._add_index(IndexConfig(index_name))
+        if index_config.index_type != "tf":
+            index_config.searcher = LuceneSearcher.from_prebuilt_index(index_config.base_index)
+        else:
+            index_config.searcher = LuceneSearcher.from_prebuilt_index(index_name)
 
         doc = index_config.searcher.doc(docid)
         if doc is None:
@@ -162,13 +184,18 @@ class SearchController:
 
         return {
             'docid': docid,
-            'text': json.loads(doc.raw())['contents'],
+            'text': json.loads(doc.raw()),
         }
 
     def get_status(self, index_name: str) -> dict[str, Any]:
         status = {}
         status['downloaded'] = check_downloaded(index_name)
-        status['size_bytes'] = TF_INDEX_INFO[index_name]['size compressed (bytes)'] if TF_INDEX_INFO.get(index_name) else 'Not available'
+        for index_type in INDEX_TYPE:
+            if INDEX_TYPE[index_type].get(index_name) != None:
+                status['size_bytes'] = INDEX_TYPE[index_type].get(index_name).get('size compressed (bytes)')
+                break
+        if status.get('size_bytes') is None:
+            status['size_bytes'] = "Not available"
         return status
 
     def update_settings(

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -23,7 +23,7 @@ Initialized with prebuilt index msmarco-v1-passage.
         
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
-from typing import Any, List
+from typing import Any
 
 from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher, LuceneFlatDenseSearcher, LuceneImpactSearcher
 from pyserini.search.faiss import FaissSearcher
@@ -101,7 +101,7 @@ class SearchController:
         """Perform search on specified index."""
         hits = []
         if "shard" in index_name and "msmarco" in index_name:
-            hits = self.sharded_search(query, k, ef_search, encoder if encoder is not None else "ArcticEmbedL")
+            hits = self.sharded_search(query, k, ef_search)
         else:
             index_config = self.indexes.get(index_name)
             if not index_config or not index_config.searcher:
@@ -123,7 +123,7 @@ class SearchController:
             if index_config.index_type == "tf":
                 raw = json.loads(hit.lucene_document.get('raw'))
             else:
-                raw = self.get_document(hit.docid, index_config.base_index).get('text') 
+                raw = self.get_document(hit.docid, index_config.base_index).get('text') if index_config.base_index != None else None
             candidates.append(
                 {
                     'docid': hit.docid,
@@ -141,8 +141,8 @@ class SearchController:
         query: str,
         k: int,
         ef_search: int,
-        encoder: str,
-    ) -> List:   
+        encoder: str = "ArcticEmbedL",
+    ) -> list:   
                 
         executor = ThreadPoolExecutor(max_workers=len(SHARDS))
 

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -31,7 +31,7 @@ from pyserini.encode import AutoQueryEncoder
 from pyserini.prebuilt_index_info import TF_INDEX_INFO, LUCENE_FLAT_INDEX_INFO, LUCENE_HNSW_INDEX_INFO, IMPACT_INDEX_INFO, FAISS_INDEX_INFO
 from pyserini.util import check_downloaded
 
-from pyserini.server.models import IndexConfig, INDEX_TYPE, Hits, SHARDS, Document, IndexSetting
+from pyserini.server.models import IndexConfig, INDEX_TYPE, Hits, SHARDS, Document, IndexSetting, IndexStatus
 
 DEFAULT_INDEX = 'msmarco-v1-passage'
 
@@ -187,7 +187,7 @@ class SearchController:
             'text': json.loads(doc.raw()),
         }
 
-    def get_status(self, index_name: str) -> dict[str, Any]:
+    def get_status(self, index_name: str) -> IndexStatus:
         status = {}
         status['downloaded'] = check_downloaded(index_name)
         for index_type in INDEX_TYPE:

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -191,7 +191,7 @@ class SearchController:
         status = {}
         status['downloaded'] = check_downloaded(index_name)
         for index_type in INDEX_TYPE:
-            if INDEX_TYPE[index_type].get(index_name) != None:
+            if INDEX_TYPE[index_type].get(index_name):
                 status['size_bytes'] = INDEX_TYPE[index_type].get(index_name).get('size compressed (bytes)')
                 break
         if status.get('size_bytes') is None:

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -195,6 +195,8 @@ def check_downloaded(index_name):
         target_index = IMPACT_INDEX_INFO[index_name]
     elif index_name in LUCENE_HNSW_INDEX_INFO:
         target_index = LUCENE_HNSW_INDEX_INFO[index_name]
+    elif index_name in LUCENE_FLAT_INDEX_INFO:
+        target_index = LUCENE_FLAT_INDEX_INFO[index_name]
     else:
         target_index = FAISS_INDEX_INFO[index_name]
     index_url = target_index['urls'][0]


### PR DESCRIPTION
All prebuilt indexes should now be able to be searched. Sharded search got integrated into search by checking if index name contains 'shard' and 'msmarco'. For indexes that aren't tf, try to get raw document contents from 'base' index mapped in prebuilt index info. If there is no 'base' index mapped, just return docids and scores. 

Side note: it'd be convenient if prebuilt indexes had mappings for the appropriate encoder like Anserini IndexInfo. 