### PR TITLE
Fix trec eval python312

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -461,3 +461,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@VCY019](https://github.com/VCY019) on 2026-03-02 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@raghav-ai](https://github.com/raghav-ai) on 2026-03-03 (commit [`99e2810`](https://github.com/castorini/pyserini/commit/99e28100860ac226a9e04cb4d65090d2d101d894))
++ Results reproduced by [@namatvir](https://github.com/namatvir) on 2026-03-16 (commit [`76c95a4`](https://github.com/castorini/pyserini/commit/76c95a455c4750e373ed2a9feb2528ffe8e5d3ba))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -719,3 +719,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@VCY019](https://github.com/VCY019) on 2026-03-02 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@raghav-ai](https://github.com/raghav-ai) on 2026-03-03 (commit [`99e2810`](https://github.com/castorini/pyserini/commit/99e28100860ac226a9e04cb4d65090d2d101d894))
++ Results reproduced by [@namatvir](https://github.com/namatvir) on 2026-03-18 (commit [`b3922b8`](https://github.com/castorini/pyserini/commit/b3922b83765e4d5ec2a7878450fcade1370a1999))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -204,3 +204,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Karrrthik](https://github.com/Karrrthik) on 2026-02-20 (commit [`2cecfb0`](https://github.com/castorini/pyserini/commit/2cecfb02eeb68cac2603cd2959ac3519bb4296cd))
 + Results reproduced by [@VCY019](https://github.com/VCY019) on 2026-03-02 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@raghav-ai](https://github.com/raghav-ai) on 2026-03-03 (commit [`99e2810`](https://github.com/castorini/pyserini/commit/99e28100860ac226a9e04cb4d65090d2d101d894))
++ Results reproduced by [@namatvir](https://github.com/namatvir) on 2026-03-21 (commit [`b3922b8`](https://github.com/castorini/pyserini/commit/b3922b83765e4d5ec2a7878450fcade1370a1999))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -497,3 +497,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@VCY019](https://github.com/VCY019) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@raghav-ai](https://github.com/raghav-ai) on 2026-03-03 (commit [`99e2810`](https://github.com/castorini/pyserini/commit/99e28100860ac226a9e04cb4d65090d2d101d894))
++ Results reproduced by [@namatvir](https://github.com/namatvir) on 2026-03-15 (commit [`76c95a4`](https://github.com/castorini/pyserini/commit/76c95a455c4750e373ed2a9feb2528ffe8e5d3ba))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -505,3 +505,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@aaliyan1230](https://github.com/aaliyan1230) on 2026-03-01 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@VCY019](https://github.com/VCY019) on 2026-03-02 (commit [`bcae91d`](https://github.com/castorini/pyserini/commit/bcae91d0e284e5650e99ce1125d98397503a295d))
 + Results reproduced by [@raghav-ai](https://github.com/raghav-ai) on 2026-03-03 (commit [`99e2810`](https://github.com/castorini/pyserini/commit/99e28100860ac226a9e04cb4d65090d2d101d894))
++ Results reproduced by [@namatvir](https://github.com/namatvir) on 2026-03-17 (commit [`76c95a4`](https://github.com/castorini/pyserini/commit/76c95a455c4750e373ed2a9feb2528ffe8e5d3ba))

--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -42,7 +42,7 @@ import jnius_config
 import pandas as pd
 
 # Don't use the jdk.incubator.vector module.
-jar_directory = str(importlib.resources.files("pyserini.resources.jars").joinpath(''))
+jar_directory = str(importlib.resources.files("pyserini") / "resources" / "jars")
 jar_path = glob.glob(os.path.join(jar_directory, '*.jar'))[0]
 
 try:


### PR DESCRIPTION
Issue:
When running pyserini.eval.trec_eval on Python 3.12, a StopIteration error occurs. This is due to the way importlib.resources.files().joinpath('') behaves in Python 3.12, which seems to differ from previous versions or expects a different usage pattern.

Changed:
jar_directory = str(importlib.resources.files("pyserini.resources.jars").joinpath('')) 
to:
jar_directory = str(importlib.resources.files("pyserini") / "resources" / "jars")
which is compatible with Python 3.12's updated behaviour.