### PR TITLE
Fix bug in #2329 - parsing of trec_eval output

### DIFF
--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -162,6 +162,18 @@ def trec_eval(
         if value is not None:
             lines[key] = value
 
+    # The above logic is janky, see https://github.com/castorini/pyserini/issues/2329
+    # If multiple metrics are requested, they override each other and only the value for the last metric gets returned.
+    # This is because we're only keeping track of array position 1 and array position 2:
+    #
+    # map                   	all	0.0933
+    # recall_100            	all	0.4895
+    # ndcg_cut_10           	all	0.1265
+    #
+    # This is probably not the desired behavior, but fixing requires more knowledge of what the upstream caller is
+    # intending to do, which requires more work to go through the code base to find the callers.
+    # TODO: FIXME
+
     if return_per_query_results:
         return lines
 


### PR DESCRIPTION
hey @sahel-sh can you take a look at this? I've preserved your original logic, but not sure what you're trying to do...

Since you only keep track of `line.split("\t")[1]`, you're not keeping track of _what metric_ you're parsing...
