### PR TITLE
vllm support and rag searcher

### DIFF
--- a/pyserini/llm/__init__.py
+++ b/pyserini/llm/__init__.py
@@ -1,0 +1,20 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyserini.llm._client import LLMClient
+from pyserini.llm._rag import RAGSearcher
+
+__all__ = ['LLMClient', 'RAGSearcher']

--- a/pyserini/llm/_client.py
+++ b/pyserini/llm/_client.py
@@ -1,0 +1,168 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+LLM client supporting OpenAI and vLLM backends via OpenAI-compatible API.
+
+vLLM (https://github.com/vllm-project/vllm) exposes an OpenAI-compatible REST API
+so we can reuse the openai Python client with a custom base_url pointing at the
+local vLLM server instead of api.openai.com.
+
+Quick start with vLLM:
+    # 1. Start a vLLM server (on port 8000 by default):
+    #    vllm serve meta-llama/Llama-3.1-8B-Instruct
+    #
+    # 2. Use LLMClient in Python:
+    #    from pyserini.llm import LLMClient
+    #    client = LLMClient("meta-llama/Llama-3.1-8B-Instruct", backend="vllm")
+    #    response = client.generate([{"role": "user", "content": "Hello!"}])
+"""
+
+import os
+import time
+from typing import Any, Dict, List, Optional, Union
+
+from openai import OpenAI
+
+RETRY_DELAY = 1.0
+MAX_RETRIES = 3
+
+
+class LLMClient:
+    """LLM client that supports OpenAI and vLLM backends via the OpenAI-compatible API.
+
+    Parameters
+    ----------
+    model : str
+        Model name to use for generation. For vLLM this is typically the HuggingFace
+        model ID (e.g., ``"meta-llama/Llama-3.1-8B-Instruct"``). For OpenAI this is
+        the model name (e.g., ``"gpt-4o"``).
+    backend : str
+        Backend to use. One of:
+        - ``"openai"`` – Use the OpenAI API (requires OPENAI_API_KEY env var or api_key).
+        - ``"vllm"`` – Use a locally running vLLM server via its OpenAI-compatible API.
+        - ``"openai_compatible"`` – Use any OpenAI-compatible endpoint; set base_url
+          accordingly.
+    api_key : str, optional
+        API key. Defaults to the ``OPENAI_API_KEY`` environment variable for OpenAI,
+        or ``"EMPTY"`` for vLLM (vLLM doesn't require authentication).
+    base_url : str, optional
+        Base URL for the API endpoint. Overrides the default per backend. Useful for
+        self-hosted or proxy OpenAI-compatible endpoints.
+    vllm_port : int
+        Port where the vLLM server is running. Used only when ``backend="vllm"`` and
+        ``base_url`` is not explicitly provided. Defaults to ``8000``.
+    max_tokens : int
+        Maximum number of tokens to generate. Defaults to ``1024``.
+    temperature : float
+        Sampling temperature. Defaults to ``0.0`` (greedy decoding).
+    timeout : float
+        Request timeout in seconds. Defaults to ``60.0``.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        backend: str = 'openai',
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        vllm_port: int = 8000,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        timeout: float = 60.0,
+    ):
+        self.model = model
+        self.backend = backend
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.timeout = timeout
+
+        if backend == 'vllm':
+            api_key = api_key or 'EMPTY'
+            base_url = base_url or f'http://localhost:{vllm_port}/v1'
+        elif backend == 'openai':
+            api_key = api_key or os.getenv('OPENAI_API_KEY', '')
+            # base_url stays None → points to api.openai.com
+        elif backend == 'openai_compatible':
+            api_key = api_key or os.getenv('OPENAI_API_KEY', '')
+            # caller must supply base_url
+        else:
+            raise ValueError(
+                f"Unknown backend '{backend}'. Choose from: 'openai', 'vllm', 'openai_compatible'."
+            )
+
+        if base_url:
+            self.client = OpenAI(api_key=api_key, base_url=base_url)
+        else:
+            self.client = OpenAI(api_key=api_key)
+
+    def generate(
+        self,
+        messages: List[Dict[str, str]],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """Send a chat request and return the generated text.
+
+        Parameters
+        ----------
+        messages : list of dict
+            Conversation in OpenAI format, e.g.::
+
+                [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user",   "content": "What is the capital of France?"},
+                ]
+
+        max_tokens : int, optional
+            Override the instance-level ``max_tokens`` for this call.
+        temperature : float, optional
+            Override the instance-level ``temperature`` for this call.
+
+        Returns
+        -------
+        str
+            The model's response text.
+
+        Raises
+        ------
+        RuntimeError
+            If all retry attempts are exhausted.
+        """
+        _max_tokens = max_tokens if max_tokens is not None else self.max_tokens
+        _temperature = temperature if temperature is not None else self.temperature
+
+        last_error: Optional[Exception] = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                completion = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    max_tokens=_max_tokens,
+                    temperature=_temperature,
+                    timeout=self.timeout,
+                )
+                content = completion.choices[0].message.content
+                return content if content is not None else ''
+            except Exception as exc:
+                last_error = exc
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAY)
+
+        raise RuntimeError(
+            f'LLM generation failed after {MAX_RETRIES} attempts. '
+            f'Last error: {last_error}'
+        )

