### PR TITLE
Add reproduction logs for MS MARCO passage ranking (Pyserini onboarding)

### DIFF
--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -1,0 +1,25 @@
+# MS MARCO BM25 Reproduction Log (Pyserini)
+
+Successfully reproduced the Pyserini BM25 baseline for MS MARCO Passage Ranking.
+
+Environment:
+- Windows 11 with WSL2 (Ubuntu 22.04)
+- Python 3.11
+- Pyserini installed via pip
+- OpenJDK installed
+- Maven installed
+
+Command used:
+
+python -m pyserini.search.lucene \
+--index msmarco-v1-passage \
+--topics msmarco-passage-dev-subset \
+--output run.msmarco-pyserini.bm25.txt \
+--bm25 \
+--hits 1000
+
+Evaluation:
+
+MRR@10 ≈ 0.199
+
+No major issues observed.

--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -1,33 +1,23 @@
-# MS MARCO BM25 Reproduction Log (Pyserini)
-Successfully reproduced the Pyserini BM25 baseline for MS MARCO Passage Ranking.
+Reproduced BM25 baseline for MS MARCO passage ranking using Pyserini.
 
-Environment:
-- Windows 11 with WSL2 (Ubuntu 22.04)
-- Python 3.11
-- Pyserini installed via pip
-- OpenJDK installed
-- Maven installed
-Installation:
-pip install pyserini
+Environment and Set-up:
 
-sudo apt update
-sudo apt install -y openjdk-11-jdk maven
+OS: Windows 11 (WSL2 Ubuntu 22.04)
+Python: 3.11
+Java: OpenJDK 11/21
+Pyserini: 1.2.0
+Hardware: CPU-only
 
-Verify installation:
+Issues and Results:
 
-java -version
-mvn -version
+MRR@10 = 0.199 (msmarco-passage-dev-subset)
 
-Retrieval
+Used prebuilt msmarco-v1-passage index and executed BM25 retrieval with hits=1000.
+Evaluation performed using msmarco_passage_eval.
 
-Multi-line command:
+Results are consistent with the expected Pyserini BM25 baseline (~0.19–0.20).
 
-python -m pyserini.search.lucene \
-  --index msmarco-v1-passage \
-  --topics msmarco-passage-dev-subset \
-  --output run.msmarco-pyserini.bm25.txt \
-  --bm25 \
-  --hits 1000
+No issues encountered.
 
 Single-line command:
 

--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -1,127 +1,26 @@
 Reproduced BM25 baseline for MS MARCO passage ranking using Pyserini.
 
-Environment and Set-up:
+Environment:
+- OS: Windows 11 (WSL2 Ubuntu 22.04)
+- Python: 3.11
+- Java: OpenJDK 11/21
+- Pyserini: 1.2.0
+- Hardware: CPU-only
 
-OS: Windows 11 (WSL2 Ubuntu 22.04)
-Python: 3.11
-Java: OpenJDK 11/21
-Pyserini: 1.2.0
-Hardware: CPU-only
-
-Issues and Results:
-
-MRR@10 = 0.199 (msmarco-passage-dev-subset)
-
-Used prebuilt msmarco-v1-passage index and executed BM25 retrieval with hits=1000.
-Evaluation performed using msmarco_passage_eval.
-
-Results are consistent with the expected Pyserini BM25 baseline (~0.19–0.20).
-
-No issues encountered.
-
-Single-line command:
-
-python -m pyserini.search.lucene --index msmarco-v1-passage --topics msmarco-passage-dev-subset --output run.msmarco-pyserini.bm25.txt --bm25 --hits 1000
-
-Index
-
-Used prebuilt index: msmarco-v1-passage (automatically downloaded by Pyserini).
-No local indexing was performed.
+Retrieval:
+python -m pyserini.search.lucene \
+  --index msmarco-v1-passage \
+  --topics msmarco-passage-dev-subset \
+  --output run.msmarco-pyserini.bm25.txt \
+  --bm25 \
+  --hits 1000
 
 Evaluation:
-
 python -m pyserini.eval.msmarco_passage_eval run.msmarco-pyserini.bm25.txt
 
-Results
+Results:
+MRR@10 = 0.199 (msmarco-passage-dev-subset)
 
-Expected MRR@10: ~0.19–0.20
-Observed MRR@10: 0.199
+Notes:
+Results are consistent with the expected Pyserini BM25 baseline (~0.19–0.20). No issues encountered during execution.
 
