### PR TITLE
Update search_controller.py to support MS MARCO v2.1 segment field

### DIFF
--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -124,7 +124,7 @@ class SearchController:
                 doc = json.loads(hit.lucene_document.get('raw'))
             elif index_config.base_index:
                 doc = self.get_document(hit.docid, index_config.base_index)
-            raw = doc.get('contents') or doc.get('text') or ""
+            raw = doc.get('contents') or doc.get('text') or doc.get('segment') or ""
             candidates.append(
                 {
                     'docid': hit.docid,

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -184,7 +184,7 @@ class SearchController:
             raise ValueError(f'Document {docid} not found in index {index_name}')
 
         doc = json.loads(doc.raw())
-        raw = doc.get('contents') or doc.get('text') or ""
+        raw = doc.get('contents') or doc.get('text') or doc.get('segment') or ""
         return {
             'docid': docid,
             'text': raw,


### PR DESCRIPTION
The MS MARCO v2.1 segment corpus is using `segment` as the main text field.

I find the REST search API is trying to always return the main text on `doc` field, instead of returning whatever the index has on that record. Is the REST search API trying to serve other statically typed downstream tools, instead of being a generic search API?