### PR TITLE
2CR: display eval command if --display-commands is set

### DIFF
--- a/pyserini/2cr/_base.py
+++ b/pyserini/2cr/_base.py
@@ -31,8 +31,12 @@ def run_command(cmd):
     return stdout, stderr
 
 
-def run_eval_and_return_metric(metric, eval_key, defs, runfile):
+def run_eval_and_return_metric(metric, eval_key, defs, runfile, display_command=False):
     eval_cmd = f'python -m pyserini.eval.trec_eval {defs} {eval_key} {runfile}'
+
+    if display_command:
+        print(f'\n```bash\n{eval_cmd}\n```\n')
+
     eval_stdout, eval_stderr = run_command(eval_cmd)
 
     for line in eval_stdout.split('\n'):

--- a/pyserini/2cr/atomic.py
+++ b/pyserini/2cr/atomic.py
@@ -225,8 +225,9 @@ def run_conditions(args):
                             if not os.path.exists(runfile):
                                 continue
                             
-                            score = float(run_eval_and_return_metric(metric, f'atomic.validation.{retrieval_type}',
-                                                                     trec_eval_metric_definitions[metric], runfile))
+                            score = float(run_eval_and_return_metric(metric,f'atomic.validation.{retrieval_type}',
+                                trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
+
                             if math.isclose(score, float(expected[metric])):
                                 result = ok_str
                             # If results are within 0.0005, just call it "OKish".

--- a/pyserini/2cr/beir.py
+++ b/pyserini/2cr/beir.py
@@ -293,7 +293,8 @@ def run_conditions(args):
                                 continue
 
                             score = float(run_eval_and_return_metric(metric, f'beir-v1.0.0-{dataset}-test',
-                                                                     trec_eval_metric_definitions[metric], runfile))
+                                trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
+
                             if math.isclose(score, float(expected[metric])):
                                 result = ok_str
                             # If results are within 0.0005, just call it "OKish".

--- a/pyserini/2cr/bright.py
+++ b/pyserini/2cr/bright.py
@@ -208,7 +208,8 @@ def run_conditions(args):
                                 continue
 
                             score = float(run_eval_and_return_metric(metric, f'bright-{dataset}',
-                                                                     trec_eval_metric_definitions[metric], runfile))
+                                trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
+
                             if math.isclose(score, float(expected[metric])):
                                 result = ok_str
                             # If results are within 0.005, just call it "OKish".

--- a/pyserini/2cr/ciral.py
+++ b/pyserini/2cr/ciral.py
@@ -287,8 +287,10 @@ def run_conditions(args):
                         if not args.skip_eval:
                             if not os.path.exists(runfile):
                                 continue
+
                             score = float(run_eval_and_return_metric(metric, f'{eval_key}-{split}',
-                                                                     trec_eval_metric_definitions[metric], runfile))
+                                trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
+
                             if math.isclose(score, float(expected[metric])):
                                 result_str = ok_str
                             else:

--- a/pyserini/2cr/dse.py
+++ b/pyserini/2cr/dse.py
@@ -119,7 +119,8 @@ def run_conditions(args):
                                 elif metric == 'Recall@10':
                                     trec_eval_metric = '-c -m recall.10'
                                 
-                                score = float(run_eval_and_return_metric(metric, dataset, trec_eval_metric, runfile)) * 100
+                                score = float(run_eval_and_return_metric(metric, dataset,
+                                    trec_eval_metric, runfile, display_command=args.display_commands)) * 100
 
 
                             if math.isclose(score, float(expected[metric]), abs_tol=0.1): 

--- a/pyserini/2cr/m_beir.py
+++ b/pyserini/2cr/m_beir.py
@@ -134,9 +134,10 @@ def run_conditions(args):
                                 if not args.skip_eval and not args.dry_run:  
                                     if not os.path.exists(runfile):  
                                         continue  
-                                    score = float(run_eval_and_return_metric(  
-                                        metric, "m-beir-" + sub_dataset.replace('_', '-'),  
-                                        trec_eval_metric_definitions[metric], runfile))  
+
+                                    score = float(run_eval_and_return_metric(metric, "m-beir-" + sub_dataset.replace('_', '-'),
+                                        trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
+
                                     if math.isclose(score, float(expected[metric])):  
                                         result = ok_str  
                                     elif abs(score - float(expected[metric])) <= 0.0005 or score > float(expected[metric]):  

--- a/pyserini/2cr/m_beir.py
+++ b/pyserini/2cr/m_beir.py
@@ -135,7 +135,7 @@ def run_conditions(args):
                                     if not os.path.exists(runfile):  
                                         continue  
 
-                                    score = float(run_eval_and_return_metric(metric, "m-beir-" + sub_dataset.replace('_', '-'),
+                                    score = float(run_eval_and_return_metric(metric, 'm-beir-' + sub_dataset.replace('_', '-'),
                                         trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
                                     if math.isclose(score, float(expected[metric])):  
@@ -164,9 +164,10 @@ def run_conditions(args):
                             if not args.skip_eval and not args.dry_run:  
                                 if not os.path.exists(runfile):  
                                     continue  
-                                score = float(run_eval_and_return_metric(  
-                                    metric, "m-beir-" + dataset.replace('_', '-'),  
-                                    trec_eval_metric_definitions[metric], runfile))  
+
+                                score = float(run_eval_and_return_metric(metric, 'm-beir-' + dataset.replace('_', '-'),
+                                    trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
+
                                 if math.isclose(score, float(expected[metric])):  
                                     result = ok_str  
                                 elif abs(score - float(expected[metric])) <= 0.0005 or score > float(expected[metric]):  

--- a/pyserini/2cr/miracl.py
+++ b/pyserini/2cr/miracl.py
@@ -387,7 +387,7 @@ def run_conditions(args):
                                 qrels = f'{eval_key}-{split}'
 
                             score = float(run_eval_and_return_metric(metric, qrels,
-                                                                     trec_eval_metric_definitions[metric], runfile))
+                                trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
                             if math.isclose(score, float(expected[metric])):
                                 result_str = ok_str

--- a/pyserini/2cr/mmeb.py
+++ b/pyserini/2cr/mmeb.py
@@ -144,10 +144,9 @@ def run_conditions(args):
                             if not os.path.exists(runfile):  
                                 continue  
                                   
-                            qrels_name = f"mmeb-visdoc-{dataset}-{get_split(dataset)}"
-                            score = float(run_eval_and_return_metric(  
-                                metric, qrels_name,
-                                trec_eval_metric_definitions[metric], runfile))  
+                            qrels_name = f'mmeb-visdoc-{dataset}-{get_split(dataset)}'
+                            score = float(run_eval_and_return_metric(metric, qrels_name,
+                                trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
                                   
                             if math.isclose(score, float(expected[metric])):  
                                 result = ok_str  

--- a/pyserini/2cr/mrtydi.py
+++ b/pyserini/2cr/mrtydi.py
@@ -272,7 +272,7 @@ def run_conditions(args):
                                 continue
 
                             score = float(run_eval_and_return_metric(metric, f'{eval_key}-{split}',
-                                                                     trec_eval_metric_definitions[metric], runfile))
+                                trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
                             if math.isclose(score, float(expected[metric])):
                                 result_str = ok_str

--- a/pyserini/2cr/msmarco.py
+++ b/pyserini/2cr/msmarco.py
@@ -583,12 +583,9 @@ def run_conditions(args):
                             if not os.path.exists(runfile):
                                 continue
 
-                            score = float(
-                                run_eval_and_return_metric(
-                                    metric,
-                                    eval_key,
-                                    trec_eval_metric_definitions[args.collection][eval_key][metric],
-                                    runfile))
+                            score = float(run_eval_and_return_metric(metric, eval_key,
+                                    trec_eval_metric_definitions[args.collection][eval_key][metric], runfile, display_command=args.display_commands))
+
                             if math.isclose(score, float(expected[metric])):
                                 result_str = ok_str
                             # If results are within 0.0005, just call it "OKish".


### PR DESCRIPTION
Currently, we only print out the retrieval command if `--display-commands` is set. With this patch, we print out the eval command also.
