### PR TITLE
Reproduction Log: Conceptual Framework — Rashad (2025-09-24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ runs/
 
 # logs should also be ignored
 logs/
+
+# Local virtualenvs
+.venv/
+.venv311/

--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -425,3 +425,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@shreyaadritabanik](https://github.com/shreyaadritabanik) on 2025-09-18 (commit [`4189efe`](https://github.com/castorini/pyserini/commit/4189efe9b1f936eda9d4142a039d146d9341deb6))
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-20 (commit [`bb9dbed`](https://github.com/castorini/pyserini/commit/bb9dbeda8ceda4d8037a17a0827b292ab727b1fb))
 + Results reproduced by [@k464wang](https://github.com/k464wang) on 2025-09-21 (commit [`6ceefc1`](https://github.com/castorini/pyserini/pull/2257/commits/6ceefc11110eff6ee1632d5d359036c210c29cae))
++ Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-19 (commit [`5a1a6540`](https://github.com/castorini/anserini/commit/5a1a654084b439243d37c94af1638cef7a8931bc))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -463,3 +463,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@shreyaadritabanik](https://github.com/shreyaadritabanik) on 2025-09-18 (commit [`4189efe`](https://github.com/castorini/pyserini/commit/4189efe9b1f936eda9d4142a039d146d9341deb6))
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-20 (commit [`bb9dbed`](https://github.com/castorini/pyserini/commit/bb9dbeda8ceda4d8037a17a0827b292ab727b1fb))
 + Results reproduced by [@k464wang](https://github.com/k464wang) on 2025-09-21 (commit [`6ceefc1`](https://github.com/castorini/pyserini/pull/2257/commits/6ceefc11110eff6ee1632d5d359036c210c29cae))
++ Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-19 (commit [`9815d56`](https://github.com/castorini/anserini/commit/9815d56eb4e41a62d59e41cbd49af25c6a907338))


### PR DESCRIPTION
System

- macOS 14.5 (M3 chip)
- Python 3.11 (venv)

Steps

- Used existing lucene-index-msmarco-passage index from prior BM25 experiment
- Verified BM25 as bi-encoder instantiation:
- Retrieved BM25 vector for docid 7187158
- Tokenized query "what is paula deen's brother" → ['what', 'paula', 'deen', 'brother']
- Computed dot product between query and document vector ≈ 17.9495
- Confirmed same score via LuceneSearcher (docid 7187158, score ≈ 17.9495)

Output

- BM25 vector JSON produced as expected
- Query tokens matched guide
- Manual dot product score matched LuceneSearcher score

Notes

- No issues encountered, results matched guide exactly.

Superseded by #2268 (consolidated per Prof. Lins request). Closing this PR.