### PR TITLE
Fix transformers 5.x compatibility for ANCE, UniCoil, and CLIP encoders

### DIFF
--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -18,15 +18,19 @@ from typing import Optional, List
 
 import torch
 from transformers import PreTrainedModel, RobertaConfig, RobertaModel, RobertaTokenizer, requires_backends
+from transformers.utils import cached_file
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
 
 
 class AnceEncoder(PreTrainedModel):
     config_class = RobertaConfig
-    base_model_prefix = 'ance_encoder'
+    base_model_prefix = 'roberta'
     load_tf_weights = None
-
+    @property
+    def all_tied_weights_keys(self):
+        return {}
+    
     def __init__(self, config: RobertaConfig):
         requires_backends(self, 'torch')
         super().__init__(config)
@@ -74,6 +78,17 @@ class AnceDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
         self.model = AnceEncoder.from_pretrained(model_name)
+        # Manually load embeddingHead and norm weights for transformers 5.x compatibility
+        weights_path = cached_file(model_name, 'pytorch_model.bin')
+        state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
+        self.model.embeddingHead.load_state_dict({
+            'weight': state_dict['embeddingHead.weight'],
+            'bias': state_dict['embeddingHead.bias']
+            })
+        self.model.norm.load_state_dict({
+            'weight': state_dict['norm.weight'],
+            'bias': state_dict['norm.bias']
+            })
         self.model.to(self.device)
         self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or model_name,
                                                           clean_up_tokenization_spaces=True)
@@ -100,6 +115,18 @@ class AnceQueryEncoder(QueryEncoder):
         if encoder_dir:
             self.device = device
             self.model = AnceEncoder.from_pretrained(encoder_dir)
+            self.model = AnceEncoder.from_pretrained(encoder_dir)
+# Manually load embeddingHead and norm weights for transformers 5.x compatibility
+            weights_path = cached_file(encoder_dir, 'pytorch_model.bin')
+            state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
+            self.model.embeddingHead.load_state_dict({
+                'weight': state_dict['embeddingHead.weight'],
+                'bias': state_dict['embeddingHead.bias']
+            })
+            self.model.norm.load_state_dict({
+                'weight': state_dict['norm.weight'],
+                'bias': state_dict['norm.bias']
+            })
             self.model.to(self.device)
             self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or encoder_dir,
                                                               clean_up_tokenization_spaces=True)

--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -25,6 +25,22 @@ from packaging.version import Version
 from transformers import __version__ as transformers_version
 
 
+def _load_ance_model(model_name_or_path: str, device: str):
+    model = AnceEncoder.from_pretrained(model_name_or_path)
+    if Version(transformers_version) >= Version("5.0.0"):
+        load_head_weights(model, model_name_or_path, {
+            'embeddingHead': {
+                'weight': 'embeddingHead.weight',
+                'bias': 'embeddingHead.bias'
+            },
+            'norm': {
+                'weight': 'norm.weight',
+                'bias': 'norm.bias'
+            }
+        })
+    model.to(device)
+    return model
+
 class AnceEncoder(PreTrainedModel):
     config_class = RobertaConfig
     base_model_prefix = 'ance_encoder'
@@ -79,19 +95,7 @@ class AnceEncoder(PreTrainedModel):
 class AnceDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
-        self.model = AnceEncoder.from_pretrained(model_name)
-        if Version(transformers_version) >= Version("5.0.0"):
-            load_head_weights(self.model, model_name, {
-                'embeddingHead': {
-                    'weight': 'embeddingHead.weight',
-                    'bias': 'embeddingHead.bias'
-                },
-                'norm': {
-                    'weight': 'norm.weight',
-                    'bias': 'norm.bias'
-                }
-            })
-        self.model.to(self.device)
+        self.model = _load_ance_model(model_name, device)
         self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or model_name,
                                                           clean_up_tokenization_spaces=True)
 