-Notes
-
-No issues encountered. Results are consistent with the reported Pyserini BM25 baseline.
-No major issues observed.
-
-
-# A Conceptual Framework for Retrieval
-
-This section reproduces the “A Conceptual Framework for Retrieval” stage in the Pyserini onboarding.
-
-**Environment & Setup:**
-
-- OS: Ubuntu 22.04  
-- Python 3.10.12  
-- Java: OpenJDK 21  
-- Pyserini installed via pip  
-- Index used: msmarco-v1-passage  
-
-**Steps performed:**
-
-1. **Configured JVM classpath in Python:**
-
-```python
-from pyserini.setup import configure_classpath
-configure_classpath()
-
-2. Loaded Lucene index and retrieved a document:
-
-from pyserini.index.lucene import LuceneIndexReader
-
-index_reader = LuceneIndexReader('indexes/lucene-index-msmarco-passage')
-doc = index_reader.document('7187158')
-print(doc)
-
-Output:
-
-{
-  "id" : "7187158",
-  "contents" : "Paula Deen and her brother Earl W. Bubba Hiers are being sued by a former general manager at Uncle Bubba's..."
-}
-
-3. Created query multi-hot vector:
-
-from pyserini.analysis import Analyzer, get_lucene_analyzer
-
-analyzer = Analyzer(get_lucene_analyzer())
-query_tokens = analyzer.analyze("what is paula deen's brother")
-multihot_query_weights = {k: 1 for k in query_tokens}
-
-print("Tokens:", query_tokens)
-print("Multi-hot vector:", multihot_query_weights)
-
-Output:
-
-Tokens: ['what', 'paula', 'deen', 'brother']
-Multi-hot vector: {'what': 1, 'paula': 1, 'deen': 1, 'brother': 1}
-
-4. Performed BM25 top-k search:
-
-from pyserini.search.lucene import LuceneSearcher
-
-searcher = LuceneSearcher('indexes/lucene-index-msmarco-passage')
-hits = searcher.search("what is paula deen's brother")
-
-for i in range(10):
-    print(f"{i+1} {hits[i].docid} {hits[i].score:.5f}")
-
-Output:
-
- 1 7187158 17.94950
- 2 7187157 17.66560
- 3 7187163 17.39060
- 4 7546327 17.03410
- 5 7187160 16.56520
- 6 8227279 15.74180
- 7 2298838 15.60820
- 8 7617404 15.40040
- 9 7187156 15.27550
-10 2298839 14.97780
-
-Conceptual notes (bi-encoder framework):
-
-BM25 produces sparse lexical vectors (unsupervised).
-Queries are represented as multi-hot vectors.
-Documents are represented as sparse BM25 vectors.
-Relevance is computed via the inner product of query and document vectors.
-Dense retrieval models use learned dense vectors via transformers (not covered in this stage).
-This completes the conceptual framework stage before moving on to dense retrieval experiments.

--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -51,3 +51,87 @@ Notes
 
 No issues encountered. Results are consistent with the reported Pyserini BM25 baseline.
 No major issues observed.
+
+
+### A Conceptual Framework for Retrieval
+
+This section reproduces the “A Conceptual Framework for Retrieval” stage in the Pyserini onboarding.
+
+**Environment & Setup:**
+
+- OS: Ubuntu 22.04  
+- Python 3.10.12  
+- Java: OpenJDK 21  
+- Pyserini installed via pip  
+- Index used: msmarco-v1-passage  
+
+**Steps performed:**
+
+1. **Configured JVM classpath in Python:**
+
+```python
+from pyserini.setup import configure_classpath
+configure_classpath()
+
+2. Loaded Lucene index and retrieved a document:
+
+from pyserini.index.lucene import LuceneIndexReader
+
+index_reader = LuceneIndexReader('indexes/lucene-index-msmarco-passage')
+doc = index_reader.document('7187158')
+print(doc)
+
+Output:
+
+{
+  "id" : "7187158",
+  "contents" : "Paula Deen and her brother Earl W. Bubba Hiers are being sued by a former general manager at Uncle Bubba's..."
+}
+
+3. Created query multi-hot vector:
+
+from pyserini.analysis import Analyzer, get_lucene_analyzer
+
+analyzer = Analyzer(get_lucene_analyzer())
+query_tokens = analyzer.analyze("what is paula deen's brother")
+multihot_query_weights = {k: 1 for k in query_tokens}
+
+print("Tokens:", query_tokens)
+print("Multi-hot vector:", multihot_query_weights)
+
+Output:
+
+Tokens: ['what', 'paula', 'deen', 'brother']
+Multi-hot vector: {'what': 1, 'paula': 1, 'deen': 1, 'brother': 1}
+
+4. Performed BM25 top-k search:
+
+from pyserini.search.lucene import LuceneSearcher
+
+searcher = LuceneSearcher('indexes/lucene-index-msmarco-passage')
+hits = searcher.search("what is paula deen's brother")
+
+for i in range(10):
+    print(f"{i+1} {hits[i].docid} {hits[i].score:.5f}")
+
+Output:
+
+ 1 7187158 17.94950
+ 2 7187157 17.66560
+ 3 7187163 17.39060
+ 4 7546327 17.03410
+ 5 7187160 16.56520
+ 6 8227279 15.74180
+ 7 2298838 15.60820
+ 8 7617404 15.40040
+ 9 7187156 15.27550
+10 2298839 14.97780
+
+Conceptual notes (bi-encoder framework):
+
+BM25 produces sparse lexical vectors (unsupervised).
+Queries are represented as multi-hot vectors.
+Documents are represented as sparse BM25 vectors.
+Relevance is computed via the inner product of query and document vectors.
+Dense retrieval models use learned dense vectors via transformers (not covered in this stage).
+This completes the conceptual framework stage before moving on to dense retrieval experiments.

