### PR TITLE
Add reproduction log entries for Foundations guides

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -458,3 +458,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-27 (commit [`9e92b42`](https://github.com/castorini/pyserini/commit/9e92b4291fd30faad4b64bdd0ddba2d106694ed5))
 + Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`e9b559c`](https://github.com/castorini/pyserini/commit/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41))
 + Results reproduced by [@Karrrthik](https://github.com/Karrrthik) on 2026-02-20 (commit [`2cecfb0`](https://github.com/castorini/pyserini/commit/2cecfb02eeb68cac2603cd2959ac3519bb4296cd))
++ Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -716,3 +716,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-27 (commit [`9e92b42`](https://github.com/castorini/pyserini/commit/9e92b4291fd30faad4b64bdd0ddba2d106694ed5))
 + Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`e9b559c`](https://github.com/castorini/pyserini/commit/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41))
 + Results reproduced by [@Karrrthik](https://github.com/Karrrthik) on 2026-02-20 (commit [`2cecfb0`](https://github.com/castorini/pyserini/commit/2cecfb02eeb68cac2603cd2959ac3519bb4296cd))
++ Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -494,3 +494,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-27 (commit [`9e92b42`](https://github.com/castorini/pyserini/commit/9e92b4291fd30faad4b64bdd0ddba2d106694ed5))
 + Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`e9b559c`](https://github.com/castorini/pyserini/commit/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41))
 + Results reproduced by [@Karrrthik](https://github.com/Karrrthik) on 2026-02-20 (commit [`2cecfb0`](https://github.com/castorini/pyserini/commit/2cecfb02eeb68cac2603cd2959ac3519bb4296cd))
++ Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -502,3 +502,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-27 (commit [`9e92b42`](https://github.com/castorini/pyserini/commit/9e92b4291fd30faad4b64bdd0ddba2d106694ed5))
 + Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`e9b559c`](https://github.com/castorini/pyserini/commit/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41))
 + Results reproduced by [@Karrrthik](https://github.com/Karrrthik) on 2026-02-20 (commit [`2cecfb0`](https://github.com/castorini/pyserini/commit/2cecfb02eeb68cac2603cd2959ac3519bb4296cd))
++ Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))


### PR DESCRIPTION
## Summary
- add 2026-03-01 reproduction log entry for @aaliyan1230 in completed Foundations guides
- update:
  - docs/experiments-msmarco-passage.md
  - docs/conceptual-framework.md
  - docs/experiments-nfcorpus.md
  - docs/conceptual-framework2.md

## Notes
- this PR only updates documentation reproduction logs
- all entries reference commit bcae91d on Pyserini main
- docs/conceptual-framework3.md is intentionally not updated because reproduction of that step is currently blocked by gated model access (naver/splade-v3) requiring authenticated Hugging Face permissions