### PR TITLE
Fix StopIteration error in trec_eval.py for Python 3.12

### DIFF
--- a/pyserini/eval/trec_eval.py
+++ b/pyserini/eval/trec_eval.py
@@ -42,7 +42,7 @@ import jnius_config
 import pandas as pd
 
 # Don't use the jdk.incubator.vector module.
-jar_directory = str(importlib.resources.files("pyserini.resources.jars").joinpath(''))
+jar_directory = str(importlib.resources.files("pyserini") / "resources" / "jars")
 jar_path = glob.glob(os.path.join(jar_directory, '*.jar'))[0]
 
 try:

--- a/tests/core/test_eval.py
+++ b/tests/core/test_eval.py
@@ -80,5 +80,10 @@ class TestTrecEval(unittest.TestCase):
         ]
         self.assertEqual(trec_eval(args), 0.5)
 
+    def test_jar_directory_exists(self):
+        import importlib.resources
+        jar_directory = str(importlib.resources.files("pyserini") / "resources" / "jars")
+        self.assertTrue(os.path.isdir(jar_directory))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added a test case (test_jar_directory_exists) to test/core/test_eval.py to verify jar directory path resolves correctly with updated syntax.