### PR TITLE
Fix HF truncation warning

### DIFF
--- a/pyserini/encode/_auto.py
+++ b/pyserini/encode/_auto.py
@@ -92,10 +92,11 @@ class AutoQueryEncoder(QueryEncoder):
             self.pooling = pooling
             self.l2_norm = l2_norm
             self.prefix = prefix
+            self.max_length = self.tokenizer.model_max_length
         if (not self.has_model) and (not self.has_encoded_query):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
-    def encode(self, query: str):
+    def encode(self, query: str, max_length: int = None):
         if self.has_model:
             if self.prefix:
                 query = f'{self.prefix} {query}'
@@ -103,9 +104,10 @@ class AutoQueryEncoder(QueryEncoder):
                 query,
                 add_special_tokens=True,
                 return_tensors='pt',
-                truncation='only_first',
                 padding='longest',
                 return_token_type_ids=False,
+                truncation=True,
+                max_length=max_length or self.max_length,
             )
             inputs.to(self.device)
             outputs = self.model(**inputs)[0].detach().cpu().numpy()

--- a/pyserini/encode/_cosdpr.py
+++ b/pyserini/encode/_cosdpr.py
@@ -101,15 +101,17 @@ class CosDprQueryEncoder(QueryEncoder):
         self.model.to(self.device)
         self.tokenizer = BertTokenizer.from_pretrained(encoder_dir or tokenizer_name,
                                                        clean_up_tokenization_spaces=True)
+        self.max_length = self.tokenizer.model_max_length
 
-    def encode(self, query: str, **kwargs):
+    def encode(self, query: str, max_length: int = None, **kwargs):
         inputs = self.tokenizer(
             query,
             add_special_tokens=True,
             return_tensors='pt',
-            truncation='only_first',
             padding='longest',
             return_token_type_ids=False,
+            truncation=True,
+            max_length=max_length or self.max_length,
         )
         inputs.to(self.device)
         embeddings = self.model(inputs["input_ids"]).detach().cpu().numpy()


### PR DESCRIPTION
Fixes #2360 by removing truncation argument that didn't do anything and was producing a warning. Set default max_length to 512 tokens.