### PR TITLE
[codex] Add Pyserini uv install skill

### DIFF
--- a/.agents/skills/install-pyserini-dev/SKILL.md
+++ b/.agents/skills/install-pyserini-dev/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: install-pyserini-dev
+description: Use this skill when the user wants to clone Pyserini from GitHub for local development, install Pyserini from source with pip editable mode using `pip install -e .`, create or reuse a development environment, install optional development extras, or debug source-checkout installation issues involving Python, Java, Git, pip, PyPI, or editable installs.
+---
+
+# Install Pyserini For Development
+
+## Purpose
+
+Clone Pyserini, install the checkout in editable mode with `python -m pip install -e .`, verify Python/Java prerequisites, and run smoke tests before handing the development environment back to the user.
+
+## Core Workflow
+
+1. Choose the checkout location:
+   - If the user named a target directory, use it.
+   - If the current directory already looks like a Pyserini checkout, do not clone over it; install from that checkout instead.
+   - If no target was specified, create or use a clear project directory such as `pyserini-dev`.
+   - Do not overwrite an existing non-empty directory without reading it first.
+
+2. Verify tools and prerequisites:
+   ```bash
+   git --version
+   python3 --version
+   java -version
+   ```
+   Pyserini depends on Anserini/Lucene and may require a specific Java version. Check current Pyserini docs or repository metadata before treating a Java version mismatch as acceptable.
+
+3. Clone Pyserini when needed:
+   ```bash
+   git clone https://github.com/castorini/pyserini.git pyserini-dev
+   cd pyserini-dev
+   ```
+   If the user needs their fork or a specific branch, clone or check out that requested remote or branch instead. Use normal `git fetch`, `git pull`, or `git checkout`; never force-update a user checkout.
+
+4. Inspect project metadata before installing:
+   ```bash
+   python3 -m pip --version
+   python3 -c "import sys; print(sys.version)"
+   ```
+   Read `pyproject.toml`, `setup.py`, or installation docs if present before selecting Python versions, extras, or dependency groups.
+
+5. Create or reuse a Python environment:
+   - If the user requested an existing environment, target it explicitly.
+   - Otherwise prefer a checkout-local virtualenv:
+     ```bash
+     python3 -m venv .venv
+     source .venv/bin/activate
+     python -m pip install --upgrade pip
+     ```
+   - If the user requested Python 3.12 or project metadata requires it, create the environment with that interpreter:
+     ```bash
+     python3.12 -m venv .venv
+     ```
+
+6. Install Pyserini in editable mode:
+   ```bash
+   python -m pip install -e .
+   ```
+   If optional extras are requested, verify the extras names from current project metadata first, then install with:
+   ```bash
+   python -m pip install -e ".[EXTRA]"
+   ```
+
+7. Run smoke tests:
+   ```bash
+   python -c "import sys, importlib.metadata as m; import pyserini; print(sys.version.split()[0]); print(m.version('pyserini')); print('pyserini editable import ok')"
+   python -c "from pyserini.search.lucene import LuceneSearcher; print('LuceneSearcher import ok')"
+   ```
+   The Lucene import may take tens of seconds while the JVM starts. Warnings about `jdk.incubator.vector` or invalid escape sequences in Pyserini internals are not install failures if the command exits successfully.
+
+8. Report the exact commands run, checkout path, active branch and commit, Python version, Java version, installed Pyserini version, environment path, and any skipped verification.
+
+## Command Choices
+
+Use `python -m pip`, not bare `pip`, so installation targets the intended interpreter.
+
+Use `pip install -e .` when the user wants source edits to be reflected without reinstalling.
+
+Use `pip install -e ".[EXTRA]"` only after verifying that the requested extra exists in current project metadata.
+
+Use a checkout-local `.venv` for a self-contained development setup unless the user asks to reuse another environment.
+
+Use a fork remote when the user plans to contribute from their fork; otherwise clone `https://github.com/castorini/pyserini.git`.
+
+## Troubleshooting
+
+- If Java is missing or too old, install a compatible JDK before retrying Pyserini.
+- If Python is too old for current Pyserini metadata, create a fresh environment with a compatible interpreter.
+- If editable install dependency resolution fails, inspect current project metadata and retry in a fresh virtualenv before mutating a broken environment in place.
+- If imports resolve to a different Pyserini installation, check `python -c "import pyserini; print(pyserini.__file__)"` and reinstall into the intended environment.
+- If optional extras fail, install the core editable package first, then add optional packages separately only if the requested workflow needs them.
+- If a Conda environment is already active and should be reused, target it explicitly with that environment's Python rather than creating `.venv`.
+
+## Safety Notes
+
+Ask for approval before installing missing system tools, downloading large dependencies, or modifying shell startup files. Do not download large indexes or models unless the user asked for functional retrieval verification or explicitly approved downloads. Do not remove an existing checkout, `.venv`, lockfile, or dependency pin unless the user requested a reset.

