### PR TITLE
Fixed the integrations/core/sparse/test_verify_rrf.py md5 values

### DIFF
--- a/integrations/core/sparse/test_verify_rrf.py
+++ b/integrations/core/sparse/test_verify_rrf.py
@@ -83,7 +83,7 @@ class TestRRF(unittest.TestCase):
 
         with open(f'{self.tmp}/anserini.covid-r3.fusion1.txt', 'rb') as f:
             md5 = hashlib.md5(f.read()).hexdigest()
-        self.assertEqual('61cbd73c6e60ba44f18ce967b5b0e5b3', md5)
+        self.assertEqual('353eb335acff30cfe74f14b1b87671c9', md5)
 
         os.system(f'python -m pyserini.fusion --method rrf --runs ' +
                   f'{self.tmp}/anserini.covid-r3.abstract.qdel.bm25.txt ' +
@@ -94,7 +94,7 @@ class TestRRF(unittest.TestCase):
 
         with open(f'{self.tmp}/anserini.covid-r3.fusion2.txt', 'rb') as f:
             md5 = hashlib.md5(f.read()).hexdigest()
-        self.assertEqual('d7eabf3dab840104c88de925e918fdab', md5)
+        self.assertEqual('604bfb165d24559d104f475486ac461b', md5)
 
     def test_round4_fusion_runs(self):
         os.system(f'python -m pyserini.fusion --method rrf --runs ' +
@@ -106,7 +106,7 @@ class TestRRF(unittest.TestCase):
 
         with open(f'{self.tmp}/anserini.covid-r4.fusion1.txt', 'rb') as f:
             md5 = hashlib.md5(f.read()).hexdigest()
-        self.assertEqual('8ae9d1fca05bd1d9bfe7b24d1bdbe270', md5)
+        self.assertEqual('0dfced296c0c2c44067796b384a038a2', md5)
 
         os.system(f'python -m pyserini.fusion --method rrf --runs ' +
                   f'{self.tmp}/anserini.covid-r4.abstract.qdel.bm25.txt ' +
@@ -117,7 +117,7 @@ class TestRRF(unittest.TestCase):
 
         with open(f'{self.tmp}/anserini.covid-r4.fusion2.txt', 'rb') as f:
             md5 = hashlib.md5(f.read()).hexdigest()
-        self.assertEqual('e1894209c815c96c6ddd4cacb578261a', md5)
+        self.assertEqual('468830f80ba5e86f3f98699e77a4cfd6', md5)
 
     def tearDown(self):
         shutil.rmtree(self.tmp)


### PR DESCRIPTION
### Summary
- The current test failures are **expected** due to the updated `merge` function, implemented in [fusion-merge](https://github.com/castorini/pyserini/pull/2294/files#:~:text=.SUM%3A-,if%20aggregation%20%3D%3D%20AggregationMethod.SUM%3A,-topics%20%3D%20list).
- I have updated the md5 value accordingly. My new md5 value matches what were posted in slack, and my results are consistent between runs.
- I only tested the unittests under pyserini/tests, this rrf test file is missed.

### Actions & Observations
To verify this, I checked out an older version of Pyserini and substituted the old `merge` function with the new implementation. The MD5 values then changed to the new ones. This confirms that the **differences are introduced by the new merge logic** (dataframe operation), not by other components. 

The numerical differences are very small.
Example:
1 Q0 fqs40ivc 13 0.03108372456964006 reciprocal_rank_fusion_k=60
vs
1 Q0 fqs40ivc 13 0.03108372456964006**4** reciprocal_rank_fusion_k=60

### Difference Summary

| Test | Fusion | Differences | Total Lines |
|------|---------|--------------|--------------|
| test_round3_fusion_runs | fusion1 | *1128 | 80,259 |
| test_round3_fusion_runs | fusion2 | *1384 | 77,291 |
| test_round4_fusion_runs | fusion1 | *1190 | 91,211 |
| test_round4_fusion_runs | fusion2 | *1553 | 87,690 |

*Some differences contains 2~3 lines, but majority is single-line.
I’ll attach a visual diff screenshot below for clarity.

---

###  Concerns
- If the pandas DataFrame is updated in the future, we may need to update the md5 value again. But should be an easy fix.

<img width="1148" height="550" alt="Screenshot 2025-11-07 at 11 48 24 PM" src="https://github.com/user-attachments/assets/ef71b477-7ef1-4fc6-8ee9-89511995796c" />

