### PR TITLE
Fix for potential null fields in mixed modality datasets

### DIFF
--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -128,7 +128,7 @@ class JsonlCollectionIterator:
 
         # if all fields are under the key of info, read these rather than 'contents' 
         if all([field in info for field in self.fields]):
-            return [info[field].strip() for field in self.fields]
+            return [info[field].strip() if info[field] else None for field in self.fields]
 
         assert "contents" in info, f"contents not found in info: {info}"
         contents = info['contents']

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -174,7 +174,7 @@ class JsonlCollectionIterator:
                     for i in range(len(fields_info)):
                         if 'path' in self.fields[i]:
                             _info = fields_info[i]
-                            if not _info.startswith(("http://", "https://")):
+                            if _info is not None and not _info.startswith(("http://", "https://")):
                                 fields_info[i] = os.path.join(self.collection_dir, fields_info[i])
                         all_info[self.fields[i]].append(fields_info[i])
         return all_info
@@ -207,7 +207,7 @@ class JsonlRepresentationWriter(RepresentationWriter):
 
     def write(self, batch_info, fields=None):
         for i in range(len(batch_info['id'])):
-            contents = "\n".join([batch_info[key][i] for key in fields])
+            contents = "\n".join([batch_info[key][i] if batch_info[key][i] is not None else "" for key in fields])
             vector = batch_info['vector'][i]
             vector = vector.tolist() if isinstance(vector, np.ndarray) else vector
             self.file.write(json.dumps({'id': batch_info['id'][i],

--- a/tests/resources/simple_mixed_modality_corpus.json
+++ b/tests/resources/simple_mixed_modality_corpus.json
@@ -1,0 +1,3 @@
+{"img_path": "mbeir_images/cirr_images/train/49/train-1287-0-img0.jpg", "modality": "image", "did": "8:1", "src_content": "{\"id\": \"train-1287-0-img0\"}", "txt": null}
+{"img_path": null, "modality": "image", "did": "8:2", "src_content": "{\"id\": \"train-224-1-img1\"}", "txt": "test"}
+{"img_path": "mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg", "modality": "image", "did": "8:3", "src_content": "{\"id\": \"train-10958-1-img1\"}", "txt": null}

--- a/tests/resources/simple_mixed_modality_corpus.json
+++ b/tests/resources/simple_mixed_modality_corpus.json
@@ -1,3 +1,3 @@
 {"img_path": "mbeir_images/cirr_images/train/49/train-1287-0-img0.jpg", "modality": "image", "did": "8:1", "src_content": "{\"id\": \"train-1287-0-img0\"}", "txt": null}
 {"img_path": null, "modality": "text", "did": "8:2", "src_content": "{\"id\": \"train-224-1-img1\"}", "txt": "test"}
-{"img_path": "mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg", "modality": "image,txt", "did": "8:3", "src_content": "{\"id\": \"train-10958-1-img1\"}", "txt": "test"}
+{"img_path": "mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg", "modality": "image,text", "did": "8:3", "src_content": "{\"id\": \"train-10958-1-img1\"}", "txt": "test"}

--- a/tests/resources/simple_mixed_modality_corpus.json
+++ b/tests/resources/simple_mixed_modality_corpus.json
@@ -1,3 +1,3 @@
 {"img_path": "mbeir_images/cirr_images/train/49/train-1287-0-img0.jpg", "modality": "image", "did": "8:1", "src_content": "{\"id\": \"train-1287-0-img0\"}", "txt": null}
 {"img_path": null, "modality": "text", "did": "8:2", "src_content": "{\"id\": \"train-224-1-img1\"}", "txt": "test"}
-{"img_path": "mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg", "modality": "image", "did": "8:3", "src_content": "{\"id\": \"train-10958-1-img1\"}", "txt": null}
+{"img_path": "mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg", "modality": "image,txt", "did": "8:3", "src_content": "{\"id\": \"train-10958-1-img1\"}", "txt": "test"}

--- a/tests/resources/simple_mixed_modality_corpus.json
+++ b/tests/resources/simple_mixed_modality_corpus.json
@@ -1,3 +1,3 @@
 {"img_path": "mbeir_images/cirr_images/train/49/train-1287-0-img0.jpg", "modality": "image", "did": "8:1", "src_content": "{\"id\": \"train-1287-0-img0\"}", "txt": null}
-{"img_path": null, "modality": "image", "did": "8:2", "src_content": "{\"id\": \"train-224-1-img1\"}", "txt": "test"}
+{"img_path": null, "modality": "text", "did": "8:2", "src_content": "{\"id\": \"train-224-1-img1\"}", "txt": "test"}
 {"img_path": "mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg", "modality": "image", "did": "8:3", "src_content": "{\"id\": \"train-10958-1-img1\"}", "txt": null}

--- a/tests/test_encoder_iterator.py
+++ b/tests/test_encoder_iterator.py
@@ -162,17 +162,18 @@ class TestJsonlCollectionIterator(unittest.TestCase):
     def test_path_loading(self):
         corpus_path = 'tests/resources/simple_mixed_modality_corpus.json'
         all_expected_info = [
-            ('tests/resources/mbeir_images/cirr_images/train/49/train-1287-0-img0.jpg', 'image', '8:1'),
-            (None, 'image', '8:2'),
-            ('tests/resources/mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg', 'image', '8:3'),
+            ('tests/resources/mbeir_images/cirr_images/train/49/train-1287-0-img0.jpg', 'image', '8:1', None),
+            (None, 'text', '8:2', "test"),
+            ('tests/resources/mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg', 'image,text', '8:3', "test"),
         ]
-        collection_iterator = JsonlCollectionIterator(corpus_path, ['img_path', 'modality', 'did'], docid_field='did')
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['img_path', 'modality', 'did', 'txt'], docid_field='did')
         for i, info in enumerate(collection_iterator):
             expected_info = all_expected_info[i]
 
             self.assertEqual(expected_info[0], info['img_path'][0])
             self.assertEqual(expected_info[1], info['modality'][0])
             self.assertEqual(expected_info[2], info['did'][0])
+            self.assertEqual(expected_info[3], info['txt'][0])
 
 
 if __name__ == '__main__':

--- a/tests/test_encoder_iterator.py
+++ b/tests/test_encoder_iterator.py
@@ -159,6 +159,21 @@ class TestJsonlCollectionIterator(unittest.TestCase):
             self.assertEqual(expected_info[1], info['title'][0])
             self.assertEqual(expected_info[2], info['text'][0])
 
+    def test_path_loading(self):
+        corpus_path = 'tests/resources/simple_mixed_modality_corpus.json'
+        all_expected_info = [
+            ('tests/resources/mbeir_images/cirr_images/train/49/train-1287-0-img0.jpg', 'image', '8:1'),
+            (None, 'image', '8:2'),
+            ('tests/resources/mbeir_images/cirr_images/train/97/train-10958-1-img1.jpg', 'image', '8:3'),
+        ]
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['img_path', 'modality', 'did'], docid_field='did')
+        for i, info in enumerate(collection_iterator):
+            expected_info = all_expected_info[i]
+
+            self.assertEqual(expected_info[0], info['img_path'][0])
+            self.assertEqual(expected_info[1], info['modality'][0])
+            self.assertEqual(expected_info[2], info['did'][0])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Mixed modality datasets will have null fields that need to be addressed gracefully.