### PR TITLE
Add fusion and qrel capabilities for MCPyserini

### DIFF
--- a/pyserini/server/mcp/tools.py
+++ b/pyserini/server/mcp/tools.py
@@ -22,7 +22,7 @@ Register tools for the MCP server.
 from typing import Any
 
 from fastmcp import FastMCP
-from pyserini.server.search_controller import SearchController
+from pyserini.server.search_controller import SearchController, DenseSearchResult
 from pyserini.server.models import INDEX_TYPE
 
 def register_tools(mcp: FastMCP, controller: SearchController):
@@ -30,7 +30,7 @@ def register_tools(mcp: FastMCP, controller: SearchController):
 
     @mcp.tool(
         name='search',
-        description='Perform a BM25 search on a given index. Returns top‑k hits with docid, score, and snippet.',
+        description='Perform search on a given index. Returns top‑k hits with docid, score, and snippet.',
     )
     def search(
         query: str,
@@ -99,3 +99,25 @@ def register_tools(mcp: FastMCP, controller: SearchController):
             Dictionary with index information.
         """
         return controller.get_status(index_name)  
+    
+    @mcp.tool(
+        name="fuse_search_results",
+        description="Performs normalization fusion on search results to improve ranking."
+    )
+    def fuse_search_results(
+        hits1: list[DenseSearchResult], 
+        hits2: list[DenseSearchResult], 
+        k: int = 10
+    ) -> list[DenseSearchResult]:
+        """
+        Performs normalization fusion on search results to improve ranking.
+
+        Args:
+            hits1: First list of search results to merge with docid and score
+            hits2: Second list of search results to merge with docid and score
+            k: Number of results to return (default: 10)
+
+        Returns:
+            Dictionary with index information.
+        """
+        return controller.fuse(hits1, hits2)

--- a/pyserini/server/mcp/tools.py
+++ b/pyserini/server/mcp/tools.py
@@ -120,4 +120,21 @@ def register_tools(mcp: FastMCP, controller: SearchController):
         Returns:
             Dictionary with index information.
         """
-        return controller.fuse(hits1, hits2)
+        return controller.fuse(hits1, hits2, k)
+    
+    @mcp.tool(
+        name="get_qrels",
+        description="Returns relevant judgements for a given index and query."
+    )
+    def get_qrels(
+        index_name: str,
+        query_id: str
+    ) -> dict[str, str]:
+        """
+        Returns relevant judgements for a given index and query.
+
+        Args:
+            index_name: Name of the index to get relevant judgements for
+            query_id: Query ID to to get relevant judgements for
+        """
+        return controller.get_query_qrels(index_name, query_id)

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -26,7 +26,8 @@ import json
 from typing import Any
 
 from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher, LuceneFlatDenseSearcher, LuceneImpactSearcher
-from pyserini.search.faiss import FaissSearcher
+from pyserini.search.faiss import FaissSearcher, DenseSearchResult
+from pyserini.search.hybrid import HybridSearcher
 from pyserini.encode import AutoQueryEncoder
 from pyserini.prebuilt_index_info import TF_INDEX_INFO, LUCENE_FLAT_INDEX_INFO, LUCENE_HNSW_INDEX_INFO, IMPACT_INDEX_INFO, FAISS_INDEX_INFO
 from pyserini.util import check_downloaded
@@ -135,6 +136,14 @@ class SearchController:
         results['candidates'] = candidates
 
         return results
+    
+    def fuse(
+        self,
+        hits1: list[DenseSearchResult],
+        hits2: list[DenseSearchResult],
+        k: int = 10
+    ) -> list[DenseSearchResult]:
+        return HybridSearcher._hybrid_results(hits1, hits2, 1, k, True)
     
     # TODO: make this not default to sharded search for msmarco-v2.1-doc-artic-embed-l
     def sharded_search( 

--- a/pyserini/server/search_controller.py
+++ b/pyserini/server/search_controller.py
@@ -25,14 +25,14 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 from typing import Any
 
-from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher, LuceneFlatDenseSearcher, LuceneImpactSearcher
-from pyserini.search.faiss import FaissSearcher, DenseSearchResult
-from pyserini.search.hybrid import HybridSearcher
 from pyserini.encode import AutoQueryEncoder
 from pyserini.prebuilt_index_info import TF_INDEX_INFO, LUCENE_FLAT_INDEX_INFO, LUCENE_HNSW_INDEX_INFO, IMPACT_INDEX_INFO, FAISS_INDEX_INFO
-from pyserini.util import check_downloaded
-
+from pyserini.search import get_qrels
+from pyserini.search.faiss import FaissSearcher, DenseSearchResult
+from pyserini.search.hybrid import HybridSearcher
+from pyserini.search.lucene import LuceneSearcher, LuceneHnswDenseSearcher, LuceneFlatDenseSearcher, LuceneImpactSearcher
 from pyserini.server.models import IndexConfig, INDEX_TYPE, SHARDS
+from pyserini.util import check_downloaded
 
 DEFAULT_INDEX = 'msmarco-v1-passage'
 
@@ -209,6 +209,10 @@ class SearchController:
         if status.get('size_bytes') is None:
             status['size_bytes'] = "Not available"
         return status
+    
+    def get_query_qrels(self, index_name: str, query_id: str) -> dict[str, str]:
+        qrels = get_qrels(index_name)
+        return qrels.get(query_id)
 
     def update_settings(
         self,


### PR DESCRIPTION
Fusion demonstration: 
<img width="293" height="414" alt="image" src="https://github.com/user-attachments/assets/3a8691ab-4e8a-4953-8f88-dce502988d77" />
Qrels demonstration: https://claude.ai/share/583b6469-3a4b-4bb3-9431-9b7952ec697d
Addresses https://github.com/castorini/pyserini/issues/2150#issuecomment-3092334699
A slightly inconvenient thing: qrels mark based on query id, but retrieval uses query text. So to retrieve and evaluate, you need to know both the query content and the query id. 