@@ -116,19 +120,7 @@ class AnceQueryEncoder(QueryEncoder):
         super().__init__(encoded_query_dir)
         if encoder_dir:
             self.device = device
-            self.model = AnceEncoder.from_pretrained(encoder_dir)
-            if Version(transformers_version) >= Version("5.0.0"):
-                load_head_weights(self.model, encoder_dir, {
-                    'embeddingHead': {
-                        'weight': 'embeddingHead.weight',
-                        'bias': 'embeddingHead.bias'
-                    },
-                    'norm': {
-                        'weight': 'norm.weight',
-                        'bias': 'norm.bias'
-                    }
-                })
-            self.model.to(self.device)
+            self.model = _load_ance_model(encoder_dir, device)
             self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or encoder_dir,
                                                               clean_up_tokenization_spaces=True)
             self.has_model = True

--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -21,6 +21,8 @@ from transformers import PreTrainedModel, RobertaConfig, RobertaModel, RobertaTo
 from transformers.utils import cached_file
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from packaging.version import Version
+from transformers import __version__ as transformers_version
 
 
 class AnceEncoder(PreTrainedModel):
@@ -74,22 +76,28 @@ class AnceEncoder(PreTrainedModel):
         pooled_output = self.norm(self.embeddingHead(pooled_output))
         return pooled_output
 
+def load_head_weights(model, model_name, weight_map):
+    weights_path = cached_file(model_name, 'pytorch_model.bin')
+    state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
+    for module_name, keys in weight_map.items():
+        module = getattr(model, module_name)
+        module.load_state_dict({k: state_dict[v] for k, v in keys.items()})
 
 class AnceDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
         self.model = AnceEncoder.from_pretrained(model_name)
-        # Manually load embeddingHead and norm weights for transformers 5.x compatibility
-        weights_path = cached_file(model_name, 'pytorch_model.bin')
-        state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
-        self.model.embeddingHead.load_state_dict({
-            'weight': state_dict['embeddingHead.weight'],
-            'bias': state_dict['embeddingHead.bias']
-        })
-        self.model.norm.load_state_dict({
-            'weight': state_dict['norm.weight'],
-            'bias': state_dict['norm.bias']
-        })
+        if Version(transformers_version) >= Version("5.0.0"):
+            load_head_weights(self.model, model_name, {
+                'embeddingHead': {
+                    'weight': 'embeddingHead.weight',
+                    'bias': 'embeddingHead.bias'
+                },
+                'norm': {
+                    'weight': 'norm.weight',
+                    'bias': 'norm.bias'
+                }
+            })
         self.model.to(self.device)
         self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or model_name,
                                                           clean_up_tokenization_spaces=True)
@@ -116,17 +124,17 @@ class AnceQueryEncoder(QueryEncoder):
         if encoder_dir:
             self.device = device
             self.model = AnceEncoder.from_pretrained(encoder_dir)
-            # Manually load embeddingHead and norm weights for transformers 5.x compatibility
-            weights_path = cached_file(encoder_dir, 'pytorch_model.bin')
-            state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
-            self.model.embeddingHead.load_state_dict({
-                'weight': state_dict['embeddingHead.weight'],
-                'bias': state_dict['embeddingHead.bias']
-            })
-            self.model.norm.load_state_dict({
-                'weight': state_dict['norm.weight'],
-                'bias': state_dict['norm.bias']
-            })
+            if Version(transformers_version) >= Version("5.0.0"):
+                load_head_weights(self.model, encoder_dir, {
+                    'embeddingHead': {
+                        'weight': 'embeddingHead.weight',
+                        'bias': 'embeddingHead.bias'
+                    },
+                    'norm': {
+                        'weight': 'norm.weight',
+                        'bias': 'norm.bias'
+                    }
+                })
             self.model.to(self.device)
             self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or encoder_dir,
                                                               clean_up_tokenization_spaces=True)

--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -18,9 +18,9 @@ from typing import Optional, List
 
 import torch
 from transformers import PreTrainedModel, RobertaConfig, RobertaModel, RobertaTokenizer, requires_backends
