### PR TITLE
Add to repro

### DIFF
--- a/docs/usage-mcp.md
+++ b/docs/usage-mcp.md
@@ -163,3 +163,4 @@ You can ask your MCP client for a full, detailed list of capabilities.
 
 + Results reproduced by [@lilyjge](https://github.com/lilyjge) on 2025-06-20 (commit [`88584b9`](https://github.com/castorini/pyserini/commit/88584b982ac9878775be1ffb0b1a8673c0cccd3b))
 + Results reproduced by [@Vik7am10](https://github.com/Vik7am10) on 2025-06-23 (commit [`f7c1077`](https://github.com/castorini/pyserini/commit/f7c10776c486744b8f28f753df29036cdfd28389))
++ Results reproduced by [@suraj-subrahmanyan](https://github.com/suraj-subrahmanyan) on 2025-07-16 (commit [`1915a15`](https://github.com/castorini/pyserini/commit/1915a154326f829b91308f275227a8bbb42eea9b))


### PR DESCRIPTION
Ran into a small issue, where retrieving the full text of a document returned none object even though the initial search was successful.

1. Initially, prompted Claude with `Search for "what is a lobster roll" in the msmarco-v1-passage index, returning 5 results.` as suggested in docs and Claude correctly replied. 
2. Then, I prompted Claude with `Retrieve the full text of document "7157715" from the msmarco-v1-passage index.`
3. Claude replied with: 
```
I'm encountering an error when trying to retrieve the full document text from the MS MARCO passage indexes. The error suggests that the document retrieval function is returning a None object instead of the expected document content.

This could indicate:

The document retrieval functionality may not be fully configured for the MS MARCO indexes

There might be a technical issue with the document storage/retrieval system

The document content may not be stored in a retrievable format in these particular indexes

While I can successfully search these indexes and get document IDs with relevance scores, I'm unable to retrieve the actual text content at this time. The search functionality is working (as we saw earlier), but the document retrieval appears to be experiencing technical difficulties.

Would you like me to try searching and retrieving documents from one of the BEIR collection indexes instead, which might have better document retrieval support?
```

Additionally errors popped up on the side of the app with:
```
MCP mcpyserini: Unexpected token 'U', "Unrecogniz"... is not valid JSON
MCP mcpyserini: Unexpected token 'A', "Attempting"... is not valid JSON
MCP mcpyserini: Unexpected token '/', "/home/ssub"... is not valid JSON
MCP mcpyserini: Unexpected token 'E', "Extracting"... is not valid JSON
MCP mcpyserini: Unexpected token 'I', "Initializi"... is not valid JSON
MCP mcpyserini: Unexpected token 'D', "Downloadin"... is not valid JSON
```

Later, I tried the same sequence of commands again, and it worked perfectly. Perhaps the Claude desktop app is buggy, restarting the client a couple hours later might have made it work.

Otherwise, reproduced successfully.