### PR TITLE
Add reproduction log for BM25 baseline on MS MARCO passage (Pyserini)

### DIFF
--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -514,3 +514,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Zixi-Sam-Tang](https://github.com/Zixi-Sam-Tang) on 2026-04-22 (commit [`b823fb0`](https://github.com/castorini/pyserini/commit/b823fb0af8c48e5a5163949dd499271336fe8f63))
 + Results reproduced by [@alex-wang101](https://github.com/alex-wang101) on 2026-04-25 (commit [`e9cd125`](https://github.com/castorini/pyserini/commit/e9cd1250b2fafa2b806fdb1214c121b2c6e991a7))
 + Results reproduced by [@Seun-Ajayi](https://github.com/Seun-Ajayi) on 2026-04-26 (commit [`1f12c67`](https://github.com/castorini/pyserini/commit/1f12c6760c95f36f87757d3efa0e3a7a7f2d9fc8))
++ Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))


### PR DESCRIPTION
## Reproduction of BM25 Baseline for MS MARCO Passage Ranking (Pyserini)

### Environment
- OS: Ubuntu 22.04
- Python: 3.12
- Java: OpenJDK 21
- Pyserini: latest (via pip install pyserini)
- Anserini: cloned and built from source

### Results
| Metric      | Expected  | Achieved  |
|-------------|-----------|-----------|
| MRR@10      | 0.1874    | 0.1874    |
| MAP         | —         | 0.1958    |
| recall@1000 | —         | 0.8573    |

### Notes
- Commands used follow the official guide: `docs/experiments-msmarco-passage.md`
- Index built using `SimpleSearchCollection` with default BM25 parameters (k1=0.9, b=0.4)
- Evaluation run on `msmarco-test.tsv` queries (6980 queries)
- `trec_eval` used for metrics computation
- Reproduction log entry added to guide page