### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/repro/bm25-msmarco.md
+++ b/docs/repro/bm25-msmarco.md
@@ -1,0 +1,18 @@
+
+## BM25 MS MARCO Reproduction
+
+Environment:
+- WSL2 Ubuntu
+- Pyserini
+- Java 21
+
+Result:
+MRR@10 = 0.1874
+
+Notes:
+- Installed Java manually
+- Fixed Pyserini environment issues
+- Learned MS MARCO evaluation pipeline
+
+
+

--- a/docs/repro/bm25-msmarco.md
+++ b/docs/repro/bm25-msmarco.md
@@ -1,4 +1,16 @@
+## Commands Used
 
+```bash
+python -m pyserini.search.lucene \
+  --index msmarco-passage \
+  --bm25 \
+  --topics msmarco-passage-dev-subset \
+  --output run.txt \
+  --output-format msmarco
+
+python -m pyserini.eval.msmarco_passage_eval \
+  msmarco-passage-dev-subset run.txt
+```
 ## BM25 MS MARCO Reproduction
 
 Environment:


### PR DESCRIPTION
This PR adds a reproduction log for the BM25 baseline on the MS MARCO passage dataset using Pyserini.

Environment:
- WSL2 Ubuntu
- Python virtual environment
- Java 21

Result:
MRR@10 = 0.1874

Notes:
- Installed Java manually
- Resolved Python environment (PEP 668) issues
- Successfully ran end-to-end retrieval and evaluation pipeline