--- a/.agents/skills/install-pyserini-dev/agents/openai.yaml
+++ b/.agents/skills/install-pyserini-dev/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Install Pyserini for dev"
+  short_description: "Clone Pyserini and install it editable"
+  default_prompt: "Use $install-pyserini-dev to clone Pyserini and install it with pip install -e ."

--- a/.agents/skills/install-pyserini-uv/SKILL.md
+++ b/.agents/skills/install-pyserini-uv/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: install-pyserini-uv
+description: Use this skill when the user wants to install Pyserini with uv, create a uv-managed environment for Pyserini, add Pyserini to an existing uv project, install optional Pyserini extras, or debug uv/Pyserini installation issues involving Python, Java, PyPI, or dependency resolution.
+---
+
+# Install Pyserini With uv
+
+## Purpose
+
+Install Pyserini in a uv-managed Python environment, verify Java/Python prerequisites, and run smoke tests before handing the environment back to the user.
+
+## Core Workflow
+
+1. Inspect the current directory:
+   - If `pyproject.toml` exists, treat it as an existing uv project.
+   - If no project exists, create one with `uv init` or create only a virtualenv with `uv venv`, depending on the user's goal.
+   - Do not overwrite project metadata without reading it first.
+
+2. Verify tools and prerequisites:
+   ```bash
+   uv --version || python -m uv --version
+   java -version
+   ```
+   If `uv` is not installed, ask for approval before installing it. If the user does not want uv installed, use the pip fallback below. Prefer `python -m uv` when uv is installed into a user site but the `uv` binary is not on `PATH`. Pyserini depends on Anserini/Lucene and currently expects Java 21.
+
+3. Check current PyPI metadata before choosing versions:
+   ```bash
+   curl -sS https://pypi.org/pypi/pyserini/json
+   ```
+   As of Pyserini 2.0.0, `requires_python` is `>=3.12`, and project docs say it is built on Python 3.12 and Java 21. Use current metadata if it differs.
+
+4. Create a uv environment. Prefer a simple project-local `.venv`:
+   ```bash
+   uv venv .venv --python 3.12
+   ```
+   For sandboxed or workspace-local installs, keep uv state under the workspace:
+   ```bash
+   python -m uv python install 3.12 --install-dir .uv-python --cache-dir .uv-cache
+   python -m uv venv .venv --python 3.12 --cache-dir .uv-cache
+   ```
+   If `uv venv --python 3.12` cannot discover the workspace-local interpreter, find it and pass the explicit path:
+   ```bash
+   find .uv-python -name 'python3.12' -print
+   python -m uv venv .venv --python PATH_FROM_FIND --cache-dir .uv-cache
+   ```
+
+5. Install Pyserini:
+   - Existing uv project:
+     ```bash
+     uv add pyserini
+     ```
+   - Existing environment without project metadata, or workspace-local `.venv`:
+     ```bash
+     python -m uv pip install pyserini --python .venv --cache-dir .uv-cache
+     ```
+   - If the user asked for reproducibility or a specific version, pin the verified version explicitly:
+     ```bash
+     python -m uv pip install pyserini==VERSION --python .venv --cache-dir .uv-cache
+     ```
+   - Optional dependencies when requested:
+     ```bash
+     uv add "pyserini[optional]"
+     ```
+     or:
+     ```bash
+     python -m uv pip install "pyserini[optional]" --python .venv --cache-dir .uv-cache
+     ```
+
+6. Run smoke tests:
+   ```bash
+   python -m uv run --no-project --python .venv/bin/python --cache-dir .uv-cache python -c "import sys, importlib.metadata as m; import pyserini; print(sys.version.split()[0]); print(m.version('pyserini')); print('pyserini import ok')"
+   python -m uv run --no-project --python .venv/bin/python --cache-dir .uv-cache python -c "from pyserini.search.lucene import LuceneSearcher; print('LuceneSearcher import ok')"
+   ```
+   The Lucene import may take tens of seconds while the JVM starts. Warnings about `jdk.incubator.vector` or invalid escape sequences in Pyserini internals are not install failures if the command exits successfully.
+
+7. Report the exact commands run, Python version, Java version, installed Pyserini version, environment path, and any skipped verification.
+
+## pip Fallback
+
+Use this only when uv is unavailable and the user does not want it installed:
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install pyserini
+python -c "import sys, importlib.metadata as m; import pyserini; print(sys.version.split()[0]); print(m.version('pyserini')); print('pyserini import ok')"
+python -c "from pyserini.search.lucene import LuceneSearcher; print('LuceneSearcher import ok')"
+```
+
+Keep using `python -m pip`, not bare `pip`, so installation targets the intended interpreter.
+
+## Command Choices
+
+Use `uv add` when the install should become part of a project and update `pyproject.toml` / `uv.lock`.
+
+Use `uv pip install` when the user only wants to populate the active `.venv` or avoid changing project files.
+
+Use `python -m uv` when `uv` was installed into a user site but its script directory is not on `PATH`.
+
+Use `--cache-dir .uv-cache` when the default uv cache under the user's home directory is not writable or when the user wants workspace-local state.
+
+Use `uv sync` after editing dependencies manually or when the repo already has a lockfile.
+
+Use `uv run ...` for verification so commands execute inside the uv-managed environment.
+
+Do not require Conda or Mamba for the default install. Mention Conda/Mamba only when the user needs a binary stack that is better managed through Conda channels, such as CUDA-specific PyTorch, Faiss variants, or cluster-standard environments. In those cases, Conda/Mamba can provide Python and binary packages, while `uv pip install` can still install PyPI packages into that environment.
+
+## Troubleshooting
+
+- If Java is missing or too old, install a compatible JDK before retrying Pyserini.
+- If dependency resolution fails, check Pyserini's current PyPI metadata and extras names before pinning anything.
+- If `uv` fails with `Failed to initialize cache` under `~/.cache/uv`, rerun the command with `--cache-dir .uv-cache`.
+- If `uv` is installed but `command -v uv` returns nothing, use `python -m uv` or add the user script directory, often `~/.local/bin`, to `PATH`.
+- If optional dependencies fail, try core `pyserini` first, then install `faiss-cpu` or other optional packages separately only if the requested workflow needs them.
+- If the environment already contains conflicting packages, create a fresh uv virtualenv and reinstall rather than mutating a broken environment in place.
+- If `uv add pyserini` or `uv pip install pyserini` pulls a large dependency set, including PyTorch, Transformers, ONNX Runtime, and PyArrow, that is expected for recent Pyserini releases.
+- If a Conda environment is already active and should be reused, target it explicitly with `uv pip install --python "$CONDA_PREFIX/bin/python" pyserini` to avoid installing into the wrong interpreter.
+
+## Safety Notes
+
+Do not run commands that download large indexes or models unless the user asked for functional retrieval verification or explicitly approved downloads. Do not remove an existing `.venv`, lockfile, or dependency pin unless the user requested a reset.

--- a/.agents/skills/install-pyserini-uv/SKILL.md
+++ b/.agents/skills/install-pyserini-uv/SKILL.md
@@ -18,10 +18,10 @@ Install Pyserini in a uv-managed Python environment, verify Java/Python prerequi
 
 2. Verify tools and prerequisites:
    ```bash