--- a/pyserini/llm/_rag.py
+++ b/pyserini/llm/_rag.py
@@ -1,0 +1,231 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Retrieval-Augmented Generation (RAG) pipeline for Pyserini.
+
+Combines any Pyserini searcher (LuceneSearcher, FaissSearcher, …) with an
+LLMClient to implement the classic retrieve-then-read RAG pattern:
+
+    from pyserini.llm import LLMClient, RAGSearcher
+    from pyserini.search.lucene import LuceneSearcher
+
+    searcher = LuceneSearcher.from_prebuilt_index("msmarco-v1-passage")
+    client   = LLMClient("meta-llama/Llama-3.1-8B-Instruct", backend="vllm")
+    rag      = RAGSearcher(searcher, client)
+
+    result = rag.search_and_generate("What is the boiling point of water?")
+    print(result["answer"])
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from pyserini.llm._client import LLMClient
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a helpful assistant. Answer the user's question using only the "
+    "information found in the provided context documents. If the context does "
+    "not contain enough information to answer the question, say so clearly."
+)
+
+DEFAULT_RAG_TEMPLATE = """\
+Context documents:
+{context}
+
+Question: {query}
+
+Answer the question based on the context above."""
+
+
+class RAGSearcher:
+    """Retrieve-then-read RAG pipeline combining a Pyserini searcher and an LLM.
+
+    Parameters
+    ----------
+    searcher :
+        Any initialised Pyserini searcher (``LuceneSearcher``, ``FaissSearcher``,
+        ``LuceneHnswDenseSearcher``, etc.). The only requirement is that it
+        exposes a ``search(query, k)`` method returning a list of hit objects.
+    llm_client : LLMClient
+        Initialised :class:`LLMClient` instance.
+    system_prompt : str, optional
+        System-role message sent to the LLM before the RAG prompt.
+    rag_template : str, optional
+        Prompt template used to format retrieved passages and the user query.
+        Must contain the ``{context}`` and ``{query}`` placeholders.
+    """
+
+    def __init__(
+        self,
+        searcher: Any,
+        llm_client: LLMClient,
+        system_prompt: Optional[str] = None,
+        rag_template: Optional[str] = None,
+    ):
+        self.searcher = searcher
+        self.llm_client = llm_client
+        self.system_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
+        self.rag_template = rag_template or DEFAULT_RAG_TEMPLATE
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def retrieve(self, query: str, k: int = 5) -> List[Dict[str, Any]]:
+        """Retrieve the top-*k* documents for *query*.
+
+        Parameters
+        ----------
+        query : str
+            The search query string.
+        k : int
+            Number of documents to retrieve.
+
+        Returns
+        -------
+        list of dict
+            Each dict has the following keys:
+
+            - ``docid`` (str) – document identifier
+            - ``score`` (float) – retrieval score
+            - ``text``  (str) – raw passage / document text
+            - ``rank``  (int) – 1-based rank position
+        """
+        hits = self.searcher.search(query, k)
+        results: List[Dict[str, Any]] = []
+        for rank, hit in enumerate(hits, start=1):
+            text = self._extract_text(hit)
+            results.append(
+                {
+                    'docid': hit.docid,
+                    'score': float(hit.score),
+                    'text': text,
+                    'rank': rank,
+                }
+            )
+        return results
+
+    def generate(
+        self,
+        query: str,
+        retrieved_docs: List[Dict[str, Any]],
+        **kwargs: Any,
+    ) -> str:
+        """Generate an answer given *query* and pre-retrieved documents.
+
+        Parameters
+        ----------
+        query : str
+            The user's question.
+        retrieved_docs : list of dict
+            Documents returned by :meth:`retrieve`.
+        **kwargs
+            Extra keyword arguments forwarded to :meth:`LLMClient.generate`
+            (e.g., ``max_tokens``, ``temperature``).
+
+        Returns
+        -------
+        str
+            Generated answer text.
+        """
+        context = self._format_context(retrieved_docs)
+        prompt = self.rag_template.format(context=context, query=query)
+        messages = [
+            {'role': 'system', 'content': self.system_prompt},
+            {'role': 'user', 'content': prompt},
+        ]
+        return self.llm_client.generate(messages, **kwargs)
+
+    def search_and_generate(
+        self,
+        query: str,
+        k: int = 5,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Retrieve documents and generate an answer in one call.
+
+        Parameters
+        ----------
+        query : str
+            The user's question.
+        k : int
+            Number of documents to retrieve (passed to :meth:`retrieve`).
+        **kwargs
+            Extra keyword arguments forwarded to :meth:`LLMClient.generate`.
+
+        Returns
+        -------
+        dict
+            A dict with three keys:
+
+            - ``query`` (str) – the original query
+            - ``retrieved_docs`` (list of dict) – ranked retrieved documents
+            - ``answer`` (str) – LLM-generated answer
+        """
+        retrieved_docs = self.retrieve(query, k)
+        answer = self.generate(query, retrieved_docs, **kwargs)
+        return {
+            'query': query,
+            'retrieved_docs': retrieved_docs,
+            'answer': answer,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_text(hit: Any) -> str:
+        """Pull plain text from a Pyserini search hit.
+
+        Handles both Lucene hits (which carry a ``lucene_document`` with a
+        ``raw`` JSON field) and dense hits (which carry a ``contents`` attribute
+        directly).
+        """
+        # Lucene / sparse hits store the document as a JSON blob in 'raw'
+        if hasattr(hit, 'lucene_document') and hit.lucene_document is not None:
+            raw = hit.lucene_document.get('raw')
+            if raw:
+                try:
+                    doc = json.loads(raw)
+                    return (
+                        doc.get('contents')
+                        or doc.get('text')
+                        or doc.get('passage')
+                        or doc.get('segment')
+                        or ''
+                    )
+                except (json.JSONDecodeError, AttributeError):
+                    return str(raw)
+
+        # Dense hits (FaissSearcher) sometimes carry text directly
+        for attr in ('contents', 'text', 'passage'):
+            if hasattr(hit, attr):
+                val = getattr(hit, attr)
+                if val:
+                    return str(val)
+
+        return ''
+
+    @staticmethod
+    def _format_context(docs: List[Dict[str, Any]]) -> str:
+        """Render retrieved documents as a numbered list for the LLM prompt."""
+        parts = []
+        for doc in docs:
+            header = f"[{doc['rank']}] docid={doc['docid']}  score={doc['score']:.4f}"
+            parts.append(f"{header}\n{doc['text']}")
+        return '\n\n'.join(parts)

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -1,0 +1,478 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Tests for pyserini.llm (LLMClient and RAGSearcher).
+
+All external API calls are mocked so the tests run without a live OpenAI key
+or a running vLLM server.  A small integration smoke-test is also included
+and skipped automatically unless a vLLM server is reachable on localhost.
+"""
+
+import json
+import socket
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pyserini.llm import LLMClient, RAGSearcher
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_completion(content: str) -> MagicMock:
+    """Build a minimal mock that looks like an openai ChatCompletion object."""
+    msg = MagicMock()
+    msg.content = content
+    choice = MagicMock()
+    choice.message = msg
+    completion = MagicMock()
+    completion.choices = [choice]
+    return completion
+
+
+def _vllm_reachable(port: int = 8000) -> bool:
+    """Return True if something is listening on localhost:{port}."""
+    try:
+        with socket.create_connection(('localhost', port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# LLMClient tests
+# ---------------------------------------------------------------------------
+
+class TestLLMClientInit(unittest.TestCase):
+    """Test that LLMClient initialises with the correct OpenAI client settings."""
+
+    def test_openai_backend_default_base_url(self):
+        """OpenAI backend should use the standard api.openai.com endpoint."""
+        with patch('pyserini.llm._client.OpenAI') as mock_openai:
+            LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+            # base_url should NOT be passed (stays as None → api.openai.com)
+            call_kwargs = mock_openai.call_args[1]
+            self.assertNotIn('base_url', call_kwargs)
+            self.assertEqual(call_kwargs['api_key'], 'sk-test')
+
+    def test_vllm_backend_default_url(self):
+        """vLLM backend should point to http://localhost:8000/v1 by default."""
+        with patch('pyserini.llm._client.OpenAI') as mock_openai:
+            LLMClient('meta-llama/Llama-3.1-8B-Instruct', backend='vllm')
+            call_kwargs = mock_openai.call_args[1]
+            self.assertEqual(call_kwargs['base_url'], 'http://localhost:8000/v1')
+            self.assertEqual(call_kwargs['api_key'], 'EMPTY')
+
+    def test_vllm_backend_custom_port(self):
+        """Custom vllm_port should be reflected in the base_url."""
+        with patch('pyserini.llm._client.OpenAI') as mock_openai:
+            LLMClient('some-model', backend='vllm', vllm_port=9000)
+            call_kwargs = mock_openai.call_args[1]
+            self.assertEqual(call_kwargs['base_url'], 'http://localhost:9000/v1')
+
+    def test_vllm_backend_custom_base_url(self):
+        """An explicit base_url overrides the vllm_port default."""
+        with patch('pyserini.llm._client.OpenAI') as mock_openai:
+            LLMClient('some-model', backend='vllm', base_url='http://gpu-server:8080/v1')
+            call_kwargs = mock_openai.call_args[1]
+            self.assertEqual(call_kwargs['base_url'], 'http://gpu-server:8080/v1')
+
+    def test_openai_compatible_backend(self):
+        """openai_compatible backend passes through base_url unchanged."""
+        with patch('pyserini.llm._client.OpenAI') as mock_openai:
+            LLMClient(
+                'some-model',
+                backend='openai_compatible',
+                api_key='my-key',
+                base_url='https://my-proxy.example.com/v1',
+            )
+            call_kwargs = mock_openai.call_args[1]
+            self.assertEqual(call_kwargs['base_url'], 'https://my-proxy.example.com/v1')
+            self.assertEqual(call_kwargs['api_key'], 'my-key')
+
+    def test_unknown_backend_raises(self):
+        """An unrecognised backend name should raise ValueError immediately."""
+        with self.assertRaises(ValueError):
+            LLMClient('gpt-4o', backend='unknown_backend')
+
+    def test_attributes_stored(self):
+        """Constructor params should be stored as instance attributes."""
+        with patch('pyserini.llm._client.OpenAI'):
+            client = LLMClient(
+                'gpt-4o',
+                backend='openai',
+                api_key='sk-test',
+                max_tokens=512,
+                temperature=0.7,
+                timeout=30.0,
+            )
+        self.assertEqual(client.model, 'gpt-4o')
+        self.assertEqual(client.backend, 'openai')
+        self.assertEqual(client.max_tokens, 512)
+        self.assertAlmostEqual(client.temperature, 0.7)
+        self.assertAlmostEqual(client.timeout, 30.0)
+
+
+class TestLLMClientGenerate(unittest.TestCase):
+    """Test the generate() method with mocked API responses."""
+
+    def _make_client(self, **kwargs) -> LLMClient:
+        with patch('pyserini.llm._client.OpenAI'):
+            client = LLMClient('gpt-4o', backend='openai', api_key='sk-test', **kwargs)
+        return client
+
+    def test_generate_returns_content(self):
+        """generate() should return the message content from the completion."""
+        client = self._make_client()
+        client.client = MagicMock()
+        client.client.chat.completions.create.return_value = _make_completion(
+            'Paris is the capital of France.'
+        )
+
+        messages = [{'role': 'user', 'content': 'What is the capital of France?'}]
+        result = client.generate(messages)
+        self.assertEqual(result, 'Paris is the capital of France.')
+
+    def test_generate_none_content_returns_empty_string(self):
+        """If the API returns None as content, generate() should return ''."""
+        client = self._make_client()
+        client.client = MagicMock()
+        client.client.chat.completions.create.return_value = _make_completion(None)
+
+        result = client.generate([{'role': 'user', 'content': 'Hi'}])
+        self.assertEqual(result, '')
+
+    def test_generate_passes_correct_params(self):
+        """generate() must forward model, messages, max_tokens, temperature to the API."""
+        client = self._make_client(max_tokens=256, temperature=0.5)
+        client.client = MagicMock()
+        client.client.chat.completions.create.return_value = _make_completion('ok')
+
+        messages = [{'role': 'user', 'content': 'Test'}]
+        client.generate(messages)
+
+        call_kwargs = client.client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs['model'], 'gpt-4o')
+        self.assertEqual(call_kwargs['messages'], messages)
+        self.assertEqual(call_kwargs['max_tokens'], 256)
+        self.assertAlmostEqual(call_kwargs['temperature'], 0.5)
+
+    def test_generate_per_call_overrides(self):
+        """max_tokens and temperature kwargs in generate() should override instance defaults."""
+        client = self._make_client(max_tokens=1024, temperature=0.0)
+        client.client = MagicMock()
+        client.client.chat.completions.create.return_value = _make_completion('ok')
+
+        client.generate([{'role': 'user', 'content': 'Test'}], max_tokens=64, temperature=1.0)
+
+        call_kwargs = client.client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs['max_tokens'], 64)
+        self.assertAlmostEqual(call_kwargs['temperature'], 1.0)
+
+    def test_generate_retries_on_error(self):
+        """generate() should retry up to MAX_RETRIES times before raising."""
+        from pyserini.llm._client import MAX_RETRIES
+
+        client = self._make_client()
+        client.client = MagicMock()
+        client.client.chat.completions.create.side_effect = RuntimeError('server error')
+
+        with patch('pyserini.llm._client.time.sleep'):  # don't actually sleep in tests
+            with self.assertRaises(RuntimeError):
+                client.generate([{'role': 'user', 'content': 'Test'}])
+
+        self.assertEqual(
+            client.client.chat.completions.create.call_count,
+            MAX_RETRIES,
+        )
+
+    def test_generate_succeeds_after_transient_error(self):
+        """generate() should succeed if a later attempt works after a transient failure."""
+        client = self._make_client()
+        client.client = MagicMock()
+        client.client.chat.completions.create.side_effect = [
+            RuntimeError('transient'),
+            _make_completion('recovered'),
+        ]
+
+        with patch('pyserini.llm._client.time.sleep'):
+            result = client.generate([{'role': 'user', 'content': 'Test'}])
+
+        self.assertEqual(result, 'recovered')
+
+
+# ---------------------------------------------------------------------------
+# RAGSearcher tests
+# ---------------------------------------------------------------------------
+
+class TestRAGSearcherRetrieve(unittest.TestCase):
+    """Test the retrieve() helper that wraps the pyserini searcher."""
+
+    def _make_lucene_hit(self, docid: str, score: float, text: str) -> MagicMock:
+        """Simulate a LuceneSearcher hit (has a lucene_document with raw JSON)."""
+        raw = json.dumps({'contents': text})
+        doc = MagicMock()
+        doc.get.return_value = raw
+        hit = MagicMock()
+        hit.docid = docid
+        hit.score = score
+        hit.lucene_document = doc
+        return hit
+
+    def _make_dense_hit(self, docid: str, score: float, contents: str) -> SimpleNamespace:
+        """Simulate a FaissSearcher dense hit (has a contents attribute)."""
+        hit = SimpleNamespace(docid=docid, score=score, contents=contents)
+        # Dense hits don't have lucene_document
+        return hit
+
+    def test_retrieve_lucene_hits(self):
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = [
+            self._make_lucene_hit('doc1', 0.9, 'Water boils at 100 °C.'),
+            self._make_lucene_hit('doc2', 0.7, 'Ice melts at 0 °C.'),
+        ]
+        with patch('pyserini.llm._client.OpenAI'):
+            llm = LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+        rag = RAGSearcher(mock_searcher, llm)
+
+        docs = rag.retrieve('boiling point of water', k=2)
+
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0]['docid'], 'doc1')
+        self.assertAlmostEqual(docs[0]['score'], 0.9)
+        self.assertEqual(docs[0]['text'], 'Water boils at 100 °C.')
+        self.assertEqual(docs[0]['rank'], 1)
+        self.assertEqual(docs[1]['rank'], 2)
+
+    def test_retrieve_passes_k_to_searcher(self):
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = []
+        with patch('pyserini.llm._client.OpenAI'):
+            llm = LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+        rag = RAGSearcher(mock_searcher, llm)
+
+        rag.retrieve('some query', k=7)
+        mock_searcher.search.assert_called_once_with('some query', 7)
+
+    def test_retrieve_dense_hits(self):
+        """retrieve() should also work with dense hits that have a contents attribute."""
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = [
+            self._make_dense_hit('d1', 0.95, 'Dense passage text.'),
+        ]
+        with patch('pyserini.llm._client.OpenAI'):
+            llm = LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+        rag = RAGSearcher(mock_searcher, llm)
+
+        docs = rag.retrieve('query', k=1)
+        self.assertEqual(docs[0]['text'], 'Dense passage text.')
+
+    def test_retrieve_empty_results(self):
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = []
+        with patch('pyserini.llm._client.OpenAI'):
+            llm = LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+        rag = RAGSearcher(mock_searcher, llm)
+
+        docs = rag.retrieve('query', k=5)
+        self.assertEqual(docs, [])
+
+
+class TestRAGSearcherGenerate(unittest.TestCase):
+    """Test RAGSearcher.generate() prompt construction and LLM invocation."""
+
+    def _make_rag(self, mock_response: str = 'Mock answer.') -> tuple:
+        mock_searcher = MagicMock()
+        with patch('pyserini.llm._client.OpenAI'):
+            llm = LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+        llm.client = MagicMock()
+        llm.client.chat.completions.create.return_value = _make_completion(mock_response)
+        rag = RAGSearcher(mock_searcher, llm)
+        return rag, llm
+
+    def test_generate_includes_query_in_prompt(self):
+        rag, llm = self._make_rag()
+        docs = [{'rank': 1, 'docid': 'doc1', 'score': 0.9, 'text': 'Passage text.'}]
+        rag.generate('What is X?', docs)
+
+        call_args = llm.client.chat.completions.create.call_args[1]
+        messages = call_args['messages']
+        user_content = next(m['content'] for m in messages if m['role'] == 'user')
+        self.assertIn('What is X?', user_content)
+        self.assertIn('Passage text.', user_content)
+
+    def test_generate_system_prompt_present(self):
+        rag, llm = self._make_rag()
+        docs = [{'rank': 1, 'docid': 'doc1', 'score': 0.9, 'text': 'Some text.'}]
+        rag.generate('Q?', docs)
+
+        call_args = llm.client.chat.completions.create.call_args[1]
+        messages = call_args['messages']
+        system_msgs = [m for m in messages if m['role'] == 'system']
+        self.assertTrue(len(system_msgs) > 0)
+
+    def test_generate_custom_system_prompt(self):
+        mock_searcher = MagicMock()
+        with patch('pyserini.llm._client.OpenAI'):
+            llm = LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+        llm.client = MagicMock()
+        llm.client.chat.completions.create.return_value = _make_completion('ans')
+        rag = RAGSearcher(mock_searcher, llm, system_prompt='Custom system prompt.')
+
+        docs = [{'rank': 1, 'docid': 'doc1', 'score': 0.5, 'text': 'text'}]
+        rag.generate('Q?', docs)
+
+        call_args = llm.client.chat.completions.create.call_args[1]
+        messages = call_args['messages']
+        system_content = next(m['content'] for m in messages if m['role'] == 'system')
+        self.assertEqual(system_content, 'Custom system prompt.')
+
+    def test_generate_returns_llm_answer(self):
+        rag, _ = self._make_rag('The answer is 42.')
+        docs = [{'rank': 1, 'docid': 'doc1', 'score': 0.9, 'text': 'Context.'}]
+        result = rag.generate('What is the answer?', docs)
+        self.assertEqual(result, 'The answer is 42.')
+
+
+class TestRAGSearcherSearchAndGenerate(unittest.TestCase):
+    """Integration-style test for the full search_and_generate() pipeline."""
+
+    def test_search_and_generate_result_structure(self):
+        raw = json.dumps({'contents': 'Water boils at 100 °C at standard pressure.'})
+        doc_mock = MagicMock()
+        doc_mock.get.return_value = raw
+        hit = MagicMock()
+        hit.docid = 'doc42'
+        hit.score = 0.88
+        hit.lucene_document = doc_mock
+
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = [hit]
+
+        with patch('pyserini.llm._client.OpenAI'):
+            llm = LLMClient('gpt-4o', backend='openai', api_key='sk-test')
+        llm.client = MagicMock()
+        llm.client.chat.completions.create.return_value = _make_completion(
+            'Water boils at 100 °C.'
+        )
+
+        rag = RAGSearcher(mock_searcher, llm)
+        result = rag.search_and_generate('What is the boiling point of water?', k=1)
+
+        self.assertEqual(result['query'], 'What is the boiling point of water?')
+        self.assertEqual(len(result['retrieved_docs']), 1)
+        self.assertEqual(result['retrieved_docs'][0]['docid'], 'doc42')
+        self.assertEqual(result['answer'], 'Water boils at 100 °C.')
+
+    def test_vllm_backend_used_in_rag(self):
+        """Ensure RAGSearcher works end-to-end with a vLLM-configured LLMClient."""
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = []
+
+        with patch('pyserini.llm._client.OpenAI') as mock_openai_cls:
+            llm = LLMClient(
+                'meta-llama/Llama-3.1-8B-Instruct',
+                backend='vllm',
+                vllm_port=8000,
+            )
+            # Verify vLLM endpoint was configured
+            call_kwargs = mock_openai_cls.call_args[1]
+            self.assertEqual(call_kwargs['base_url'], 'http://localhost:8000/v1')
+            self.assertEqual(call_kwargs['api_key'], 'EMPTY')
+
+        llm.client = MagicMock()
+        llm.client.chat.completions.create.return_value = _make_completion(
+            'I could not find relevant documents to answer your question.'
+        )
+
+        rag = RAGSearcher(mock_searcher, llm)
+        result = rag.search_and_generate('obscure query with no hits', k=3)
+
+        self.assertIn('query', result)
+        self.assertIn('retrieved_docs', result)
+        self.assertIn('answer', result)
+        self.assertEqual(result['retrieved_docs'], [])
+
+
+# ---------------------------------------------------------------------------
+# vLLM integration smoke-test (skipped if no server is running)
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(_vllm_reachable(), 'No vLLM server detected on localhost:8000')
+class TestVLLMIntegration(unittest.TestCase):
+    """Live smoke-test against a running vLLM server.
+
+    Start a vLLM server before running:
+        vllm serve <model-name> --port 8000
+
+    These tests are automatically skipped when no server is detected.
+    """
+
+    MODEL = 'meta-llama/Llama-3.1-8B-Instruct'
+
+    def _get_running_model(self) -> str:
+        """Query the vLLM /v1/models endpoint to get the deployed model name."""
+        import requests
+        try:
+            resp = requests.get('http://localhost:8000/v1/models', timeout=5)
+            data = resp.json()
+            return data['data'][0]['id']
+        except Exception:
+            return self.MODEL
+
+    def test_llm_client_generate(self):
+        model = self._get_running_model()
+        client = LLMClient(model, backend='vllm')
+        response = client.generate(
+            [{'role': 'user', 'content': 'Reply with exactly one word: hello'}],
+            max_tokens=10,
+        )
+        self.assertIsInstance(response, str)
+        self.assertTrue(len(response) > 0)
+
+    def test_rag_searcher_with_mock_search(self):
+        """RAGSearcher with vLLM client and a fake single-document searcher."""
+        model = self._get_running_model()
+        client = LLMClient(model, backend='vllm')
+
+        raw = json.dumps({'contents': 'Water boils at 100 °C at standard pressure.'})
+        doc_mock = MagicMock()
+        doc_mock.get.return_value = raw
+        hit = MagicMock()
+        hit.docid = 'doc1'
+        hit.score = 1.0
+        hit.lucene_document = doc_mock
+
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = [hit]
+
+        rag = RAGSearcher(mock_searcher, client)
+        result = rag.search_and_generate(
+            'What temperature does water boil at?', k=1, max_tokens=64
+        )
+
+        self.assertEqual(result['query'], 'What temperature does water boil at?')
+        self.assertEqual(len(result['retrieved_docs']), 1)
+        self.assertIsInstance(result['answer'], str)
+        self.assertTrue(len(result['answer']) > 0)
+        print(f"\n[vLLM integration] Answer: {result['answer']}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds vLLM support as well as a simple RAG Searcher of 2 steps: apply LuceneSearcher/FaissSearcher etc, then ask vLLM to analyze the Searcher output.

A simple demo:
<img width="1533" height="1362" alt="Screenshot 2026-02-18 at 1 09 51 PM" src="https://github.com/user-attachments/assets/d831189e-fe7a-4f06-986a-f670d9692072" />
