### PR TITLE
Fix VM already running bug in trec_eval

### DIFF
--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -43,7 +43,12 @@ import pandas as pd
 # Don't use the jdk.incubator.vector module.
 jar_directory = str(importlib.resources.files("pyserini.resources.jars").joinpath(''))
 jar_path = glob.glob(os.path.join(jar_directory, '*.jar'))[0]
-jnius_config.add_classpath(jar_path)
+
+try:
+    jnius_config.add_classpath(jar_path)
+except:
+    # This might happen if the JVM's already been initialized. Just eat the error.
+    pass
 
 # This triggers loading of the JVM.
 import jnius


### PR DESCRIPTION
Fixing this exception:

```
======================================================================
ERROR: tests.test_rest (unittest.loader._FailedTest.tests.test_rest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.test_rest
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/loader.py", line 407, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/loader.py", line 350, in _get_module_from_name
    __import__(name)
  File "/Users/jimmylin/workspace/pyserini/tests/test_rest.py", line 19, in <module>
    from pyserini.server.rest.app import app, VERSION
  File "/Users/jimmylin/workspace/pyserini/pyserini/server/rest/app.py", line 20, in <module>
    from pyserini.server.rest.routes.indexes import router
  File "/Users/jimmylin/workspace/pyserini/pyserini/server/rest/routes/indexes.py", line 25, in <module>
    from pyserini.server.search_controller import get_controller
  File "/Users/jimmylin/workspace/pyserini/pyserini/server/search_controller.py", line 29, in <module>
    from pyserini.eval.trec_eval import trec_eval
  File "/Users/jimmylin/workspace/pyserini/pyserini/eval/trec_eval.py", line 46, in <module>
    jnius_config.add_classpath(jar_path)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/site-packages/jnius_config.py", line 57, in add_classpath
    check_vm_running()
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/site-packages/jnius_config.py", line 20, in check_vm_running
    raise ValueError("VM is already running, can't set classpath/options; VM started at" + vm_started_at)
ValueError: VM is already running, can't set classpath/options; VM started at  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/__main__.py", line 18, in <module>
    main(module=None)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/main.py", line 101, in __init__
    self.parseArgs(argv)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/main.py", line 133, in parseArgs
    self._do_discovery([])
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/main.py", line 247, in _do_discovery
    self.createTests(from_discovery=True, Loader=Loader)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/main.py", line 157, in createTests
    self.test = loader.discover(self.start, self.pattern, self.top)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/loader.py", line 322, in discover
    tests = list(self._find_tests(start_dir, pattern))
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/loader.py", line 385, in _find_tests
    yield from self._find_tests(full_path, pattern)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/loader.py", line 377, in _find_tests
    tests, should_recurse = self._find_test_path(full_path, pattern)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/loader.py", line 440, in _find_test_path
    package = self._get_module_from_name(name)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/unittest/loader.py", line 350, in _get_module_from_name
    __import__(name)
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/jimmylin/workspace/pyserini/pyserini/analysis/__init__.py", line 17, in <module>
    from ._base import get_lucene_analyzer, Analyzer, JAnalyzer, JAnalyzerUtils, JDefaultEnglishAnalyzer, JWhiteSpaceAnalyzer
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/jimmylin/workspace/pyserini/pyserini/analysis/_base.py", line 19, in <module>
    from pyserini.pyclass import autoclass
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/jimmylin/workspace/pyserini/pyserini/pyclass.py", line 31, in <module>
    from jnius import autoclass, cast
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/site-packages/jnius/__init__.py", line 45, in <module>
    from .reflect import *  # noqa
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/homebrew/Caskroom/miniforge/base/envs/pyserini-dev1/lib/python3.11/site-packages/jnius/reflect.py", line 19, in <module>
    class Class(JavaClass, metaclass=MetaJavaClass):
```