### PR TITLE
Pyserini PR

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -430,3 +430,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-10-05 (commit [`5de309a`](https://github.com/castorini/pyserini/commit/5de309ad6ca5129b62d611cd33d38e4d8bf4c66d))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`322d95d`](https://github.com/castorini/pyserini/commit/322d95d67621862ff5ddee4b398155cc5b1b68fc))
 + Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`42e97dc`] (https://github.com/castorini/pyserini/commit/42e97dcb9bef044c91ec4f5191995cee98b4e47b))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-15 (commit [`cd45e54`](https://github.com/castorini/pyserini/commit/cd45e5488f269cbd3d77722e788d51fd2dc26671))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -686,3 +686,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-10-06 (commit [`5de309a`](https://github.com/castorini/pyserini/commit/5de309ad6ca5129b62d611cd33d38e4d8bf4c66d))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`322d95d`](https://github.com/castorini/pyserini/commit/322d95d67621862ff5ddee4b398155cc5b1b68fc))
 + Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`42e97dc`] (https://github.com/castorini/pyserini/commit/42e97dcb9bef044c91ec4f5191995cee98b4e47b))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-15 (commit [`cd45e54`](https://github.com/castorini/pyserini/commit/cd45e5488f269cbd3d77722e788d51fd2dc26671))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -468,3 +468,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-10-04 (commit [`5de309a`](https://github.com/castorini/pyserini/commit/5de309ad6ca5129b62d611cd33d38e4d8bf4c66d))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`322d95d`](https://github.com/castorini/pyserini/commit/322d95d67621862ff5ddee4b398155cc5b1b68fc))
 + Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`42e97dc`] (https://github.com/castorini/pyserini/commit/42e97dcb9bef044c91ec4f5191995cee98b4e47b))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-15 (commit [`cd45e54`](https://github.com/castorini/pyserini/commit/cd45e5488f269cbd3d77722e788d51fd2dc26671))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -474,3 +474,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-10-06 (commit [`5de309a`](https://github.com/castorini/pyserini/commit/5de309ad6ca5129b62d611cd33d38e4d8bf4c66d))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`322d95d`](https://github.com/castorini/pyserini/commit/322d95d67621862ff5ddee4b398155cc5b1b68fc))
 + Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`42e97dc`] (https://github.com/castorini/pyserini/commit/42e97dcb9bef044c91ec4f5191995cee98b4e47b))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-15 (commit [`cd45e54`](https://github.com/castorini/pyserini/commit/cd45e5488f269cbd3d77722e788d51fd2dc26671))


### PR DESCRIPTION
I worked through the full four-step guide myself, carefully following each instruction, cross-checking outputs, and re-running pieces when needed. I reproduced all of the expected results and verified that interactive runs match batch runs. Everything completed successfully. The entire effort took **more than 2 days** to read, execute, debug minor hiccups, and document thoroughly.

## What I changed

* **Docs:**

  * `docs/conceptual-framework2.md` 
  * `docs/conceptual-framework.md` 
  * `docs/experiments-nfcorpus.md`
  * `docs/experiments-msmarco-passage.md` 

## Reproduction summary (what I actually did)

### Step 1 — MS MARCO Passage with Pyserini (BM25)

* Set up dev env; downloaded `collectionandqueries.tar.gz` (verified MD5 `31644046b18952c1386cd4564ba2ae69`).
* Converted `collection.tsv` → 9 JSONL shards; indexed as `JsonCollection` with positions, docvectors, raw.
* Confirmed index size **8,841,823** docs.
* Ran tuned BM25 (`k1=0.82, b=0.68`) over the **6,980** dev queries; produced MSMARCO-format and TREC-format runs (~6.9M lines).
* Evaluated with Pyserini’s MS MARCO evaluator and `trec_eval`; reproduced **MRR@10 ≈ 0.1874** and expected MAP/Recall.

### Step 2 — Conceptual framework (bi-encoder)

* Verified that BM25 (unsupervised sparse) and BGE-base (supervised dense) fit the same bi-encoder pattern.
* Materialized multi-hot query vectors, confirmed inner-product scoring intuition, and connected it to Lucene/Faiss top-k behavior.

### Step 3 — NFCorpus dense baseline (BGE-base)

* Fetched BEIR NFCorpus (3,633 docs); converted queries/qrels to the required formats.
* Encoded with `BAAI/bge-base-en-v1.5` (mean pooling, L2-norm) on CPU; built Faiss **FlatIP** index.
* Ran batch retrieval and evaluated with `trec_eval`; reproduced **nDCG@10 ≈ 0.3808**.
* Confirmed interactive search returns the same top-10 and scores as batch.

### Step 4 — Dense & sparse deep dive

* **Dense:** Reconstructed vectors from Faiss, mapped docids, encoded queries, and verified scores with explicit `np.dot`—matching `FaissSearcher`.
* **Sparse:** Rebuilt BM25 doc vectors from Lucene, formed multi-hot queries, and computed scores via dictionary intersection/sum—matching `LuceneSearcher`.

## Environment & runtime notes

| Item             | Details                                            |
| ---------------- | -------------------------------------------------- |
| Dates            | 2025-10-16 → 2025-10-18                            |
| OS               | macOS 15.1.1                                       |
| Python           | 3.12.x                                              |
| Java             | 21.0.x                                             |
| Tools            | Pyserini, Faiss, `trec_eval` (via Pyserini)        |
| Hardware         | Laptop (CPU; no CUDA)                              |
| Concurrency      | BM25 threads: 4; Dense batch: 128; threads: 4 |
| MS MARCO docs    | **8,841,823**                                      |
| MS MARCO queries | **6,980**                                          |
| BM25 metrics     | **MRR@10 ≈ 0.1874**                                |
| NFCorpus docs    | **3,633**                                          |
| Dense metric     | **nDCG@10 ≈ 0.3808**                               |
| NFCorpus BM25    | **nDCG@10 ≈ 0.3218**                               |
| Overall effort   | **> 2 days** end-to-end                            |

## Owner-only notes (limitations & suggestions)

* **CPU-only constraint** : I ran dense encoding on NFCorpus without a GPU. It worked but was slow; I had to tune --batch and --threads to keep things moving. A CUDA-enabled run would cut wall time substantially.

* **Introspection requirement**: I intentionally kept `--storeDocvectors` in Lucene indexing so I could inspect BM25 vectors. Dropping this flag would save disk but remove a key debugging/learning tool.

* **Validation gotchas**: When results looked off, the fixes were almost always analyzer/tokenization mismatches or the wrong run-file format (MS MARCO vs. TREC). Double-checking those resolved discrepancies.

Result: ✅ I completed all steps, validated each stage, and reproduced the expected results for both BM25 and BGE-base pipelines (batch and interactive).