-from transformers.utils import cached_file
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import load_head_weights
 from packaging.version import Version
 from transformers import __version__ as transformers_version
 
@@ -75,13 +75,6 @@ class AnceEncoder(PreTrainedModel):
         pooled_output = sequence_output[:, 0, :]
         pooled_output = self.norm(self.embeddingHead(pooled_output))
         return pooled_output
-
-def load_head_weights(model, model_name, weight_map):
-    weights_path = cached_file(model_name, 'pytorch_model.bin')
-    state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
-    for module_name, keys in weight_map.items():
-        module = getattr(model, module_name)
-        module.load_state_dict({k: state_dict[v] for k, v in keys.items()})
 
 class AnceDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):

--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -25,22 +25,6 @@ from packaging.version import Version
 from transformers import __version__ as transformers_version
 
 
-def _load_ance_model(model_name_or_path: str, device: str):
-    model = AnceEncoder.from_pretrained(model_name_or_path)
-    if Version(transformers_version) >= Version("5.0.0"):
-        load_head_weights(model, model_name_or_path, {
-            'embeddingHead': {
-                'weight': 'embeddingHead.weight',
-                'bias': 'embeddingHead.bias'
-            },
-            'norm': {
-                'weight': 'norm.weight',
-                'bias': 'norm.bias'
-            }
-        })
-    model.to(device)
-    return model
-
 class AnceEncoder(PreTrainedModel):
     config_class = RobertaConfig
     base_model_prefix = 'ance_encoder'
@@ -91,11 +75,29 @@ class AnceEncoder(PreTrainedModel):
         pooled_output = sequence_output[:, 0, :]
         pooled_output = self.norm(self.embeddingHead(pooled_output))
         return pooled_output
+    
+    @classmethod
+    def load_pretrained_encoder(cls, model_name_or_path: str, device: str):
+        model = cls.from_pretrained(model_name_or_path)
+        if Version(transformers_version) >= Version("5.0.0"):
+            load_head_weights(model, model_name_or_path, {
+                'embeddingHead': {
+                    'weight': 'embeddingHead.weight',
+                    'bias': 'embeddingHead.bias'
+                },
+                'norm': {
+                    'weight': 'norm.weight',
+                    'bias': 'norm.bias'
+                }
+            })
+        model.to(device)
+        return model
+
 
 class AnceDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
-        self.model = _load_ance_model(model_name, device)
+        self.model = AnceEncoder.load_pretrained_encoder(model_name, device)
         self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or model_name,
                                                           clean_up_tokenization_spaces=True)
 
@@ -120,7 +122,7 @@ class AnceQueryEncoder(QueryEncoder):
         super().__init__(encoded_query_dir)
         if encoder_dir:
             self.device = device
-            self.model = _load_ance_model(encoder_dir, device)
+            self.model = AnceEncoder.load_pretrained_encoder(encoder_dir, device)
             self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or encoder_dir,
                                                               clean_up_tokenization_spaces=True)
             self.has_model = True

--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -25,8 +25,9 @@ from pyserini.encode import DocumentEncoder, QueryEncoder
 
 class AnceEncoder(PreTrainedModel):
     config_class = RobertaConfig
-    base_model_prefix = 'roberta'
+    base_model_prefix = 'ance_encoder'
     load_tf_weights = None
+
     @property
     def all_tied_weights_keys(self):
         return {}
@@ -84,11 +85,11 @@ class AnceDocumentEncoder(DocumentEncoder):
         self.model.embeddingHead.load_state_dict({
             'weight': state_dict['embeddingHead.weight'],
             'bias': state_dict['embeddingHead.bias']
-            })
+        })
         self.model.norm.load_state_dict({
             'weight': state_dict['norm.weight'],
             'bias': state_dict['norm.bias']
-            })
+        })
         self.model.to(self.device)
         self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or model_name,
                                                           clean_up_tokenization_spaces=True)
