### PR TITLE
Fix failing MCP tests

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -87,6 +87,8 @@ class TestMCPyseriniServer(unittest.TestCase):
                 self.server_process.stdin.flush()
                 
                 init_response = self.server_process.stdout.readline()
+                if init_response.startswith("Downloading index at "):
+                    init_response = self.server_process.stdout.readline()
                 if init_response:
                     json.loads(init_response.strip())
                 


### PR DESCRIPTION
I found that when running `python -m unittest tests.test_mcp`, everything worked fine, but when running `python -m unittest discover tests`, the MCP tests failed. This is because running it directly somehow 'swallowed up' the logging, but running it with discovery had the prebuilt index print statement in stdout, which messed up the output. This filters out that log. 