### PR TITLE
Add onboarding reproduction log entries 

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -417,3 +417,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@goodzcyabc](https://github.com/goodzcyabc) on 2025-07-29 (commit [`44889de`](https://github.com/castorini/pyserini/commit/44889de3d151b2e1317934b405b3ad6badd81308))
 + Results reproduced by [@bikram993298](https://github.com/bikram993298) on 2025-08-21 (commit [`a6b70c8`](https://github.com/castorini/pyserini/commit/a6b70c8759d60dc376a0b7ce66e9dcea2f851796))
 + Results reproduced by [@JoshElkind](https://github.com/JoshElkind) on 2025-08-24 (commit [`4490f7b`](https://github.com/castorini/pyserini/commit/4490f7b1162c130309ad36cbb27fe16787026f3d))
++ Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-04 (commit [`e6617ad`](https://github.com/castorini/pyserini/commit/b09c7869e07d41ae5b348ac69063914207e6617ad))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -673,3 +673,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@goodzcyabc](https://github.com/goodzcyabc) on 2025-08-06 (commit [`44889de`](https://github.com/castorini/pyserini/commit/44889de3d151b2e1317934b405b3ad6badd81308))
 + Results reproduced by [@bikram993298](https://github.com/bikram993298) on 2025-08-21 (commit [`a6b70c8`](https://github.com/castorini/pyserini/commit/a6b70c8759d60dc376a0b7ce66e9dcea2f851796))
 + Results reproduced by [@JoshElkind](https://github.com/JoshElkind) on 2025-08-24 (commit [`4490f7b`](https://github.com/castorini/pyserini/commit/4490f7b1162c130309ad36cbb27fe16787026f3d))
++ Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-08 (commit [`e6617ad`](https://github.com/castorini/pyserini/commit/b09c7869e07d41ae5b348ac69063914207e6617ad))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -455,3 +455,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@goodzcyabc](https://github.com/goodzcyabc) on 2025-07-28 (commit [`44889de`](https://github.com/castorini/pyserini/commit/44889de3d151b2e1317934b405b3ad6badd81308))
 + Results reproduced by [@bikram993298](https://github.com/bikram993298) on 2025-08-21 (commit [`a6b70c8`](https://github.com/castorini/pyserini/commit/a6b70c8759d60dc376a0b7ce66e9dcea2f851796))
 + Results reproduced by [@JoshElkind](https://github.com/JoshElkind) on 2025-08-24 (commit [`4490f7b`](https://github.com/castorini/pyserini/commit/4490f7b1162c130309ad36cbb27fe16787026f3d))
++ Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-03 (commit [`e6617ad`](https://github.com/castorini/pyserini/commit/b09c7869e07d41ae5b348ac69063914207e6617ad))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -461,3 +461,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@goodzcyabc](https://github.com/goodzcyabc) on 2025-08-2 (commit [`44889de`](https://github.com/castorini/pyserini/commit/44889de3d151b2e1317934b405b3ad6badd81308))
 + Results reproduced by [@bikram993298](https://github.com/bikram993298) on 2025-08-21 (commit [`a6b70c8`](https://github.com/castorini/pyserini/commit/a6b70c8759d60dc376a0b7ce66e9dcea2f851796))
 + Results reproduced by [@JoshElkind](https://github.com/JoshElkind) on 2025-08-24 (commit [`4490f7b`](https://github.com/castorini/pyserini/commit/4490f7b1162c130309ad36cbb27fe16787026f3d))
++ Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-08 (commit [`e6617ad`](https://github.com/castorini/pyserini/commit/b09c7869e07d41ae5b348ac69063914207e6617ad))


### PR DESCRIPTION
## **Setup Details**
OS: macOS 15.5 (Apple Silicon M2)
Hardware: MacBook Pro, 16GB RAM
Java: 21.0.1
Python: 3.11.9
Environment: Standard terminal(zsh)

## **Results** and **Issues**

Able to reproduce all the respective results while facing these issues and fixing with the solution

**Missing Dependencies** (8 packages) even after installing pyserini
Sequential import errors: faiss-cpu, typeguard, torch, clip, transformers, timm, cv2, omegaconf
Solution: Complete dependency installation documented

**macOS OpenMP Crash**
SIGSEGV in libomp.dylib during dense retrieval in BGE-base Baseline for NFCorpus while Retrieval
Solution: export KMP_DUPLICATE_LIB_OK=TRUE + thread reduction

**Java Path Issues**
BM25 evaluation failed due to missing JAR
Solution: JAR path configuration in pyserini/eval/trec_eval.py