--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -53,7 +53,7 @@ No issues encountered. Results are consistent with the reported Pyserini BM25 ba
 No major issues observed.
 
 
-### A Conceptual Framework for Retrieval
+# A Conceptual Framework for Retrieval
 
 This section reproduces the “A Conceptual Framework for Retrieval” stage in the Pyserini onboarding.
 

--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -135,3 +135,80 @@ Documents are represented as sparse BM25 vectors.
 Relevance is computed via the inner product of query and document vectors.
 Dense retrieval models use learned dense vectors via transformers (not covered in this stage).
 This completes the conceptual framework stage before moving on to dense retrieval experiments.
+
+**## BGE-base Baseline for NFCorpus**
+
+Environment:
+- Linux / Ubuntu
+- Python 3.10+
+- Pyserini installed in local environment
+- CPU-only (for encoding); Faiss used for indexing and retrieval
+- HuggingFace model: BAAI/bge-base-en-v1.5
+
+Data:
+- Dataset: NFCorpus (BEIR)
+- Corpus size: 3,633 documents
+- Queries munged to TSV; qrels munged to TREC format
+
+Indexing:
+```bash
+python -m pyserini.encode \
+  input   --corpus collections/nfcorpus/corpus.jsonl \
+          --fields title text \
+  output  --embeddings indexes/nfcorpus.bge-base-en-v1.5 \
+          --to-faiss \
+  encoder --encoder BAAI/bge-base-en-v1.5 --l2-norm \
+          --device cpu \
+          --pooling mean \
+          --fields title text \
+          --batch 32
+
+Retrieval:
+python -m pyserini.search.faiss \
+  --encoder-class auto --encoder BAAI/bge-base-en-v1.5 --l2-norm \
+  --pooling mean \
+  --index indexes/nfcorpus.bge-base-en-v1.5 \
+  --topics collections/nfcorpus/queries.tsv \
+  --output runs/run.beir.bge-base-en-v1.5.nfcorpus.txt \
+  --batch 128 --threads 8 \
+  --hits 1000
+
+Evaluation:
+python -m pyserini.eval.trec_eval \
+  -c -m ndcg_cut.10 collections/nfcorpus/qrels/test.qrels \
+  runs/run.beir.bge-base-en-v1.5.nfcorpus.txt
+
+Results:
+ndcg_cut_10    all   0.3682
+
+Interactive Retrieval:
+from pyserini.search.faiss import FaissSearcher
+from pyserini.encode import AutoQueryEncoder
+
+encoder = AutoQueryEncoder('BAAI/bge-base-en-v1.5', device='cpu', pooling='mean', l2_norm=True)
+searcher = FaissSearcher('indexes/nfcorpus.bge-base-en-v1.5', encoder)
+hits = searcher.search('How to Help Prevent Abdominal Aortic Aneurysms')
+
+for i in range(0, 10):
+    print(f'{i+1:2} {hits[i].docid:7} {hits[i].score:.6f}')
+
+Sample output:
+ 1 MED-4555 0.764650
+ 2 MED-4424 0.683133
+ 3 MED-4421 0.680794
+ 4 MED-4560 0.679586
+ 5 MED-2750 0.666892
+ 6 MED-2939 0.665468
+ 7 MED-2946 0.662942
+ 8 MED-1663 0.661462
+ 9 MED-3436 0.656931
+10 MED-4993 0.656215
+
+Confirms that interactive retrieval matches batch retrieval results
+
+Notes:
+
+Used CPU for encoding; batch size adjusted for performance
+Retrieval uses exact dot-product similarity (Faiss flat index)
+HuggingFace model requires authentication token if exceeding rate limits
+Workflow can also be performed with Contriever as an alternative dense retriever

--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -1,5 +1,4 @@
 # MS MARCO BM25 Reproduction Log (Pyserini)
-
 Successfully reproduced the Pyserini BM25 baseline for MS MARCO Passage Ranking.
 
 Environment:
@@ -8,18 +7,47 @@ Environment:
 - Pyserini installed via pip
 - OpenJDK installed
 - Maven installed
+Installation:
+pip install pyserini
 
-Command used:
+sudo apt update
+sudo apt install -y openjdk-11-jdk maven
+
+Verify installation:
+
+java -version
+mvn -version
+
+Retrieval
+
+Multi-line command:
 
 python -m pyserini.search.lucene \
---index msmarco-v1-passage \
---topics msmarco-passage-dev-subset \
---output run.msmarco-pyserini.bm25.txt \
---bm25 \
---hits 1000
+  --index msmarco-v1-passage \
+  --topics msmarco-passage-dev-subset \
+  --output run.msmarco-pyserini.bm25.txt \
+  --bm25 \
+  --hits 1000
+
+Single-line command:
+
+python -m pyserini.search.lucene --index msmarco-v1-passage --topics msmarco-passage-dev-subset --output run.msmarco-pyserini.bm25.txt --bm25 --hits 1000
+
+Index
+
+Used prebuilt index: msmarco-v1-passage (automatically downloaded by Pyserini).
+No local indexing was performed.
 
 Evaluation:
 
-MRR@10 ≈ 0.199
+python -m pyserini.eval.msmarco_passage_eval run.msmarco-pyserini.bm25.txt
 
+Results
+
+Expected MRR@10: ~0.19–0.20
+Observed MRR@10: 0.199
+
+Notes
+
+No issues encountered. Results are consistent with the reported Pyserini BM25 baseline.
 No major issues observed.

--- a/docs/reproduction/kwamearhin-msmarco-bm25.md
+++ b/docs/reproduction/kwamearhin-msmarco-bm25.md
@@ -212,3 +212,52 @@ Used CPU for encoding; batch size adjusted for performance
 Retrieval uses exact dot-product similarity (Faiss flat index)
 HuggingFace model requires authentication token if exceeding rate limits
 Workflow can also be performed with Contriever as an alternative dense retriever
+
+- 2026-04-07: Verified dense and sparse retrieval on NFCorpus using Pyserini (commit 218da76).
+
+  ### Dense Retrieval (Faiss / Bi-encoder)
+  - Used Pyserini dense retrieval pipeline with a pretrained encoder.
+  - Successfully encoded query into dense vector representation.
+  - Performed retrieval over dense index.
+  - Query:
+        "How to Help Prevent Abdominal Aortic Aneurysms"
+  - Retrieved top-k semantically similar documents.
+  - Verified that results are relevant even without exact keyword matches.
+  - Confirms understanding:
+        Dense retrieval = similarity (dot product) in embedding space.
+
+  ### Sparse Retrieval (BM25 / Lucene)
+  - Indexed NFCorpus using Pyserini:
+        Total documents indexed: 3,633
+  - Encountered missing Anserini JAR → resolved by building from source.
+  - Built fat jar:
+        anserini-1.7.2-SNAPSHOT-fatjar.jar
+  - Placed jar in:
+        pyserini/resources/jars/
+  - Fixed Java-Lucene compatibility issue (MemorySegmentIndexInputProvider).
+  - Initialized LuceneSearcher with index:
+        ~/research/pyserini/indexes/lucene.nfcorpus
+
+  - Query:
+        "How to Help Prevent Abdominal Aortic Aneurysms"
+
+  - Top 10 BM25 results:
+        1 MED-4555 11.9305
+        2 MED-4423  8.4771
+        3 MED-3180  7.1896
+        4 MED-2718  6.0102
+        5 MED-1309  5.8181
+        6 MED-4424  5.7448
+        7 MED-1705  5.6101
+        8 MED-4902  5.3639
+        9 MED-1009  5.2533
+       10 MED-1512  5.2068
+
+  - Verified BM25 retrieval works correctly.
+
+  ### Key Takeaways
+  - Dense and sparse retrieval follow the same conceptual framework:
+        query representation vs document representation
+  - Dense retrieval uses learned embeddings.
+  - Sparse retrieval uses term-based weighting (BM25).
+  - In both cases, ranking is based on similarity scoring.


### PR DESCRIPTION
Environment and Set-up:

OS: Windows 11 (WSL2 Ubuntu)
Python: 3.11
Java: OpenJDK 21
Hardware: CPU-only setup
RAM: 8GB

Issues and Results:

Successfully reproduced the Pyserini BM25 baseline for MS MARCO passage ranking.

MRR@10 = 0.199 on msmarco-passage-dev-subset.

Everything worked as expected and results are consistent with the reported baseline. No issues were encountered during installation or retrieval.