@@ -115,8 +116,7 @@ class AnceQueryEncoder(QueryEncoder):
         if encoder_dir:
             self.device = device
             self.model = AnceEncoder.from_pretrained(encoder_dir)
-            self.model = AnceEncoder.from_pretrained(encoder_dir)
-# Manually load embeddingHead and norm weights for transformers 5.x compatibility
+            # Manually load embeddingHead and norm weights for transformers 5.x compatibility
             weights_path = cached_file(encoder_dir, 'pytorch_model.bin')
             state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
             self.model.embeddingHead.load_state_dict({

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -23,6 +23,7 @@ import torch
 from tqdm import tqdm
 
 from pyserini.util import download_encoded_queries
+from transformers.utils import cached_file
 
 
 class DocumentEncoder:
@@ -230,3 +231,15 @@ class JsonlRepresentationWriter(RepresentationWriter):
             self.file.write(json.dumps({'id': batch_info['id'][i],
                                         'contents': contents,
                                         'vector': vector}) + '\n')
+            
+def load_head_weights(model, model_name, weight_map):
+    """
+    Load head weights from checkpoint for transformers 5.x compatibility.
+    This function manually loads head weights from the checkpoint file.
+    """
+
+    weights_path = cached_file(model_name, 'pytorch_model.bin')
+    state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
+    for module_name, keys in weight_map.items():
+        module = getattr(model, module_name)
+        module.load_state_dict({k: state_dict[v] for k, v in keys.items()})

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -111,7 +111,11 @@ class ClipTextEncoder(BaseClipEncoder):
 
         # In transformers 5.x, get_text_features() returns BaseModelOutputWithPooling
         # instead of a tensor directly; use pooler_output to get the text embeddings
-        embeddings = text_features.pooler_output.detach().cpu().numpy()
+        # If statement to support both versions of transformers
+        if hasattr(text_features, 'pooler_output'):
+            embeddings = text_features.pooler_output.detach().cpu().numpy()
+        else:
+            embeddings = text_features.detach().cpu().numpy()
         return self.normalize_embeddings(embeddings)
     
     

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -109,7 +109,7 @@ class ClipTextEncoder(BaseClipEncoder):
         with torch.no_grad():
             text_features = self.model.get_text_features(**inputs)
 
-        embeddings = text_features.detach().cpu().numpy()
+        embeddings = text_features.pooler_output.detach().cpu().numpy()
         return self.normalize_embeddings(embeddings)
     
     

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -109,6 +109,8 @@ class ClipTextEncoder(BaseClipEncoder):
         with torch.no_grad():
             text_features = self.model.get_text_features(**inputs)
 
+        # In transformers 5.x, get_text_features() returns BaseModelOutputWithPooling
+        # instead of a tensor directly; use pooler_output to get the text embeddings
         embeddings = text_features.pooler_output.detach().cpu().numpy()
         return self.normalize_embeddings(embeddings)
     

--- a/pyserini/encode/_unicoil.py
+++ b/pyserini/encode/_unicoil.py
@@ -21,9 +21,9 @@ import torch
 if torch.cuda.is_available():
     from torch.cuda.amp import autocast
 from transformers import BertConfig, BertModel, BertTokenizer, PreTrainedModel
-from transformers.utils import cached_file
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import load_head_weights
 from packaging.version import Version
 from transformers import __version__ as transformers_version
 
@@ -79,13 +79,6 @@ class UniCoilEncoder(PreTrainedModel):
         tok_weights = self.tok_proj(sequence_output)
         tok_weights = torch.relu(tok_weights)
         return tok_weights
-
-def load_head_weights(model, model_name, weight_map):
-    weights_path = cached_file(model_name, 'pytorch_model.bin')
-    state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
-    for module_name, keys in weight_map.items():
-        module = getattr(model, module_name)
-        module.load_state_dict({k: state_dict[v] for k, v in keys.items()})
 
 class UniCoilDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):

--- a/pyserini/encode/_unicoil.py
+++ b/pyserini/encode/_unicoil.py
@@ -28,18 +28,6 @@ from packaging.version import Version
 from transformers import __version__ as transformers_version
 
 
-def _load_unicoil_model(model_name_or_path: str, device: str):
-    model = UniCoilEncoder.from_pretrained(model_name_or_path)
-    if Version(transformers_version) >= Version("5.0.0"):
-        load_head_weights(model, model_name_or_path, {
-            'tok_proj': {
-                'weight': 'coil_encoder.tok_proj.weight',
-                'bias': 'coil_encoder.tok_proj.bias'
-            }
-        })
-    model.to(device)
-    return model
-
 class UniCoilEncoder(PreTrainedModel):
     config_class = BertConfig
     base_model_prefix = 'coil_encoder'
@@ -91,11 +79,25 @@ class UniCoilEncoder(PreTrainedModel):
         tok_weights = self.tok_proj(sequence_output)
         tok_weights = torch.relu(tok_weights)
         return tok_weights
+    
+    @classmethod
+    def load_pretrained_encoder(cls, model_name_or_path: str, device: str):
+        model = cls.from_pretrained(model_name_or_path)
+        if Version(transformers_version) >= Version("5.0.0"):
+            load_head_weights(model, model_name_or_path, {
+                'tok_proj': {
+                    'weight': 'coil_encoder.tok_proj.weight',
+                    'bias': 'coil_encoder.tok_proj.bias'
+                }
+            })
+        model.to(device)
+        return model
+
 
 class UniCoilDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
-        self.model = _load_unicoil_model(model_name, device)
+        self.model = UniCoilEncoder.load_pretrained_encoder(model_name, device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name, clean_up_tokenization_spaces=True)
 
     def encode(self, texts, titles=None, expands=None, fp16=False,  max_length=512, **kwargs):
@@ -159,7 +161,7 @@ class UniCoilDocumentEncoder(DocumentEncoder):
 class UniCoilQueryEncoder(QueryEncoder):
     def __init__(self, model_name_or_path, tokenizer_name=None, device='cpu'):
         self.device = device
-        self.model = _load_unicoil_model(model_name_or_path, device)
+        self.model = UniCoilEncoder.load_pretrained_encoder(model_name_or_path, device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name_or_path)
         self.weight_range = 5
         self.quant_range = 256

--- a/pyserini/encode/_unicoil.py
+++ b/pyserini/encode/_unicoil.py
@@ -28,6 +28,18 @@ from packaging.version import Version
 from transformers import __version__ as transformers_version
 
 
+def _load_unicoil_model(model_name_or_path: str, device: str):
+    model = UniCoilEncoder.from_pretrained(model_name_or_path)
+    if Version(transformers_version) >= Version("5.0.0"):
+        load_head_weights(model, model_name_or_path, {
+            'tok_proj': {
+                'weight': 'coil_encoder.tok_proj.weight',
+                'bias': 'coil_encoder.tok_proj.bias'
+            }
+        })
+    model.to(device)
+    return model
+
 class UniCoilEncoder(PreTrainedModel):
     config_class = BertConfig
     base_model_prefix = 'coil_encoder'
@@ -83,15 +95,7 @@ class UniCoilEncoder(PreTrainedModel):
 class UniCoilDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
-        self.model = UniCoilEncoder.from_pretrained(model_name)
-        if Version(transformers_version) >= Version("5.0.0"):
-            load_head_weights(self.model, model_name, {
-                'tok_proj': {
-                    'weight': 'coil_encoder.tok_proj.weight',
-                    'bias': 'coil_encoder.tok_proj.bias'
-                }
-            }) 
-        self.model.to(self.device)
+        self.model = _load_unicoil_model(model_name, device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name, clean_up_tokenization_spaces=True)
 
     def encode(self, texts, titles=None, expands=None, fp16=False,  max_length=512, **kwargs):
@@ -155,15 +159,7 @@ class UniCoilDocumentEncoder(DocumentEncoder):
 class UniCoilQueryEncoder(QueryEncoder):
     def __init__(self, model_name_or_path, tokenizer_name=None, device='cpu'):
         self.device = device
-        self.model = UniCoilEncoder.from_pretrained(model_name_or_path)
-        if Version(transformers_version) >= Version("5.0.0"):
-            load_head_weights(self.model, model_name_or_path, {
-                'tok_proj': {
-                    'weight': 'coil_encoder.tok_proj.weight',
-                    'bias': 'coil_encoder.tok_proj.bias'
-                }
-            })
-        self.model.to(self.device)
+        self.model = _load_unicoil_model(model_name_or_path, device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name_or_path)
         self.weight_range = 5
         self.quant_range = 256

--- a/pyserini/encode/_unicoil.py
+++ b/pyserini/encode/_unicoil.py
@@ -24,6 +24,8 @@ from transformers import BertConfig, BertModel, BertTokenizer, PreTrainedModel
 from transformers.utils import cached_file
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from packaging.version import Version
+from transformers import __version__ as transformers_version
 
 
 class UniCoilEncoder(PreTrainedModel):
@@ -78,17 +80,24 @@ class UniCoilEncoder(PreTrainedModel):
         tok_weights = torch.relu(tok_weights)
         return tok_weights
 
+def load_head_weights(model, model_name, weight_map):
+    weights_path = cached_file(model_name, 'pytorch_model.bin')
+    state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
+    for module_name, keys in weight_map.items():
+        module = getattr(model, module_name)
+        module.load_state_dict({k: state_dict[v] for k, v in keys.items()})
 
 class UniCoilDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
         self.model = UniCoilEncoder.from_pretrained(model_name)
-        weights_path = cached_file(model_name, 'pytorch_model.bin')
-        state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
-        self.model.tok_proj.load_state_dict({
-            'weight': state_dict['coil_encoder.tok_proj.weight'],
-            'bias': state_dict['coil_encoder.tok_proj.bias']
-            })
+        if Version(transformers_version) >= Version("5.0.0"):
+            load_head_weights(self.model, model_name, {
+                'tok_proj': {
+                    'weight': 'coil_encoder.tok_proj.weight',
+                    'bias': 'coil_encoder.tok_proj.bias'
+                }
+            }) 
         self.model.to(self.device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name, clean_up_tokenization_spaces=True)
 
@@ -154,11 +163,12 @@ class UniCoilQueryEncoder(QueryEncoder):
     def __init__(self, model_name_or_path, tokenizer_name=None, device='cpu'):
         self.device = device
         self.model = UniCoilEncoder.from_pretrained(model_name_or_path)
-        weights_path = cached_file(model_name_or_path, 'pytorch_model.bin')
-        state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
-        self.model.tok_proj.load_state_dict({
-            'weight': state_dict['coil_encoder.tok_proj.weight'],
-            'bias': state_dict['coil_encoder.tok_proj.bias']
+        if Version(transformers_version) >= Version("5.0.0"):
+            load_head_weights(self.model, model_name_or_path, {
+                'tok_proj': {
+                    'weight': 'coil_encoder.tok_proj.weight',
+                    'bias': 'coil_encoder.tok_proj.bias'
+                }
             })
         self.model.to(self.device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name_or_path)

--- a/pyserini/encode/_unicoil.py
+++ b/pyserini/encode/_unicoil.py
@@ -30,6 +30,7 @@ class UniCoilEncoder(PreTrainedModel):
     config_class = BertConfig
     base_model_prefix = 'coil_encoder'
     load_tf_weights = None
+    
     @property
     def all_tied_weights_keys(self):
         return {}

--- a/pyserini/encode/_unicoil.py
+++ b/pyserini/encode/_unicoil.py
@@ -21,6 +21,7 @@ import torch
 if torch.cuda.is_available():
     from torch.cuda.amp import autocast
 from transformers import BertConfig, BertModel, BertTokenizer, PreTrainedModel
+from transformers.utils import cached_file
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
 
@@ -29,6 +30,9 @@ class UniCoilEncoder(PreTrainedModel):
     config_class = BertConfig
     base_model_prefix = 'coil_encoder'
     load_tf_weights = None
+    @property
+    def all_tied_weights_keys(self):
+        return {}
 
     def __init__(self, config: BertConfig):
         super().__init__(config)
@@ -78,6 +82,12 @@ class UniCoilDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
         self.model = UniCoilEncoder.from_pretrained(model_name)
+        weights_path = cached_file(model_name, 'pytorch_model.bin')
+        state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
+        self.model.tok_proj.load_state_dict({
+            'weight': state_dict['coil_encoder.tok_proj.weight'],
+            'bias': state_dict['coil_encoder.tok_proj.bias']
+            })
         self.model.to(self.device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name, clean_up_tokenization_spaces=True)
 
@@ -143,6 +153,12 @@ class UniCoilQueryEncoder(QueryEncoder):
     def __init__(self, model_name_or_path, tokenizer_name=None, device='cpu'):
         self.device = device
         self.model = UniCoilEncoder.from_pretrained(model_name_or_path)
+        weights_path = cached_file(model_name_or_path, 'pytorch_model.bin')
+        state_dict = torch.load(weights_path, map_location='cpu', weights_only=True)
+        self.model.tok_proj.load_state_dict({
+            'weight': state_dict['coil_encoder.tok_proj.weight'],
+            'bias': state_dict['coil_encoder.tok_proj.bias']
+            })
         self.model.to(self.device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name_or_path)
         self.weight_range = 5

--- a/tests/core/test_encoder_model_ance.py
+++ b/tests/core/test_encoder_model_ance.py
@@ -51,7 +51,14 @@ class TestEncodeAnce(unittest.TestCase):
             encoded_vector = np.array(encoder.encode(topics[t]['title']))
 
             l1 = np.sum(np.abs(cached_vector - encoded_vector))
+            # print(f'l1 values is {l1}')
             self.assertTrue(l1 < 0.0005)
+
+    def test_ance_weights_loaded(self):
+        encoder = AnceQueryEncoder('castorini/ance-msmarco-passage')
+        norm_weights = encoder.model.norm.weight.detach().cpu().numpy()
+        self.assertFalse(np.allclose(norm_weights, np.ones_like(norm_weights)),
+            "norm weights appear to be default initialized, not loaded from checkpoint")
 
 
 if __name__ == '__main__':

--- a/tests/core/test_encoder_model_ance.py
+++ b/tests/core/test_encoder_model_ance.py
@@ -51,14 +51,16 @@ class TestEncodeAnce(unittest.TestCase):
             encoded_vector = np.array(encoder.encode(topics[t]['title']))
 
             l1 = np.sum(np.abs(cached_vector - encoded_vector))
-            # print(f'l1 values is {l1}')
             self.assertTrue(l1 < 0.0005)
 
     def test_ance_weights_loaded(self):
         encoder = AnceQueryEncoder('castorini/ance-msmarco-passage')
         norm_weights = encoder.model.norm.weight.detach().cpu().numpy()
+        norm_bias = encoder.model.norm.bias.detach().cpu().numpy()
         self.assertFalse(np.allclose(norm_weights, np.ones_like(norm_weights)),
             "norm weights appear to be default initialized, not loaded from checkpoint")
+        self.assertFalse(np.allclose(norm_bias, np.zeros_like(norm_bias)),
+            "norm bias appear to be default initialized, not loaded from checkpoint")
 
 
 if __name__ == '__main__':

--- a/tests/core/test_encoder_model_clip.py
+++ b/tests/core/test_encoder_model_clip.py
@@ -17,8 +17,10 @@
 import json
 import os
 import unittest
+import numpy as np
 
 from pyserini.encode import ClipDocumentEncoder
+from pyserini.encode._clip import ClipTextEncoder
 
 
 class TestEncodeClip(unittest.TestCase):
@@ -44,6 +46,11 @@ class TestEncodeClip(unittest.TestCase):
         self.assertAlmostEqual(vectors[0][-1], -0.21501173, places=4)
         self.assertAlmostEqual(vectors[2][0], 0.06461975, places=4)
         self.assertAlmostEqual(vectors[2][-1], 0.35396004, places=4)
+
+    def test_clip_text_encoder_returns_embeddings(self):
+        encoder = ClipTextEncoder('openai/clip-vit-base-patch32', device='cpu')
+        embeddings = encoder.encode(['test query'])
+        self.assertEqual(embeddings.shape[1], 512)
 
 
 if __name__ == '__main__':

--- a/tests/core/test_encoder_model_unicoil.py
+++ b/tests/core/test_encoder_model_unicoil.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import tarfile
 import unittest
+import numpy as np
 from random import randint
 from urllib.request import urlretrieve
 
@@ -88,6 +89,12 @@ class TestEncodeUniCoil(unittest.TestCase):
 
         os.remove(tarball_name)
         shutil.rmtree(index_dir)
+
+    def test_unicoil_weights_loaded(self):
+        encoder = UniCoilDocumentEncoder('castorini/unicoil-msmarco-passage', device='cpu')
+        tok_proj_weights = encoder.model.tok_proj.weight.detach().cpu().numpy()
+        self.assertFalse(np.allclose(tok_proj_weights, np.zeros_like(tok_proj_weights)),
+                     "tok_proj weights appear to be default initialized, not loaded from checkpoint")
 
 
 if __name__ == '__main__':

--- a/tests/core/test_encoder_model_unicoil.py
+++ b/tests/core/test_encoder_model_unicoil.py
@@ -93,8 +93,11 @@ class TestEncodeUniCoil(unittest.TestCase):
     def test_unicoil_weights_loaded(self):
         encoder = UniCoilDocumentEncoder('castorini/unicoil-msmarco-passage', device='cpu')
         tok_proj_weights = encoder.model.tok_proj.weight.detach().cpu().numpy()
+        tok_proj_weights_bias = encoder.model.tok_proj.bias.detach().cpu().numpy()
         self.assertFalse(np.allclose(tok_proj_weights, np.zeros_like(tok_proj_weights)),
                      "tok_proj weights appear to be default initialized, not loaded from checkpoint")
+        self.assertFalse(np.allclose(tok_proj_weights_bias, np.zeros_like(tok_proj_weights_bias)),
+                     "tok_proj bias appear to be default initialized, not loaded from checkpoint")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After upgrading to transformers 5.X, 3 issues were found.

**Issue 1. "all_tied_weights_keys" attribute was missing in ANCE and UniCoil**
- Transformers5.X introduces new logic which expects models to define all_tied_weights_keys
- Custom encoder classes did not implement this which led to attribute error

**Issue 2. Incorrect/missing weight loading in ANCE and UniCoil**
- "from_pretrained()" no longer correctly loads all weights for custom model components.
- In ANCE: embeddingHead and norm were not loaded and left at default initialization
- in UniCoil: tok_proj weights were not loaded correctly

**Issue 3. Changed return type in CLIP**
- In transformers5.X, get_text_features() doesn't return a tensor but instead a BaseModelOutputWithPooling object
- Existing code assumed a tensor and called .detach() directly which caused an AttributeError

**Implemented fix 1:**
Added all_tied_weights_keys property for ANCE and UniCoil encoders

**Implemented fix 2:**
Manually loaded weights and bias. 
(embeddingHead.weight/.bias for ANCE and coil_encoder.tok_proj.weight/.bias for UniCoil)

**Implemented fix 3:**
Updated code to extract correct tensor with new return type
embeddings = text_features.pooler_output.detach().cpu().numpy()




_verified with: python -m pytest tests/core/ -v --ignore=tests/core/test_rest.py --ignore=tests/core/test_mcp.py 2>&1 | tail -30_