### PR TITLE
Refactor test cases and cached queries

### DIFF
--- a/integrations/optional/dense/test_ance.py
+++ b/integrations/optional/dense/test_ance.py
@@ -62,7 +62,7 @@ class TestAnce(unittest.TestCase):
         self.assertAlmostEqual(score, 0.3796, delta=0.0002)
 
     def test_msmarco_doc_ance_bf_encoded_queries(self):
-        encoder = QueryEncoder.load_cached_queries('ance_maxp-msmarco-doc-dev', quiet=True)
+        encoder = QueryEncoder.load_cached_queries('ance_maxp-msmarco-doc-dev', verbose=False)
         topics = get_topics('msmarco-doc-dev')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -90,7 +90,7 @@ class TestAnce(unittest.TestCase):
         self.assertAlmostEqual(score, 0.8224, places=4)
 
     def test_nq_test_ance_encoded_queries(self):
-        encoder = QueryEncoder.load_cached_queries('dpr_multi-nq-test', quiet=True)
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-nq-test', verbose=False)
         topics = get_topics('dpr-nq-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -118,7 +118,7 @@ class TestAnce(unittest.TestCase):
         self.assertAlmostEqual(score, 0.8010, places=4)
 
     def test_trivia_test_ance_encoded_queries(self):
-        encoder = QueryEncoder.load_cached_queries('dpr_multi-trivia-test', quiet=True)
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-trivia-test', verbose=False)
         topics = get_topics('dpr-trivia-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)

--- a/integrations/optional/dense/test_ance.py
+++ b/integrations/optional/dense/test_ance.py
@@ -62,7 +62,7 @@ class TestAnce(unittest.TestCase):
         self.assertAlmostEqual(score, 0.3796, delta=0.0002)
 
     def test_msmarco_doc_ance_bf_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('ance_maxp-msmarco-doc-dev')
+        encoder = QueryEncoder.load_cached_queries('ance_maxp-msmarco-doc-dev', quiet=True)
         topics = get_topics('msmarco-doc-dev')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -90,7 +90,7 @@ class TestAnce(unittest.TestCase):
         self.assertAlmostEqual(score, 0.8224, places=4)
 
     def test_nq_test_ance_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('dpr_multi-nq-test')
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-nq-test', quiet=True)
         topics = get_topics('dpr-nq-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -118,7 +118,7 @@ class TestAnce(unittest.TestCase):
         self.assertAlmostEqual(score, 0.8010, places=4)
 
     def test_trivia_test_ance_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('dpr_multi-trivia-test')
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-trivia-test', quiet=True)
         topics = get_topics('dpr-trivia-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)

--- a/integrations/optional/dense/test_dpr.py
+++ b/integrations/optional/dense/test_dpr.py
@@ -86,7 +86,7 @@ class TestDpr(unittest.TestCase):
         self.assertAlmostEqual(score, 0.8260, places=4)
 
     def test_dpr_nq_test_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('dpr_multi-nq-test')
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-nq-test')
         topics = get_topics('dpr-nq-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -138,7 +138,7 @@ class TestDpr(unittest.TestCase):
         self.assertAlmostEqual(score, 0.8264, places=4)
 
     def test_dpr_trivia_test_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('dpr_multi-trivia-test')
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-trivia-test')
         topics = get_topics('dpr-trivia-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -190,7 +190,7 @@ class TestDpr(unittest.TestCase):
         self.assertAlmostEqual(score, 0.7712, places=4)
 
     def test_dpr_wq_test_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('dpr_multi-wq-test')
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-wq-test')
         topics = get_topics('dpr-wq-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -244,7 +244,7 @@ class TestDpr(unittest.TestCase):
         self.assertAlmostEqual(score, 0.9006, places=4)
 
     def test_dpr_curated_test_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('dpr_multi-curated-test')
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-curated-test')
         topics = get_topics('dpr-curated-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)
@@ -299,7 +299,7 @@ class TestDpr(unittest.TestCase):
         self.assertAlmostEqual(score, 0.7514, places=3)
 
     def test_dpr_squad_test_encoded_queries(self):
-        encoder = QueryEncoder.load_encoded_queries('dpr_multi-squad-test')
+        encoder = QueryEncoder.load_cached_queries('dpr_multi-squad-test')
         topics = get_topics('dpr-squad-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoder.embedding)

--- a/integrations/optional/dense/test_tct_colbert.py
+++ b/integrations/optional/dense/test_tct_colbert.py
@@ -108,7 +108,7 @@ class TestTctColBert(unittest.TestCase):
         self.assertAlmostEqual(score, 0.3647, delta=0.0002)
 
     def test_msmarco_passage_tct_colbert_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('tct_colbert-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('tct_colbert-msmarco-passage-dev-subset')
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)

--- a/pyserini/encode/_aggretriever.py
+++ b/pyserini/encode/_aggretriever.py
@@ -174,7 +174,7 @@ class AggretrieverQueryEncoder(QueryEncoder):
             self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or encoder_dir,
                                                            clean_up_tokenization_spaces=True)
             self.has_model = True
-        if (not self.has_model) and (not self.has_encoded_query):
+        if (not self.has_model) and (not self.has_encoded_queries):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     def encode(self, query: str,  max_length: int=32):

--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -105,7 +105,7 @@ class AnceQueryEncoder(QueryEncoder):
                                                               clean_up_tokenization_spaces=True)
             self.has_model = True
             self.tokenizer.do_lower_case = True
-        if (not self.has_model) and (not self.has_encoded_query):
+        if (not self.has_model) and (not self.has_encoded_queries):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     def encode(self, query: str):

--- a/pyserini/encode/_arctic.py
+++ b/pyserini/encode/_arctic.py
@@ -63,7 +63,7 @@ class ArcticQueryEncoder(QueryEncoder):
             self.has_model = True
             self.normalize = normalize
 
-        if (not self.has_model) and (not self.has_encoded_query):
+        if (not self.has_model) and (not self.has_encoded_queries):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one.')
 
     def encode(self, query: str):

--- a/pyserini/encode/_auto.py
+++ b/pyserini/encode/_auto.py
@@ -92,7 +92,7 @@ class AutoQueryEncoder(QueryEncoder):
             self.pooling = pooling
             self.l2_norm = l2_norm
             self.prefix = prefix
-        if (not self.has_model) and (not self.has_encoded_query):
+        if (not self.has_model) and (not self.has_encoded_queries):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     def encode(self, query: str, max_length: int = None):

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -22,7 +22,7 @@ import pandas as pd
 import torch
 from tqdm import tqdm
 
-from pyserini.util import download_encoded_queries
+from pyserini.util import download_cached_queries
 
 
 class DocumentEncoder:
@@ -39,48 +39,53 @@ class DocumentEncoder:
 
 
 class QueryEncoder:
-    def __init__(self, encoded_query_dir: str = None):
+    def __init__(self, cache_dir: str = None):
         self.has_model = False
-        self.has_encoded_query = False
-        if encoded_query_dir:
-            self.embedding = self._load_embeddings(encoded_query_dir)
-            self.has_encoded_query = True
+        self.has_encoded_queries = False
+        if cache_dir:
+            self.embedding = self._load_embeddings(cache_dir)
+            self.has_encoded_queries = True
 
     def encode(self, query: str):
         return self.embedding[query]
 
     @classmethod
-    def load_encoded_queries(cls, encoded_query_name: str):
-        """Build a query encoder from a pre-encoded query; download the encoded queries if necessary.
+    def load_cached_queries(cls, name: str, verbose=True):
+        """Build a QueryEncoder from cached queries; download the cached queries if necessary.
 
         Parameters
         ----------
-        encoded_query_name : str
-            pre encoded query name.
+        name : str
+            Name of the cached queries.
 
         Returns
         -------
         QueryEncoder
-            Encoder built from the pre encoded queries.
+            QueryEncoder built from the cached queries.
         """
-        print(f'Attempting to initialize pre-encoded queries {encoded_query_name}.')
+        if verbose:
+            print(f'Attempting to initialize cached queries: {name}')
+
         try:
-            query_dir = download_encoded_queries(encoded_query_name)
+            dir = download_cached_queries(name, verbose=verbose)
         except ValueError as e:
             print(str(e))
             return None
 
-        print(f'Initializing {encoded_query_name}...')
-        return cls(encoded_query_dir=query_dir)
+        if verbose:
+            print(f'Initializing {name}...')
+        return cls(cache_dir=dir)
 
     @staticmethod
-    def _load_embeddings(encoded_query_dir):
-        df = pd.read_pickle(os.path.join(encoded_query_dir, 'embedding.pkl'))
+    def _load_embeddings(dir):
+        df = pd.read_pickle(os.path.join(dir, 'embedding.pkl'))
         return dict(zip(df['text'].tolist(), df['embedding'].tolist()))
 
 
 class JsonlCollectionIterator:
-    def __init__(self, collection_path: str, fields=None, docid_field=None, delimiter="\n"):
+    def __init__(self, collection_path: str, fields=None, docid_field=None, delimiter="\n", quiet=False):
+        self.quiet = quiet
+
         # Assume multimodal input files are located in the same directory as the collection file
         if os.path.isdir(collection_path):
             self.collection_dir = collection_path
@@ -112,15 +117,15 @@ class JsonlCollectionIterator:
         if self.shard_id == self.shard_num - 1:
             end_idx = total_len
         to_yield = {}
-        for idx in tqdm(range(start_idx, end_idx, self.batch_size)):
+        for idx in tqdm(range(start_idx, end_idx, self.batch_size), disable=self.quiet):
             for key in self.all_info:
                 to_yield[key] = self.all_info[key][idx: min(idx + self.batch_size, end_idx)]
             yield to_yield
 
     def _parse_fields_from_info(self, info, strict=True, strip_trailing_space=True):
         """
-        :params info: dict, containing all fields as speicifed in self.fields either under 
-        the key of the field name or under the key of 'contents'.  If under `contents`, this 
+        :params info: dict, containing all fields as specified in self.fields either under
+        the key of the field name or under the key of 'contents'.  If under `contents`, this
         function will parse the input contents into each fields based the self.delimiter
         return: List, each corresponds to the value of self.fields
         """
@@ -172,7 +177,7 @@ class JsonlCollectionIterator:
         all_info['id'] = []
         for filename in filenames:
             with open(filename) as f:
-                for line_i, line in tqdm(enumerate(f)):
+                for line_i, line in tqdm(enumerate(f), disable=self.quiet):
                     info = json.loads(line)
                     if self.docid_field:
                         _id = info.get(self.docid_field, None)

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -144,7 +144,7 @@ class ClipQueryEncoder(QueryEncoder):
             self.encoder = ClipEncoder(encoder_dir, device, l2_norm, prefix, multimodal)
             self.has_model = True
 
-        if not self.has_model and not self.has_encoded_query:
+        if not self.has_model and not self.has_encoded_queries:
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     def encode(self, query: str):

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -52,7 +52,7 @@ class BaseClipEncoder:
     def __init__(self, model_name, device='cuda:0', l2_norm=True):
         self.device = device
         self.model = CLIPModel.from_pretrained(model_name).to(device)
-        self.processor = CLIPProcessor.from_pretrained(model_name, clean_up_tokenization_spaces=True)
+        self.processor = CLIPProcessor.from_pretrained(model_name, clean_up_tokenization_spaces=True, use_fast=True)
         self.l2_norm = l2_norm
 
     def normalize_embeddings(self, embeddings):

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -52,7 +52,12 @@ class BaseClipEncoder:
     def __init__(self, model_name, device='cuda:0', l2_norm=True):
         self.device = device
         self.model = CLIPModel.from_pretrained(model_name).to(device)
-        self.processor = CLIPProcessor.from_pretrained(model_name, clean_up_tokenization_spaces=True, use_fast=True)
+
+        # Explicitly set use_fast=False to address this warning:
+        # > Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model.
+        # > `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor.
+        # > This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.
+        self.processor = CLIPProcessor.from_pretrained(model_name, clean_up_tokenization_spaces=True, use_fast=False)
         self.l2_norm = l2_norm
 
     def normalize_embeddings(self, embeddings):

--- a/pyserini/encode/_dpr.py
+++ b/pyserini/encode/_dpr.py
@@ -72,8 +72,8 @@ class DprDocumentEncoder(DocumentEncoder):
 
 class DprQueryEncoder(QueryEncoder):
     def __init__(self, encoder_dir: str = None, tokenizer_name: str = None,
-                 encoded_query_dir: str = None, device: str = 'cpu', **kwargs):
-        super().__init__(encoded_query_dir)
+                 cache_dir: str = None, device: str = 'cpu', **kwargs):
+        super().__init__(cache_dir)
         if encoder_dir:
             self.device = device
             with log_level(logging.ERROR):
@@ -81,7 +81,7 @@ class DprQueryEncoder(QueryEncoder):
             self.model.to(self.device)
             self.tokenizer = DPRQuestionEncoderTokenizer.from_pretrained(tokenizer_name or encoder_dir, clean_up_tokenization_spaces=True)
             self.has_model = True
-        if (not self.has_model) and (not self.has_encoded_query):
+        if (not self.has_model) and (not self.has_encoded_queries):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     def encode(self, query: str):

--- a/pyserini/encode/_dpr.py
+++ b/pyserini/encode/_dpr.py
@@ -20,8 +20,9 @@ from transformers.utils import logging
 from pyserini.encode import DocumentEncoder, QueryEncoder
 
 
-# See https://github.com/huggingface/transformers/issues/5421
-# about suprressing warning "Some weights of the model checkpoint ... were not used when initializing"
+# - Suppress warning "Some weights of the model checkpoint at facebook/dpr-ctx_encoder-multiset-base were not used when initializing DPRContextEncoder..."
+#   See https://github.com/huggingface/transformers/issues/5421
+# - Suppress warning "The tokenizer class you load from this checkpoint is not the same type as the class this function is called from..."
 class log_level:
     orig_log_level: int
     log_level: int
@@ -43,8 +44,11 @@ class DprDocumentEncoder(DocumentEncoder):
         with log_level(logging.ERROR):
             self.model = DPRContextEncoder.from_pretrained(model_name)
         self.model.to(self.device)
-        self.tokenizer = DPRContextEncoderTokenizer.from_pretrained(tokenizer_name or model_name,
-                                                                    clean_up_tokenization_spaces=True)
+        with log_level(logging.ERROR):
+            self.tokenizer = DPRContextEncoderTokenizer.from_pretrained(
+                tokenizer_name or model_name,
+                clean_up_tokenization_spaces=True
+            )
 
     def encode(self, texts, titles=None,  max_length=256, **kwargs):
         if titles:

--- a/pyserini/encode/_dse.py
+++ b/pyserini/encode/_dse.py
@@ -368,7 +368,7 @@ class DseQueryEncoder(QueryEncoder):
             
             self.has_model = True
 
-        if not self.has_model and not self.has_encoded_query:
+        if not self.has_model and not self.has_encoded_queries:
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     def encode(self, query: str, max_length: int = 256, **kwargs):

--- a/pyserini/encode/_openai.py
+++ b/pyserini/encode/_openai.py
@@ -77,7 +77,7 @@ class OpenAiQueryEncoder(QueryEncoder):
             self.tokenizer = tiktoken.get_encoding(tokenizer_name)
             self.max_length = max_length
             self.has_model = True
-        if (not self.has_model) and (not self.has_encoded_query):
+        if (not self.has_model) and (not self.has_encoded_queries):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     @retry_with_delay

--- a/pyserini/encode/_tct_colbert.py
+++ b/pyserini/encode/_tct_colbert.py
@@ -84,7 +84,7 @@ class TctColBertQueryEncoder(QueryEncoder):
             self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or encoder_dir,
                                                            clean_up_tokenization_spaces=True)
             self.has_model = True
-        if (not self.has_model) and (not self.has_encoded_query):
+        if (not self.has_model) and (not self.has_encoded_queries):
             raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
 
     def encode(self, query: str):

--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -60,7 +60,10 @@ from pyserini.search import get_qrels_file
 
 
 def trec_eval(
-    args, query_id=None, return_per_query_results=False
+    args,
+    query_id=None,
+    return_per_query_results=False,
+    verbose=True
 ) -> float | dict[Any, float]:
     cmd_prefix = ['java', '-cp', jar_path, 'trec_eval']
 
@@ -160,10 +163,12 @@ def trec_eval(
     #   args: [-c -m judged.20 -m ndcg_cut.10 qrels run]  -> call: [-c -m ndcg_cut.10 qrels run]  -> print ndcg_cut.10
     #   args: [-c -m ndcg_cut.10 qrels run]               -> call: [-c -m ndcg_cut.10 qrels run]  -> print ndcg_cut.10
     if not judged_result or non_judge_k_metrics:
-        print(output)
+        if verbose:
+            print(output)
 
     for judged in judged_result:
-        print(judged)
+        if verbose:
+            print(judged)
 
     if temp_file:
         os.remove(temp_file)

--- a/pyserini/index/lucene/_base.py
+++ b/pyserini/index/lucene/_base.py
@@ -195,7 +195,7 @@ class LuceneIndexReader:
         self.reader = self.object.getReader(index_dir)
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str, verbose=False):
+    def from_prebuilt_index(cls, prebuilt_index_name: str, verbose=True):
         """Build an index reader from a prebuilt index; download the index if necessary.
 
         Parameters
@@ -211,7 +211,7 @@ class LuceneIndexReader:
             Index reader built from the prebuilt index.
         """
         if verbose:
-            print(f'Attempting to initialize prebuilt index {prebuilt_index_name}.')
+            print(f'Attempting to initialize prebuilt index: {prebuilt_index_name}')
 
         try:
             index_dir = download_prebuilt_index(prebuilt_index_name, verbose=verbose)
@@ -256,7 +256,7 @@ class LuceneIndexReader:
             tokens.append(token)
         return tokens
 
-    def validate(self, prebuilt_index_name: str, verbose=False):
+    def validate(self, prebuilt_index_name: str, verbose=True):
         """Validate this index against stored stats for a prebuilt index."""
         stats = self.stats()
 
@@ -280,7 +280,7 @@ class LuceneIndexReader:
 
         if verbose:
             print(stats)
-            print(f'Index passes consistency checks against prebuilt index \'{prebuilt_index_name}\'!')
+            print(f'Prebuilt index \'{prebuilt_index_name}\' passes consistency checks.')
 
         return True
 

--- a/pyserini/query_iterator.py
+++ b/pyserini/query_iterator.py
@@ -75,13 +75,14 @@ class QueryIterator(ABC):
         return len(self.topics.keys())
 
     @staticmethod
-    def get_predefined_order(topics_path: str):
+    def get_predefined_order(topics_path: str, verbose=False):
         order = None
         normalized_path = Path(topics_path).stem  # get filename w/o extension
         normalized_path = normalized_path.replace('_', '-')
 
         if normalized_path in QueryIterator.PREDEFINED_ORDER:
-            print(f'Using pre-defined topic order for {normalized_path}')
+            if verbose:
+                print(f'Using pre-defined topic order for {normalized_path}')
             # Lazy import:
             from pyserini.query_iterator_order_info import QUERY_IDS
 

--- a/pyserini/resources/logging.properties
+++ b/pyserini/resources/logging.properties
@@ -1,0 +1,1 @@
+org.apache.lucene.store.MemorySegmentIndexInputProvider.level = WARNING

--- a/pyserini/search/faiss/__main__.py
+++ b/pyserini/search/faiss/__main__.py
@@ -340,12 +340,12 @@ def init_query_encoder(
                 return QueryEncoder(encoded_queries)
         else:
             if "bpr" in encoded_queries:
-                return BprQueryEncoder.load_encoded_queries(encoded_queries)
+                return BprQueryEncoder.load_cached_queries(encoded_queries)
             else:
-                return QueryEncoder.load_encoded_queries(encoded_queries)
+                return QueryEncoder.load_cached_queries(encoded_queries)
 
     if topics_name in encoded_queries_map:
-        return QueryEncoder.load_encoded_queries(encoded_queries_map[topics_name])
+        return QueryEncoder.load_cached_queries(encoded_queries_map[topics_name])
 
     raise ValueError(f"No encoded queries for topic {topics_name}")
 

--- a/pyserini/search/faiss/_searcher.py
+++ b/pyserini/search/faiss/_searcher.py
@@ -85,7 +85,9 @@ class FaissSearcher:
         assert self.docids is None or self.num_docs == len(self.docids)
         if prebuilt_index_name:
             sparse_index = get_sparse_index(prebuilt_index_name)
-            self.ssearcher = LuceneSearcher.from_prebuilt_index(sparse_index)
+            # This searcher is for fetching the raw docs.
+            # When initializing, explicitly suppress logging output.
+            self.ssearcher = LuceneSearcher.from_prebuilt_index(sparse_index, verbose=False)
 
     @classmethod
     def from_prebuilt_index(
@@ -94,6 +96,7 @@ class FaissSearcher:
         query_encoder: QueryEncoder,
         normalize_distances: bool = False,
         faiss_device: str = "cpu",
+        verbose=True
     ):
         """Build a searcher from a prebuilt index; download the index if necessary.
 
@@ -113,7 +116,9 @@ class FaissSearcher:
         FaissSearcher
             Searcher built from the prebuilt faiss index.
         """
-        print(f'Attempting to initialize prebuilt index {prebuilt_index_name}.')
+        if verbose:
+            print(f'Attempting to initialize prebuilt index: {prebuilt_index_name}')
+
         # see integrations/papers/test_sigir2021.py - preserve working commands published in papers
         if prebuilt_index_name == 'msmarco-passage-tct_colbert-hnsw':
             prebuilt_index_name = 'msmarco-v1-passage.tct_colbert.hnsw'
@@ -122,12 +127,14 @@ class FaissSearcher:
             prebuilt_index_name = 'wikipedia-dpr-100w.dkrr-nq'
 
         try:
-            index_dir = download_prebuilt_index(prebuilt_index_name)
+            index_dir = download_prebuilt_index(prebuilt_index_name, verbose=verbose)
         except ValueError as e:
             print(str(e))
             return None
 
-        print(f'Initializing {prebuilt_index_name}...')
+        if verbose:
+            print(f'Initializing {prebuilt_index_name}...')
+
         return cls(index_dir, query_encoder, prebuilt_index_name, normalize_distances, faiss_device)
 
     @staticmethod

--- a/pyserini/search/lucene/__main__.py
+++ b/pyserini/search/lucene/__main__.py
@@ -164,14 +164,14 @@ if __name__ == "__main__":
         # Nevertheless, we still do this to be explicit and have Python manage all index downloads.
         if os.path.exists(args.index):
             if args.hnsw:
-                searcher = LuceneHnswDenseSearcher(args.index, ef_search=args.ef_search, encoder=args.onnx_encoder, verbose=False)
+                searcher = LuceneHnswDenseSearcher(args.index, ef_search=args.ef_search, encoder=args.onnx_encoder, verbose=True)
             elif args.flat:
                 searcher = LuceneFlatDenseSearcher(args.index, encoder=args.onnx_encoder)
             else:
                 raise ValueError(f'Unrecognized dense vector index type: must set either --hnsw or --flat')
         else:
             if args.hnsw:
-                searcher = LuceneHnswDenseSearcher.from_prebuilt_index(args.index, ef_search=args.ef_search, encoder=args.onnx_encoder, verbose=False)
+                searcher = LuceneHnswDenseSearcher.from_prebuilt_index(args.index, ef_search=args.ef_search, encoder=args.onnx_encoder, verbose=True)
             elif args.flat:
                 searcher = LuceneFlatDenseSearcher.from_prebuilt_index(args.index, encoder=args.onnx_encoder)
             else:

--- a/pyserini/search/lucene/_hnsw_searcher.py
+++ b/pyserini/search/lucene/_hnsw_searcher.py
@@ -41,7 +41,7 @@ class LuceneHnswDenseSearcher:
         Path to Lucene index directory.
     """
 
-    def __init__(self, index_dir: str, ef_search=100, encoder=None, prebuilt_index_name=None, verbose=False):
+    def __init__(self, index_dir: str, ef_search=100, encoder=None, prebuilt_index_name=None, verbose=True):
         self.index_dir = index_dir
 
         args = JHnswDenseSearcherArgs()
@@ -56,7 +56,7 @@ class LuceneHnswDenseSearcher:
         self.prebuilt_index_name = prebuilt_index_name
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str, ef_search=100, encoder=None, verbose=False):
+    def from_prebuilt_index(cls, prebuilt_index_name: str, ef_search=100, encoder=None, verbose=True):
         """Build a searcher from a prebuilt index; download the index if necessary.
 
         Parameters
@@ -74,7 +74,7 @@ class LuceneHnswDenseSearcher:
             Searcher initialized from the prebuilt index.
         """
         if verbose:
-            print(f'Attempting to initialize prebuilt index {prebuilt_index_name}.')
+            print(f'Attempting to initialize prebuilt index: {prebuilt_index_name}')
 
         try:
             index_dir = download_prebuilt_index(prebuilt_index_name, verbose=verbose)
@@ -166,7 +166,7 @@ class LuceneFlatDenseSearcher:
         self.prebuilt_index_name = prebuilt_index_name
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str, encoder=None, verbose=False):
+    def from_prebuilt_index(cls, prebuilt_index_name: str, encoder=None, verbose=True):
         """Build a searcher from a prebuilt index; download the index if necessary.
 
         Parameters
@@ -184,7 +184,8 @@ class LuceneFlatDenseSearcher:
             Searcher initialized from the prebuilt index.
         """
         if verbose:
-            print(f'Attempting to initialize prebuilt index {prebuilt_index_name}.')
+            print(f'Attempting to initialize prebuilt index: {prebuilt_index_name}')
+
         try:
             index_dir = download_prebuilt_index(prebuilt_index_name, verbose=verbose)
         except ValueError as e:

--- a/pyserini/search/lucene/_impact_searcher.py
+++ b/pyserini/search/lucene/_impact_searcher.py
@@ -53,7 +53,14 @@ class LuceneImpactSearcher:
         QueryEncoder to encode query text
     """
 
-    def __init__(self, index_dir: str, query_encoder: Union[QueryEncoder, str], min_idf=0, encoder_type: str = 'pytorch', prebuilt_index_name=None):
+    def __init__(
+        self,
+        index_dir: str,
+        query_encoder: Union[QueryEncoder, str],
+        min_idf=0,
+        encoder_type: str = 'pytorch',
+        prebuilt_index_name=None
+    ):
         self.index_dir = index_dir
         self.idf = self._compute_idf(index_dir)
         self.min_idf = min_idf
@@ -76,7 +83,14 @@ class LuceneImpactSearcher:
             raise ValueError(f'Invalid encoder type: {encoder_type}')
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str, query_encoder: Union[QueryEncoder, str], min_idf=0, encoder_type: str = 'pytorch'):
+    def from_prebuilt_index(
+        cls,
+        prebuilt_index_name: str,
+        query_encoder: Union[QueryEncoder, str],
+        min_idf=0,
+        encoder_type: str = 'pytorch',
+        verbose=True
+    ):
         """Build a searcher from a prebuilt index; download the index if necessary.
 
         Parameters
@@ -95,15 +109,18 @@ class LuceneImpactSearcher:
         LuceneImpactSearcher
             Searcher built from the prebuilt index.
         """
-        print(f'Attempting to initialize prebuilt index {prebuilt_index_name}.')
+        if verbose:
+            print(f'Attempting to initialize prebuilt index: {prebuilt_index_name}')
 
         try:
-            index_dir = download_prebuilt_index(prebuilt_index_name)
+            index_dir = download_prebuilt_index(prebuilt_index_name, verbose=verbose)
         except ValueError as e:
             print(str(e))
             return None
 
-        print(f'Initializing {prebuilt_index_name}...')
+        if verbose:
+            print(f'Initializing {prebuilt_index_name}...')
+
         return cls(index_dir, query_encoder, min_idf, encoder_type, prebuilt_index_name=prebuilt_index_name)
 
     def encode(self, query):
@@ -414,16 +431,27 @@ class SlimSearcher(LuceneImpactSearcher):
         self.sparse_vecs = [sparse_vecs[start:end] for start, end in tqdm(self.sparse_ranges)]
     
     @classmethod
-    def from_prebuilt_index(cls, encoded_corpus:str, prebuilt_index_name: str, query_encoder: Union[QueryEncoder, str], min_idf=0):
-        print(f'Attempting to initialize prebuilt index {prebuilt_index_name}.')
+    def from_prebuilt_index(
+        cls,
+        encoded_corpus: str,
+        prebuilt_index_name: str,
+        query_encoder: Union[QueryEncoder, str],
+        min_idf=0,
+        verbose=True
+    ):
+        if verbose:
+            print(f'Attempting to initialize prebuilt index: {prebuilt_index_name}')
+
         try:
-            index_dir = download_prebuilt_index(prebuilt_index_name)
-            encoded_corpus = download_encoded_corpus(encoded_corpus)
+            index_dir = download_prebuilt_index(prebuilt_index_name, verbose=verbose)
+            encoded_corpus = download_encoded_corpus(encoded_corpus, verbose=verbose)
         except ValueError as e:
             print(str(e))
             return None
 
-        print(f'Initializing {prebuilt_index_name}...')
+        if verbose:
+            print(f'Initializing {prebuilt_index_name}...')
+
         return cls(encoded_corpus, index_dir, query_encoder, min_idf)
 
     def search(self, q: str, k: int = 10, fields=dict()) -> List[JScoredDoc]:

--- a/pyserini/search/lucene/_searcher.py
+++ b/pyserini/search/lucene/_searcher.py
@@ -54,7 +54,7 @@ class LuceneSearcher:
         self.index_reader = index_reader if index_reader else LuceneIndexReader(index_dir)
 
     @classmethod
-    def from_prebuilt_index(cls, prebuilt_index_name: str, verbose=False):
+    def from_prebuilt_index(cls, prebuilt_index_name: str, verbose=True):
         """Build a searcher from a prebuilt index; download the index if necessary.
 
         Parameters
@@ -70,7 +70,7 @@ class LuceneSearcher:
             Searcher initialized from the prebuilt index.
         """
         if verbose:
-            print(f'Attempting to initialize prebuilt index {prebuilt_index_name}.')
+            print(f'Attempting to initialize prebuilt index: {prebuilt_index_name}')
 
         try:
             index_dir = download_prebuilt_index(prebuilt_index_name, verbose=verbose)
@@ -82,7 +82,8 @@ class LuceneSearcher:
         # to obtain the underlying reader of a SimpleSearcher; see https://github.com/castorini/anserini/issues/2013
         index_reader = LuceneIndexReader(index_dir)
         # This is janky as we're created a separate LuceneIndexReader for the sole purpose of validating index stats.
-        index_reader.validate(prebuilt_index_name, verbose=verbose)
+        index_reader.validate(prebuilt_index_name, verbose=False)
+        # Explicitly set verbose to False above
 
         if verbose:
             print(f'Initializing {prebuilt_index_name}...')

--- a/pyserini/setup.py
+++ b/pyserini/setup.py
@@ -37,5 +37,10 @@ def configure_classpath(anserini_root="."):
         raise Exception('No matching jar file found in {}'.format(os.path.abspath(anserini_root)))
 
     latest = max(paths, key=os.path.getctime)
+    logging_config = os.path.join(os.path.dirname(__file__), 'resources', 'logging.properties')
     jnius_config.add_classpath(latest)
     jnius_config.add_options('--add-modules=jdk.incubator.vector')
+    jnius_config.add_options('-Dslf4j.internal.verbosity=WARN')
+    # This gets rid of the following logging: org.apache.lucene.store.MemorySegmentIndexInputProvider <init>
+    # INFO: Using MemorySegmentIndexInput with Java 21; to disable start with -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
+    jnius_config.add_options(f'-Djava.util.logging.config.file={logging_config}')

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -289,7 +289,9 @@ def download_and_unpack_index(url, index_directory='indexes', local_filename=Fal
             print(f'{index_path} already exists, but force=True, removing {index_path} and fetching fresh copy...')
         shutil.rmtree(index_path)
 
-    print(f'Downloading index at {url}...')
+    if verbose:
+        print(f'Downloading index at {url}...')
+
     download_url(url, index_directory, local_filename=local_filename, verbose=False, md5=md5, expected_size=expected_size)
 
     if verbose:

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -397,13 +397,13 @@ def download_prebuilt_index(index_name, force=False, verbose=True, mirror=None):
     raise ValueError(f'Unable to download prebuilt index at any known URLs.')
 
 
-def download_encoded_queries(query_name, force=False, verbose=True, mirror=None):
+def download_cached_queries(query_name, force=False, verbose=True, mirror=None):
     if query_name not in QUERY_INFO:
         raise ValueError(f'Unrecognized query name {query_name}')
     query_md5 = QUERY_INFO[query_name]['md5']
     for url in QUERY_INFO[query_name]['urls']:
         try:
-            return download_and_unpack_index(url, index_directory='queries', prebuilt=True, md5=query_md5)
+            return download_and_unpack_index(url, index_directory='queries', prebuilt=True, md5=query_md5, verbose=verbose)
         except (HTTPError, URLError) as e:
             print(f'Unable to download encoded query at {url}, trying next URL...')
     raise ValueError(f'Unable to download encoded query at any known URLs.')

--- a/scripts/validate_prebuilt_indexes.py
+++ b/scripts/validate_prebuilt_indexes.py
@@ -47,7 +47,7 @@ def check_lucene_dense_flat(index):
 def check_faiss(index):
     # dummy queries; there is no explicit validation...
     # we just try to initialize the index and make sure there are no exceptions
-    dummy_queries = QueryEncoder.load_encoded_queries('tct_colbert-msmarco-passage-dev-subset')
+    dummy_queries = QueryEncoder.load_cached_queries('tct_colbert-msmarco-passage-dev-subset')
     print('\n')
     for entry in index:
         print(f'# Validating "{entry}"...')

--- a/tests/core/test_encoder_iterator.py
+++ b/tests/core/test_encoder_iterator.py
@@ -58,7 +58,7 @@ class TestJsonlCollectionIterator(unittest.TestCase):
             ('bf003bb2d52304fea114d824bc0bf7bfbc7c3106', 'Dissecting social engineering', ''),
             ('50bc77f3ec070940b1923b823503a4c2b09e9921', 'PHANTOM: A Scalable BlockDAG Protocol', ''),
         ]
-        collection_iterator = JsonlCollectionIterator(corpus_path, ['title', 'text'], delimiter='\n')
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['title', 'text'], delimiter='\n', quiet=True)
         for i, info in enumerate(collection_iterator):
             expected_info = all_expected_info[i]
 
@@ -76,7 +76,7 @@ class TestJsonlCollectionIterator(unittest.TestCase):
             ('CACM-0981',
              'Rounding Problems in Commercial Data Processing A common requirement in commercial data processing is that the sum of a set of numbers, rounded in a generally understood manner, be equal to the sum of the numbers rounded individually. Four rounding procedures are described to accomplish this. The particular procedure that is appropriate depends upon whether the numbers being accumulated can vary in sign, whether their sum can vary in sign, and whether the last number being summed can be recognized as such prior to its rounding. CACM November, 1964 Kelley, T. B. CA641102 JB March 9, 1978 4:25 PM 981 5 981 981 5 981 981 5 981'),
         ]
-        collection_iterator = JsonlCollectionIterator(corpus_path, ['text'], delimiter='\n')
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['text'], delimiter='\n', quiet=True)
         for i, info in enumerate(collection_iterator):
             expected_info = all_expected_info[i]
 
@@ -109,7 +109,7 @@ class TestJsonlCollectionIterator(unittest.TestCase):
              'วิกิพีเดียดำเนินการโดยมูลนิธิวิกิมีเดีย องค์กรไม่แสวงผลกำไร ผู้ดำเนินการอีกหลาย ได้แก่'),
         ]
         delimiter = '\n\n'
-        collection_iterator = JsonlCollectionIterator(corpus_path, ['title', 'text'], delimiter=delimiter)
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['title', 'text'], delimiter=delimiter, quiet=True)
         for i, info in enumerate(collection_iterator):
             expected_info = all_expected_info[i]
 
@@ -129,7 +129,7 @@ class TestJsonlCollectionIterator(unittest.TestCase):
         ]
 
         # Note that here we *don't* specify a delimiter.
-        collection_iterator = JsonlCollectionIterator(corpus_path, ['text'])
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['text'], quiet=True)
         for i, info in enumerate(collection_iterator):
             expected_info = all_expected_info[i]
 
@@ -162,7 +162,7 @@ class TestJsonlCollectionIterator(unittest.TestCase):
              'วิกิพีเดียดำเนินการโดยมูลนิธิวิกิมีเดีย องค์กรไม่แสวงผลกำไร ผู้ดำเนินการอีกหลาย ได้แก่'),
         ]
         # Note that here we *don't* specify a delimiter.
-        collection_iterator = JsonlCollectionIterator(corpus_path, ['title', 'text'])
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['title', 'text'], quiet=True)
         for i, info in enumerate(collection_iterator):
             expected_info = all_expected_info[i]
 
@@ -177,7 +177,7 @@ class TestJsonlCollectionIterator(unittest.TestCase):
             (None, 'text', '8:2', "test"),
             ('train-10958-1-img1.jpg', 'image,text', '8:3', "test"),
         ]
-        collection_iterator = JsonlCollectionIterator(corpus_path, ['img_path', 'modality', 'did', 'txt'], docid_field='did')
+        collection_iterator = JsonlCollectionIterator(corpus_path, ['img_path', 'modality', 'did', 'txt'], docid_field='did', quiet=True)
         for i, info in enumerate(collection_iterator):
             expected_info = all_expected_info[i]
 

--- a/tests/core/test_encoder_model_ance.py
+++ b/tests/core/test_encoder_model_ance.py
@@ -25,17 +25,17 @@ from pyserini.search import get_topics
 
 class TestEncodeAnce(unittest.TestCase):
     def test_ance_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('ance-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('ance-msmarco-passage-dev-subset', verbose=False)
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
-        encoded = QueryEncoder.load_encoded_queries('ance-dl19-passage')
+        encoded = QueryEncoder.load_cached_queries('ance-dl19-passage', verbose=False)
         topics = get_topics('dl19-passage')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
-        encoded = QueryEncoder.load_encoded_queries('ance-dl20')
+        encoded = QueryEncoder.load_cached_queries('ance-dl20', verbose=False)
         topics = get_topics('dl20')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
@@ -43,7 +43,7 @@ class TestEncodeAnce(unittest.TestCase):
     def test_ance_encoder(self):
         encoder = AnceQueryEncoder('castorini/ance-msmarco-passage')
 
-        cached_encoder = QueryEncoder.load_encoded_queries('ance-dl20')
+        cached_encoder = QueryEncoder.load_cached_queries('ance-dl20', verbose=False)
         topics = get_topics('dl20')
         # Just test the first 10 topics
         for t in dict(islice(topics.items(), 10)):

--- a/tests/core/test_encoder_model_distilbert_kd.py
+++ b/tests/core/test_encoder_model_distilbert_kd.py
@@ -25,25 +25,25 @@ from pyserini.search import get_topics
 
 class TestEncodeDistilBertKd(unittest.TestCase):
     def test_distilbert_kd_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('distilbert_kd-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('distilbert_kd-msmarco-passage-dev-subset', verbose=False)
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
-        encoded = QueryEncoder.load_encoded_queries('distilbert_kd-dl19-passage')
+        encoded = QueryEncoder.load_cached_queries('distilbert_kd-dl19-passage', verbose=False)
         topics = get_topics('dl19-passage')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
-        encoded = QueryEncoder.load_encoded_queries('distilbert_kd-dl20')
+        encoded = QueryEncoder.load_cached_queries('distilbert_kd-dl20', verbose=False)
         topics = get_topics('dl20')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
     def test_distilbert_kd_encoder(self):
-        encoder = AutoQueryEncoder('sebastian-hofstaetter/distilbert-dot-margin_mse-T2-msmarco')
+        encoder = AutoQueryEncoder('sebastian-hofstaetter/distilbert-dot-margin_mse-T2-msmarco', verbose=False)
 
-        cached_encoder = QueryEncoder.load_encoded_queries('distilbert_kd-dl20')
+        cached_encoder = QueryEncoder.load_cached_queries('distilbert_kd-dl20', verbose=False)
         topics = get_topics('dl20')
         # Just test the first 10 topics
         for t in dict(islice(topics.items(), 10)):

--- a/tests/core/test_encoder_model_distilbert_tasb.py
+++ b/tests/core/test_encoder_model_distilbert_tasb.py
@@ -25,17 +25,17 @@ from pyserini.search import get_topics
 
 class TestEncodeDistilBertTasB(unittest.TestCase):
     def test_distilbert_tas_b_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('distilbert_tas_b-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('distilbert_tas_b-msmarco-passage-dev-subset', verbose=False)
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
-        encoded = QueryEncoder.load_encoded_queries('distilbert_tas_b-dl19-passage')
+        encoded = QueryEncoder.load_cached_queries('distilbert_tas_b-dl19-passage', verbose=False)
         topics = get_topics('dl19-passage')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
-        encoded = QueryEncoder.load_encoded_queries('distilbert_tas_b-dl20')
+        encoded = QueryEncoder.load_cached_queries('distilbert_tas_b-dl20', verbose=False)
         topics = get_topics('dl20')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
@@ -43,7 +43,7 @@ class TestEncodeDistilBertTasB(unittest.TestCase):
     def test_distilbert_tas_b_encoder(self):
         encoder = AutoQueryEncoder('sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco')
 
-        cached_encoder = QueryEncoder.load_encoded_queries('distilbert_tas_b-dl20')
+        cached_encoder = QueryEncoder.load_cached_queries('distilbert_tas_b-dl20', verbose=False)
         topics = get_topics('dl20')
         # Just test the first 10 topics
         for t in dict(islice(topics.items(), 10)):

--- a/tests/core/test_encoder_model_dpr.py
+++ b/tests/core/test_encoder_model_dpr.py
@@ -50,7 +50,7 @@ class TestEncodeDpr(unittest.TestCase):
         self.assertAlmostEqual(vectors[2][-1], 0.1516793, places=4)
 
     def test_dpr_encoded_queries(self):
-        encoded = DprQueryEncoder.load_encoded_queries('dpr_multi-nq-test')
+        encoded = DprQueryEncoder.load_cached_queries('dpr_multi-nq-test')
         topics = get_topics('dpr-nq-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
@@ -58,7 +58,7 @@ class TestEncodeDpr(unittest.TestCase):
     def test_dpr_query_encoder(self):
         encoder = DprQueryEncoder('facebook/dpr-question_encoder-multiset-base')
 
-        cached_encoder = DprQueryEncoder.load_encoded_queries('dpr_multi-nq-test')
+        cached_encoder = DprQueryEncoder.load_cached_queries('dpr_multi-nq-test')
         topics = get_topics('dpr-nq-test')
         # Just test the first 10 topics
         for t in dict(islice(topics.items(), 10)):

--- a/tests/core/test_encoder_model_dpr.py
+++ b/tests/core/test_encoder_model_dpr.py
@@ -50,7 +50,7 @@ class TestEncodeDpr(unittest.TestCase):
         self.assertAlmostEqual(vectors[2][-1], 0.1516793, places=4)
 
     def test_dpr_encoded_queries(self):
-        encoded = DprQueryEncoder.load_cached_queries('dpr_multi-nq-test')
+        encoded = DprQueryEncoder.load_cached_queries('dpr_multi-nq-test', verbose=False)
         topics = get_topics('dpr-nq-test')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
@@ -58,7 +58,7 @@ class TestEncodeDpr(unittest.TestCase):
     def test_dpr_query_encoder(self):
         encoder = DprQueryEncoder('facebook/dpr-question_encoder-multiset-base')
 
-        cached_encoder = DprQueryEncoder.load_cached_queries('dpr_multi-nq-test')
+        cached_encoder = DprQueryEncoder.load_cached_queries('dpr_multi-nq-test', verbose=False)
         topics = get_topics('dpr-nq-test')
         # Just test the first 10 topics
         for t in dict(islice(topics.items(), 10)):

--- a/tests/core/test_encoder_model_sbert.py
+++ b/tests/core/test_encoder_model_sbert.py
@@ -22,7 +22,7 @@ from pyserini.search import get_topics
 
 class TestEncodeSBert(unittest.TestCase):
     def test_msmarco_passage_sbert_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('sbert-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('sbert-msmarco-passage-dev-subset', verbose=False)
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)

--- a/tests/core/test_encoder_model_tct.py
+++ b/tests/core/test_encoder_model_tct.py
@@ -48,25 +48,25 @@ class TestEncodeTctColBert(unittest.TestCase):
         self.assertAlmostEqual(vectors[2][-1], 0.05549275, places=4)
 
     def test_msmarco_doc_tct_colbert_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('tct_colbert-msmarco-doc-dev')
+        encoded = QueryEncoder.load_cached_queries('tct_colbert-msmarco-doc-dev', verbose=False)
         topics = get_topics('msmarco-doc-dev')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
     def test_msmarco_passage_tct_colbert_v2_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('tct_colbert-v2-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('tct_colbert-v2-msmarco-passage-dev-subset', verbose=False)
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
     def test_msmarco_passage_tct_colbert_v2_hn_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('tct_colbert-v2-hn-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('tct_colbert-v2-hn-msmarco-passage-dev-subset', verbose=False)
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)
 
     def test_msmarco_passage_tct_colbert_v2_hnp_encoded_queries(self):
-        encoded = QueryEncoder.load_encoded_queries('tct_colbert-v2-hnp-msmarco-passage-dev-subset')
+        encoded = QueryEncoder.load_cached_queries('tct_colbert-v2-hnp-msmarco-passage-dev-subset', verbose=False)
         topics = get_topics('msmarco-passage-dev-subset')
         for t in topics:
             self.assertTrue(topics[t]['title'] in encoded.embedding)

--- a/tests/core/test_eval.py
+++ b/tests/core/test_eval.py
@@ -29,12 +29,8 @@ class TestTrecEval(unittest.TestCase):
         else:
             self.root = "."
 
-        self.qrels_path = os.path.join(
-            self.root, "tools/topics-and-qrels/qrels.covid-round1.txt"
-        )
-        self.run_path = os.path.join(
-            self.root, "tests/resources/simple_trec_run_filter.txt"
-        )
+        self.qrels_path = os.path.join(self.root, "tools/topics-and-qrels/qrels.covid-round1.txt")
+        self.run_path = os.path.join(self.root, "tests/resources/simple_trec_run_filter.txt")
 
     def test_aggeregated_scores(self):
         args = [
@@ -44,7 +40,7 @@ class TestTrecEval(unittest.TestCase):
             self.qrels_path,
             self.run_path,
         ]
-        self.assertEqual(trec_eval(args), 0.055)
+        self.assertEqual(trec_eval(args, verbose=False), 0.055)
 
     def test_single_query_score(self):
         args = [
@@ -55,7 +51,7 @@ class TestTrecEval(unittest.TestCase):
             self.qrels_path,
             self.run_path,
         ]
-        self.assertEqual(trec_eval(args, query_id="1"), 0.2201)
+        self.assertEqual(trec_eval(args, query_id="1", verbose=False), 0.2201)
 
     def test_per_query_unaggeregated_scores(self):
         args = [
@@ -67,7 +63,7 @@ class TestTrecEval(unittest.TestCase):
             self.run_path,
         ]
         expected = {"1": 0.2201, "2": 0.0, "3": 0.0, "4": 0.0, "all": 0.055}
-        self.assertDictEqual(trec_eval(args, return_per_query_results=True), expected)
+        self.assertDictEqual(trec_eval(args, return_per_query_results=True, verbose=False), expected)
 
     def test_judged_at_k_scores(self):
         args = [
@@ -78,7 +74,7 @@ class TestTrecEval(unittest.TestCase):
             self.qrels_path,
             self.run_path,
         ]
-        self.assertEqual(trec_eval(args), 0.5)
+        self.assertEqual(trec_eval(args, verbose=False), 0.5)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_fusion.py
+++ b/tests/core/test_fusion.py
@@ -83,9 +83,9 @@ class TestFusion(unittest.TestCase):
 
         # Initialize searchers and encoder at class level (shared across all tests)
         cls.encoder = AutoQueryEncoder('BAAI/bge-base-en-v1.5', pooling='cls', l2_norm=True, prefix='Represent this sentence for searching relevant passages:')
-        cls.bm25_searcher = LuceneSearcher.from_prebuilt_index('beir-v1.0.0-arguana.flat')
-        cls.lucene_dense_searcher = LuceneFlatDenseSearcher.from_prebuilt_index('beir-v1.0.0-arguana.bge-base-en-v1.5.flat', encoder='BgeBaseEn15')
-        cls.faiss_dense_searcher_normalized = FaissSearcher.from_prebuilt_index('beir-v1.0.0-arguana.bge-base-en-v1.5', cls.encoder, True)
+        cls.bm25_searcher = LuceneSearcher.from_prebuilt_index('beir-v1.0.0-arguana.flat', verbose=False)
+        cls.lucene_dense_searcher = LuceneFlatDenseSearcher.from_prebuilt_index('beir-v1.0.0-arguana.bge-base-en-v1.5.flat', encoder='BgeBaseEn15', verbose=False)
+        cls.faiss_dense_searcher_normalized = FaissSearcher.from_prebuilt_index('beir-v1.0.0-arguana.bge-base-en-v1.5', query_encoder=cls.encoder, normalize_distances=True, verbose=False)
         cls.qids = ['test-culture-ahrtsdlgra-con01a', 'test-culture-ahrtsdlgra-con02a']
         cls.long_qids = ['test-sport-tshbmlbscac-con01a']
         

--- a/tests/core/test_index_download.py
+++ b/tests/core/test_index_download.py
@@ -27,12 +27,12 @@ class TestIndexDownload(unittest.TestCase):
         self.tmp_dir = f'tmp_{self.__class__.__name__}_{str(random.randint(0, 1000))}'
 
     def test_default_cache(self):
-        LuceneSearcher.from_prebuilt_index('cacm')
+        LuceneSearcher.from_prebuilt_index('cacm', verbose=False)
         self.assertTrue(os.path.exists(os.path.expanduser('~/.cache/pyserini/indexes')))
 
     def test_custom_cache(self):
         os.environ['PYSERINI_CACHE'] = self.tmp_dir
-        LuceneSearcher.from_prebuilt_index('cacm')
+        LuceneSearcher.from_prebuilt_index('cacm', verbose=False)
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'indexes')))
 
     def tearDown(self):

--- a/tests/core/test_index_reader.py
+++ b/tests/core/test_index_reader.py
@@ -20,6 +20,7 @@ import os
 import shutil
 import tarfile
 import unittest
+import warnings
 from random import randint
 from urllib.request import urlretrieve
 
@@ -113,7 +114,18 @@ class TestIndexUtils(unittest.TestCase):
         train_vectors = vectorizer.get_vectors(train_docs)
         test_vectors = vectorizer.get_vectors(test_docs)
         clf = LogisticRegression()
-        clf.fit(train_vectors, train_labels)
+        # Catch and ignore warnings in _linear_loss.py:
+        # > RuntimeWarning: divide by zero encountered in matmul
+        # > RuntimeWarning: overflow encountered in matmul
+        # > RuntimeWarning: invalid value encountered in matmul
+        # Does not appear to effect test case.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                category=RuntimeWarning,
+                module='sklearn.linear_model._linear_loss'
+            )
+            clf.fit(train_vectors, train_labels)
         pred = clf.predict_proba(test_vectors)
         self.assertAlmostEqual(0.4630, pred[0][0], places=4)
         self.assertAlmostEqual(0.5370, pred[0][1], places=4)

--- a/tests/core/test_load_cached_queries.py
+++ b/tests/core/test_load_cached_queries.py
@@ -22,35 +22,35 @@ from pyserini.encode import QueryEncoder
 class TestLoadCachedQueries(unittest.TestCase):
 
     def test_msmarco_v1_and_dl(self):
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-ada2-msmarco-passage-dev-subset'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-ada2-dl19-passage'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-ada2-dl20'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-ada2-msmarco-passage-dev-subset', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-ada2-dl19-passage', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-ada2-dl20', verbose=False))
 
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('msmarco-v1-passage.dev.openai-ada2'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl19-passage.openai-ada2'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl20-passage.openai-ada2'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('msmarco-v1-passage.dev.openai-ada2', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl19-passage.openai-ada2', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl20-passage.openai-ada2', verbose=False))
 
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-ada2-dl19-passage-hyde'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-ada2-dl20-hyde'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-ada2-dl19-passage-hyde', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-ada2-dl20-hyde', verbose=False))
 
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl19-passage.openai-ada2-hyde'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl20-passage.openai-ada2-hyde'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl19-passage.openai-ada2-hyde', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl20-passage.openai-ada2-hyde', verbose=False))
 
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-text-embedding-3-large-msmarco-passage-dev-subset'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-text-embedding-3-large-dl19-passage'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('openai-text-embedding-3-large-dl20'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-text-embedding-3-large-msmarco-passage-dev-subset', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-text-embedding-3-large-dl19-passage', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('openai-text-embedding-3-large-dl20', verbose=False))
 
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('msmarco-v1-passage.dev.openai-text-embedding-3-large'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl19-passage.openai-text-embedding-3-large'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl20-passage.openai-text-embedding-3-large'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('msmarco-v1-passage.dev.openai-text-embedding-3-large', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl19-passage.openai-text-embedding-3-large', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl20-passage.openai-text-embedding-3-large', verbose=False))
 
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('cohere-embed-english-v3.0-msmarco-passage-dev-subset'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('cohere-embed-english-v3.0-dl19-passage'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('cohere-embed-english-v3.0-dl20'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('cohere-embed-english-v3.0-msmarco-passage-dev-subset', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('cohere-embed-english-v3.0-dl19-passage', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('cohere-embed-english-v3.0-dl20', verbose=False))
 
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('msmarco-v1-passage.dev.cohere-embed-english-v3.0'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl19-passage.cohere-embed-english-v3.0'))
-        self.assertIsNotNone(QueryEncoder.load_encoded_queries('dl20-passage.cohere-embed-english-v3.0'))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('msmarco-v1-passage.dev.cohere-embed-english-v3.0', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl19-passage.cohere-embed-english-v3.0', verbose=False))
+        self.assertIsNotNone(QueryEncoder.load_cached_queries('dl20-passage.cohere-embed-english-v3.0', verbose=False))
 
 
 if __name__ == '__main__':

--- a/tests/core/test_lucene_dense_search.py
+++ b/tests/core/test_lucene_dense_search.py
@@ -26,7 +26,10 @@ from pyserini.util import get_cache_home
 class TestLuceneDenseSearch(unittest.TestCase):
     def test_lucene_hnsw_dense_searcher(self):
         searcher = LuceneHnswDenseSearcher.from_prebuilt_index(
-            'beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw', encoder='BgeBaseEn15')
+            'beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw',
+            encoder='BgeBaseEn15',
+            verbose=False
+        )
         topics = get_topics('beir-v1.0.0-arguana-test')
         qid = 'test-culture-ahrtsdlgra-con01a'
         q = topics[qid]['title']
@@ -75,7 +78,10 @@ class TestLuceneDenseSearch(unittest.TestCase):
 
     def test_lucene_hnsw_dense_searcher_batch(self):
         searcher = LuceneHnswDenseSearcher.from_prebuilt_index(
-            'beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw', encoder='BgeBaseEn15')
+            'beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw',
+            encoder='BgeBaseEn15',
+            verbose=False
+        )
         topics = get_topics('beir-v1.0.0-arguana-test')
         qids = ['test-culture-ahrtsdlgra-con01a', 'test-culture-ahrtsdlgra-con02a']
         queries = [topics[qids[0]]['title'], topics[qids[1]]['title']]
@@ -121,7 +127,10 @@ class TestLuceneDenseSearch(unittest.TestCase):
 
     def test_lucene_flat_dense_searcher(self):
         searcher = LuceneFlatDenseSearcher.from_prebuilt_index(
-            'beir-v1.0.0-arguana.bge-base-en-v1.5.flat', encoder='BgeBaseEn15')
+            'beir-v1.0.0-arguana.bge-base-en-v1.5.flat',
+            encoder='BgeBaseEn15',
+            verbose=False
+        )
         topics = get_topics('beir-v1.0.0-arguana-test')
         qid = 'test-culture-ahrtsdlgra-con01a'
         q = topics[qid]['title']
@@ -170,7 +179,10 @@ class TestLuceneDenseSearch(unittest.TestCase):
 
     def test_lucene_flat_dense_searcher_batch(self):
         searcher = LuceneFlatDenseSearcher.from_prebuilt_index(
-            'beir-v1.0.0-arguana.bge-base-en-v1.5.flat', encoder='BgeBaseEn15')
+            'beir-v1.0.0-arguana.bge-base-en-v1.5.flat',
+            encoder='BgeBaseEn15',
+            verbose=False
+        )
         topics = get_topics('beir-v1.0.0-arguana-test')
         qids = ['test-culture-ahrtsdlgra-con01a', 'test-culture-ahrtsdlgra-con02a']
         queries = [topics[qids[0]]['title'], topics[qids[1]]['title']]

--- a/tests/core/test_mcp.py
+++ b/tests/core/test_mcp.py
@@ -67,8 +67,12 @@ class TestMCPyseriniServer(unittest.TestCase):
             mcp,
             transport='streamable-http',
         ) as url:
-            async with Client(StreamableHttpTransport(url)) as client:
+            client = Client(StreamableHttpTransport(url))
+            await client.__aenter__()
+            try:
                 return await client.call_tool(name, arguments)
+            finally:
+                await client.close()
 
     def test_search_tool(self):
         result = self._run_async(self._call_tool('search', {

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -25,6 +25,10 @@ class TestRestServer(unittest.TestCase):
     def setUpClass(cls):
         cls.client = TestClient(app)
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.close()
+
     def test_docs_available(self):
         response = self.client.get('/docs')
         self.assertEqual(response.status_code, 200)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -32,7 +32,7 @@ class TestIterateCollection(unittest.TestCase):
         expected_md5 = info.get("md5", None)
 
         with tempfile.TemporaryDirectory(prefix="prebuilt-index-") as directory:
-            tarball_path = download_url(url, directory, md5=expected_md5, expected_size=expected_size)
+            tarball_path = download_url(url, directory, md5=expected_md5, expected_size=expected_size, verbose=False)
             self.assertTrue(os.path.exists(tarball_path), "Downloaded tarball not found on disk.")
 
     def test_prebuilt_index_download_size_mismatch_raises(self):
@@ -43,7 +43,7 @@ class TestIterateCollection(unittest.TestCase):
 
         with tempfile.TemporaryDirectory(prefix="prebuilt-index-") as directory:
             with self.assertRaises((AssertionError, ValueError)):
-                download_url(url, directory, expected_size=1, force=True)
+                download_url(url, directory, expected_size=1, force=True, verbose=False)
 
     def test_prebuilt_index_download_md5_mismatch_raises(self):
         """Negative case: wrong md5 should raise."""
@@ -55,7 +55,7 @@ class TestIterateCollection(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="prebuilt-index-") as directory:
             bad_md5 = "0" * 32
             with self.assertRaises((AssertionError, ValueError)):
-                download_url(url, directory, md5=bad_md5, expected_size=expected_size, force=True)
+                download_url(url, directory, md5=bad_md5, expected_size=expected_size, force=True, verbose=False)
 
     def test_download_and_unpack_index_sanity(self):
         """

--- a/tests/optional/test_hybrid_search.py
+++ b/tests/optional/test_hybrid_search.py
@@ -30,9 +30,9 @@ class TestHybridSearch(unittest.TestCase):
         cls.d_searcher_name = 'facebook/contriever-msmarco'
         cls.d_index_name = 'beir-v1.0.0-arguana.contriever-msmarco'
         
-        cls.s_searcher = LuceneSearcher.from_prebuilt_index(f'{cls.s_index_name}')
+        cls.s_searcher = LuceneSearcher.from_prebuilt_index(cls.s_index_name, verbose=False)
         cls.d_encoder = AutoQueryEncoder(cls.d_searcher_name, pooling='mean', l2_norm=False)
-        cls.d_searcher = FaissSearcher.from_prebuilt_index(f'{cls.d_index_name}', cls.d_encoder)
+        cls.d_searcher = FaissSearcher.from_prebuilt_index(cls.d_index_name, cls.d_encoder, verbose=False)
         cls.searcher = HybridSearcher(cls.d_searcher, cls.s_searcher)
 
     def test_hybrid_searcher(self):


### PR DESCRIPTION
+ Rename `QueryEncoder.load_encoded_queries` to `QueryEncoder.load_cached_queries` for consistency wrt rest code base and Anserini.
+ Enforce more consistent implementation of `verbose` flag for logging.
+ Fixed resource leakage in test cases.
