### PR TITLE
Reproduced splade results

### DIFF
--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -215,3 +215,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@ricky42613](https://github.com/ricky42613) on 2025-04-25 (commit [`ea70638`](https://github.com/castorini/pyserini/commit/ea70638d56e4346ab8ae9ec205b1e278bcc5afe2))
 + Results reproduced by [@lzguan](https://github.com/lzguan) on 2025-05-02 (commit [`252ee06`](https://github.com/castorini/pyserini/commit/252ee0695c0a533153cd4e769380bbef0edaae7f))
 + Results reproduced by [@mindlesstruffle](https://github.com/mindlesstruffle) on 2025-07-15 (commit [`b5d4838`](https://github.com/castorini/pyserini/commit/b5d48381c171e0ac36cd0c2523fe77b7bfe45435))
++ Results reproduced by [@FarmersWrap](https://github.com/FarmersWrap) on 2025-11-02 (commit [`80395dc`](https://github.com/castorini/pyserini/commit/80395dc7b6e0d5c045f4dcf4ef8e61958ec636ca))


### PR DESCRIPTION
Ubuntu 24.04.3 LTS
i9-12900K
Mem 125Gi
Python 3.12.3
openjdk version "21.0.8"


Reproduced the splade results, and read we are using SPLADE_v2 max pooling for our queries and docs.
```python
batch_aggregated_logits, _ = torch.max(torch.log(1 + torch.relu(batch_logits)) * input_attention.unsqueeze(-1), dim=1)
```
The results are exactly the same as the tutorial.