### PR TITLE
fix failing tests

### DIFF
--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -143,7 +143,7 @@ def trec_eval(
     )
     stdout, stderr = process.communicate()
     if stderr:
-        print(stderr.decode("utf-8"))
+        print(stderr.decode("utf-8"), file=sys.stderr)
 
     output = stdout.decode("utf-8").rstrip()
     # Print trec_eval's stdout only when it contains metrics the user actually asked for.
@@ -206,7 +206,6 @@ def trec_eval(
     if query_id:
         return lines[query_id]
     else:
-        print(f"returning: {lines['all']}")
         return lines["all"]
 
 


### PR DESCRIPTION
Some tests dump the print value of the trec_eval function and compare it to an expected file, the extra print from PR #2332 makes these tests fail.

Sometimes the `Picked up JAVA_TOOL_OPTIONS: -Djava.io.tmpdir=...\n` or only the end '\n' stays in stderr. Printing this into stdout changes makes the test_trectools to fail.