-   uv --version || python -m uv --version
+   uv --version
    java -version
    ```
-   If `uv` is not installed, ask for approval before installing it. If the user does not want uv installed, use the pip fallback below. Prefer `python -m uv` when uv is installed into a user site but the `uv` binary is not on `PATH`. Pyserini depends on Anserini/Lucene and currently expects Java 21.
+   If the `uv` binary is not on `PATH`, check `python -c "import uv"` before trying `python -m uv --version`. If `uv` is not installed, ask for approval before installing it. If the user does not want uv installed, use the pip fallback below. Prefer the `uv` binary when it is available; use `python -m uv` only after confirming the `uv` Python module is importable and the binary is not on `PATH`. Pyserini depends on Anserini/Lucene and currently expects Java 21.
 
 3. Check current PyPI metadata before choosing versions:
    ```bash
@@ -35,13 +35,13 @@ Install Pyserini in a uv-managed Python environment, verify Java/Python prerequi
    ```
    For sandboxed or workspace-local installs, keep uv state under the workspace:
    ```bash
-   python -m uv python install 3.12 --install-dir .uv-python --cache-dir .uv-cache
-   python -m uv venv .venv --python 3.12 --cache-dir .uv-cache
+   uv python install 3.12 --install-dir .uv-python --cache-dir .uv-cache
+   uv venv .venv --python 3.12 --cache-dir .uv-cache
    ```
    If `uv venv --python 3.12` cannot discover the workspace-local interpreter, find it and pass the explicit path:
    ```bash
    find .uv-python -name 'python3.12' -print
