### PR TITLE
Reproduction Log: Pyserini MS MARCO Passage BM25 (2025-09-24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ runs/
 
 # logs should also be ignored
 logs/
+
+# Local virtualenvs
+.venv/
+.venv311/

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -463,3 +463,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@shreyaadritabanik](https://github.com/shreyaadritabanik) on 2025-09-18 (commit [`4189efe`](https://github.com/castorini/pyserini/commit/4189efe9b1f936eda9d4142a039d146d9341deb6))
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-20 (commit [`bb9dbed`](https://github.com/castorini/pyserini/commit/bb9dbeda8ceda4d8037a17a0827b292ab727b1fb))
 + Results reproduced by [@k464wang](https://github.com/k464wang) on 2025-09-21 (commit [`6ceefc1`](https://github.com/castorini/pyserini/pull/2257/commits/6ceefc11110eff6ee1632d5d359036c210c29cae))
++ Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-19 (commit [`9815d56`](https://github.com/castorini/anserini/commit/9815d56eb4e41a62d59e41cbd49af25c6a907338))


### PR DESCRIPTION
System

- macOS 14.5 (M3 chip)
- Python 3.11 (venv)

Data/Index

- Downloaded MS MARCO passage (~4 GB)
- Converted to JSONL (~7 GB, 9 shards)
- Indexed 8,841,823 docs (~4.3 GB), threads=9

Run & Eval

- BM25 tuned (k1 = 0.82, b = 0.68, hits=1000, threads=4, batch-size=16)
- MS MARCO eval: MRR@10 = 0.1874 (6980 queries)
- trec_eval: MAP = 0.1957; recall@1000 = 0.8573

Notes

- Used Python route via Pyserini.
- Results matched expected values from the guide.
- No issues encountered.

Superseded by #2268 (consolidated per Prof. Lins request). Closing this PR.