### PR TITLE
Tweak M-BEIR 2CR: if score is higher, don't indicate [FAIL]

### DIFF
--- a/pyserini/2cr/m_beir.py
+++ b/pyserini/2cr/m_beir.py
@@ -174,7 +174,7 @@ def run_conditions(args):
                                   
                             if math.isclose(score, float(expected[metric])):  
                                 result = ok_str  
-                            elif abs(score - float(expected[metric])) <= 0.0005:  
+                            elif abs(score - float(expected[metric])) <= 0.0005 or score > float(expected[metric]):
                                 result = okish_str + f' expected {expected[metric]:.4f}'  
                             else:  
                                 result = fail_str + f' expected {expected[metric]:.4f}'  


### PR DESCRIPTION
This is the result currently:

```
  - Dataset: nights_task4

      R@1    : 0.0887 [OK]
      R@5    : 0.3198 [FAIL] expected 0.3193
      R@10   : 0.5325 [OK]
```

Results are actually better... don't fail.