### PR TITLE
fix qwen3 encoder

### DIFF
--- a/pyserini/encode/__init__.py
+++ b/pyserini/encode/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
 try:
     from pyserini.encode.optional._mmeb import MMEBCorpusEncoder, MMEBQueryEncoder
     MMEB_IMPORT_ERROR = None
-except ImportError:
+except Exception as e:
     MMEBCorpusEncoder = None
     MMEBQueryEncoder = None
     MMEB_IMPORT_ERROR = traceback.format_exc()

--- a/pyserini/encode/__main__.py
+++ b/pyserini/encode/__main__.py
@@ -24,7 +24,7 @@ from pyserini.encode import JsonlRepresentationWriter, JsonlCollectionIterator
 from pyserini.encode.optional import FaissRepresentationWriter
 
 
-def init_encoder(encoder, encoder_class, device, pooling, l2_norm, prefix, multimodal):
+def init_encoder(encoder, encoder_class, device, pooling, l2_norm, prefix, multimodal, explicit_truncate):
     _encoder_class = encoder_class
 
     # determine encoder_class
@@ -59,7 +59,7 @@ def init_encoder(encoder, encoder_class, device, pooling, l2_norm, prefix, multi
         if encoder_class is None: # check if the uniir-for-pyserini package is installed
             raise ValueError("UniIR's corpus encoder class is not available (as the uniir-for-pyserini package is not installed or CLIP is not installed). Please run 'pip install pyserini[optional]' to install the uniir-for-pyserini package and run 'pip install git+https://github.com/openai/CLIP.git' to install CLIP.")
     if _encoder_class == 'qwen3':
-        kwargs.update(dict(l2_norm=l2_norm, prefix=prefix))
+        kwargs.update(dict(l2_norm=l2_norm, prefix=prefix, explicit_truncate=explicit_truncate))
     if _encoder_class == 'dse' or 'dse' in encoder.lower():
         kwargs.update(dict(l2_norm=True, multimodal=multimodal, pooling=pooling))
     if _encoder_class == 'mmeb':
@@ -129,10 +129,11 @@ if __name__ == '__main__':
     encoder_parser.add_argument('--prefix', type=str, help='prefix of document input', default=None, required=False)
     encoder_parser.add_argument('--use-openai', help='use OpenAI text-embedding-ada-002 to retreive embeddings', action='store_true', default=False)
     encoder_parser.add_argument('--rate-limit', type=int, help='rate limit of the requests per minute for OpenAI embeddings', default=3500, required=False)
+    encoder_parser.add_argument('--explicit-truncate', action='store_true', default=False, required=False)
 
     args = parse_args(parser, commands)
     delimiter = args.input.delimiter.replace("\\n", "\n")  # argparse would add \ prior to the passed '\n\n'
-    encoder = init_encoder(args.encoder.encoder, args.encoder.encoder_class, device=args.encoder.device, pooling=args.encoder.pooling, l2_norm=args.encoder.l2_norm, prefix=args.encoder.prefix, multimodal=args.encoder.multimodal)
+    encoder = init_encoder(args.encoder.encoder, args.encoder.encoder_class, device=args.encoder.device, pooling=args.encoder.pooling, l2_norm=args.encoder.l2_norm, prefix=args.encoder.prefix, multimodal=args.encoder.multimodal, explicit_truncate=args.encoder.explicit_truncate)
 
     if args.output.to_faiss:
         embedding_writer = FaissRepresentationWriter(args.output.embeddings, dimension=args.encoder.dimension)

--- a/pyserini/search/faiss/__main__.py
+++ b/pyserini/search/faiss/__main__.py
@@ -254,6 +254,7 @@ def init_query_encoder(
     multimodal=False,
     instruction_config=None,
     fp16=False,
+    explicit_truncate=False,
 ):
     encoded_queries_map = {
         "msmarco-passage-dev-subset": "tct_colbert-msmarco-passage-dev-subset",
@@ -309,7 +310,7 @@ def init_query_encoder(
             if encoder_class is None:
                 raise ValueError("UniIR's query encoder class is not available (as the uniir-for-pyserini package is not installed or CLIP is not installed). Please run 'pip install pyserini[optional]' to install the uniir-for-pyserini package and run 'pip install git+https://github.com/openai/CLIP.git' to install CLIP.")
         if _encoder_class == "qwen3":
-            kwargs.update(dict(l2_norm=l2_norm, prefix=prefix))
+            kwargs.update(dict(l2_norm=l2_norm, prefix=prefix, max_length=max_length, explicit_truncate=explicit_truncate))
         if _encoder_class == "dse" or (encoder and "dse" in encoder.lower()):
             kwargs.update(dict(l2_norm=True, pooling=pooling, multimodal=multimodal))
         if _encoder_class == "mmeb":
@@ -436,6 +437,12 @@ if __name__ == "__main__":
         default=False,
         help="Remove query from results list.",
     )
+    parser.add_argument(
+        "--explicit-truncate",
+        action="store_true",
+        default=False,
+        help="Explicitly truncate the query.",
+    )
     define_dsearch_args(parser)
     args = parser.parse_args()
 
@@ -455,7 +462,8 @@ if __name__ == "__main__":
         args.query_prefix,
         args.multimodal,
         args.instruction_config,
-        args.fp16
+        args.fp16,
+        args.explicit_truncate
     )
     if args.pca_model:
         query_encoder = PcaEncoder(query_encoder, args.pca_model)


### PR DESCRIPTION
Diver explicitly truncates the documents and queries before passing them to the tokenizer, this causes subtle differences in the final truncated due to special tokens. This pr exposes this option as a flag.
QueryEncoders read the max_query length at init time (unlike document encoders), this cl properly reads the query max length for _qwen3 query encoder.
Plus other minor changes to how documents and queries are read/parsed ensuring that our implementation is consistent with the baseline.