-   python -m uv venv .venv --python PATH_FROM_FIND --cache-dir .uv-cache
+   uv venv .venv --python PATH_FROM_FIND --cache-dir .uv-cache
    ```
 
 5. Install Pyserini:
@@ -51,11 +51,11 @@ Install Pyserini in a uv-managed Python environment, verify Java/Python prerequi
      ```
    - Existing environment without project metadata, or workspace-local `.venv`:
      ```bash
-     python -m uv pip install pyserini --python .venv --cache-dir .uv-cache
+     uv pip install pyserini --python .venv --cache-dir .uv-cache
      ```
    - If the user asked for reproducibility or a specific version, pin the verified version explicitly:
      ```bash
-     python -m uv pip install pyserini==VERSION --python .venv --cache-dir .uv-cache
+     uv pip install pyserini==VERSION --python .venv --cache-dir .uv-cache
      ```
    - Optional dependencies when requested:
      ```bash
@@ -63,13 +63,13 @@ Install Pyserini in a uv-managed Python environment, verify Java/Python prerequi
      ```
      or:
      ```bash
-     python -m uv pip install "pyserini[optional]" --python .venv --cache-dir .uv-cache
+     uv pip install "pyserini[optional]" --python .venv --cache-dir .uv-cache
      ```
 
 6. Run smoke tests:
    ```bash
-   python -m uv run --no-project --python .venv/bin/python --cache-dir .uv-cache python -c "import sys, importlib.metadata as m; import pyserini; print(sys.version.split()[0]); print(m.version('pyserini')); print('pyserini import ok')"
-   python -m uv run --no-project --python .venv/bin/python --cache-dir .uv-cache python -c "from pyserini.search.lucene import LuceneSearcher; print('LuceneSearcher import ok')"
+   uv run --no-project --python .venv/bin/python --cache-dir .uv-cache python -c "import sys, importlib.metadata as m; import pyserini; print(sys.version.split()[0]); print(m.version('pyserini')); print('pyserini import ok')"
+   uv run --no-project --python .venv/bin/python --cache-dir .uv-cache python -c "from pyserini.search.lucene import LuceneSearcher; print('LuceneSearcher import ok')"
    ```
    The Lucene import may take tens of seconds while the JVM starts. Warnings about `jdk.incubator.vector` or invalid escape sequences in Pyserini internals are not install failures if the command exits successfully.
 
@@ -96,7 +96,7 @@ Use `uv add` when the install should become part of a project and update `pyproj
 
 Use `uv pip install` when the user only wants to populate the active `.venv` or avoid changing project files.
 
-Use `python -m uv` when `uv` was installed into a user site but its script directory is not on `PATH`.
+Use `python -m uv` only when `uv` was installed into a user site, its script directory is not on `PATH`, and `python -c "import uv"` succeeds.
 
 Use `--cache-dir .uv-cache` when the default uv cache under the user's home directory is not writable or when the user wants workspace-local state.
 
@@ -111,7 +111,7 @@ Do not require Conda or Mamba for the default install. Mention Conda/Mamba only 
 - If Java is missing or too old, install a compatible JDK before retrying Pyserini.
 - If dependency resolution fails, check Pyserini's current PyPI metadata and extras names before pinning anything.
 - If `uv` fails with `Failed to initialize cache` under `~/.cache/uv`, rerun the command with `--cache-dir .uv-cache`.
-- If `uv` is installed but `command -v uv` returns nothing, use `python -m uv` or add the user script directory, often `~/.local/bin`, to `PATH`.
+- If `uv` is installed but `command -v uv` returns nothing, either add the user script directory, often `~/.local/bin`, to `PATH`, or use `python -m uv` only after `python -c "import uv"` succeeds.
 - If optional dependencies fail, try core `pyserini` first, then install `faiss-cpu` or other optional packages separately only if the requested workflow needs them.
 - If the environment already contains conflicting packages, create a fresh uv virtualenv and reinstall rather than mutating a broken environment in place.
 - If `uv add pyserini` or `uv pip install pyserini` pulls a large dependency set, including PyTorch, Transformers, ONNX Runtime, and PyArrow, that is expected for recent Pyserini releases.

--- a/.agents/skills/install-pyserini-uv/agents/openai.yaml
+++ b/.agents/skills/install-pyserini-uv/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Install Pyserini with uv"
+  short_description: "Set up Pyserini in a uv-managed env"
+  default_prompt: "Use $install-pyserini-uv to install Pyserini with uv and verify the environment."


### PR DESCRIPTION
## Summary

- Add a local Codex skill for installing Pyserini with `uv`.
- Add a counterpart local Codex skill for cloning Pyserini and installing it in editable development mode with `pip install -e .`.
- Include OpenAI agents UI metadata for both skills.

## Validation

- `python /Users/jimmylin/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/install-pyserini-uv`
- `python /Users/jimmylin/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/install-pyserini-dev`

Validation note: these commands were attempted locally but failed because the current Python environment is missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`). Both skills were manually checked against the validator's structural rules: required `SKILL.md`, valid frontmatter, valid hyphen-case names, and matching `agents/openai.yaml`.