### PR TITLE
Add to experiments-nfcorpus.md log

### DIFF
--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -472,3 +472,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-25 (commit [`9815d56`](https://github.com/castorini/pyserini/commit/9815d56eb4e41a62d59e41cbd49af25c6a907338))
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-29 (commit [`b853071`](https://github.com/castorini/pyserini/commit/b853071b2fff4ee8951e8fce455ad61ace893b57))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-10-06 (commit [`5de309a`](https://github.com/castorini/pyserini/commit/5de309ad6ca5129b62d611cd33d38e4d8bf4c66d))
++ Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`42e97dc`] (https://github.com/castorini/pyserini/commit/42e97dcb9bef044c91ec4f5191995cee98b4e47b))


### PR DESCRIPTION
Machine:
MacOS Sequoia 15.6.1, apple M2, 8GB

The updated conda env:
name: pyserini
channels:
  - defaults
  - conda-forge
dependencies:
  - python=3.11
  - numpy=1.26.4
  - pandas
  - pytorch
  - onnxruntime
  - openjdk=21
  - maven
  - pip
  - faiss-cpu
  - pip:
    - pyjnius
    - transformers
    - pyserini

The CPU runtime exceeded the server limit, so I witched back to my mac with 4 threads, 32 batch size in indexing and 8 threads, 128 batch size for retrieval, which took at least 10 min.