### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -476,3 +476,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@tqmsh](https://github.com/tqmsh) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -733,3 +733,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@tqmsh](https://github.com/tqmsh) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -219,3 +219,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@tqmsh](https://github.com/tqmsh) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -512,3 +512,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@tqmsh](https://github.com/tqmsh) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -520,3 +520,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@tqmsh](https://github.com/tqmsh) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))


### PR DESCRIPTION
Adding myself to the reproduction logs for lessons 4 through 8.

Environment:
- Started L4 on macOS, moved to Ubuntu 24.04 (Vast.ai) for the rest because of disk constraints on the laptop
- Python 3.12, Java 21
- Pyserini master @ b0bf30c, Anserini master @ deb4c7b

L4 (experiments-msmarco-passage.md): BM25 in Pyserini on the freshly rebuilt MS MARCO index (~3 min to index 8,841,823 docs). k1=0.82, b=0.68. MRR@10 = 0.18741227770955546, bit-exact to what I got Anserini-side. MAP = 0.1958 vs the doc's 0.1957 — same ranking, that 1e-4 drop is probably the Anserini 2.0.0 fatjar that ships with Pyserini PyPI vs the 2.0.1-SNAPSHOT I built on master. R@1000 = 0.8573 matches.

L5 (conceptual-framework.md): Did the BM25-as-bi-encoder walkthrough for qid 1048585, doc 7187158. The NumPy and dict inner products both come out to 17.949487686157227 — exact. Pyserini's searcher reports 17.949499... for the same query, which is just float-summation ordering between the two code paths.

L6 (experiments-nfcorpus.md): BGE-base-en-v1.5 over all 3,633 NFCorpus docs. Had to encode on CPU because pip pulled torch 2.12 which expects CUDA 13, but the box only has driver 12.8, so torch silently fell back. nDCG@10 = 0.3808, matches.

L7 (conceptual-framework2.md): BM25 NFCorpus, title+text concatenated into one `contents` field. nDCG@10 = 0.3218 matches. Also did the dense-side verification — reconstructing vectors from the Faiss index, computing q·d by hand against the brute-force result. Numbers line up.

L8 (conceptual-framework3.md): SPLADE-v3 on NFCorpus. CPU encoding took roughly 17 min for the 3,633 docs across ~13 cores. nDCG@10 = 0.3624, matches.

Notes:

1. None of the Pyserini CLI commands worked for me on first run — every `python -m pyserini.search.lucene ...` or `pyserini.index.lucene` raised `ClassNotFoundException: org.apache.lucene.analysis.Analyzer`. Pretty sure jnius is initializing the JVM before `pyserini.pyclass` gets to call `jnius_config.set_classpath(...)`, so the JVM never sees the bundled fatjar. Setting `CLASSPATH=...anserini-2.0.0-fatjar.jar` explicitly before each command fixed it. Can file an issue if that's useful, didn't want to assume it isn't environment-specific.

2. `pyserini.encode._openai` does an unguarded `openai.OpenAI()` at module load. Any `python -m pyserini.*` import fails with OpenAIError if `OPENAI_API_KEY` isn't set, even when nothing OpenAI-related is being called. Worked around with a dummy value. Probably a one-line move to a lazy import.

3. The eval invocation from L4 (`python -m pyserini.eval.msmarco_passage_eval tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt ...`) raises FileNotFoundError — Pyserini is treating the path as an alias instead of a file. Calling the underlying anserini-tools script directly worked, that's what produced the MRR@10 I'm reporting.

4. naver/splade-v3 is a gated HF model, so the first run got a 401 and the second got a 403 once the token was set. Accepting the license on the model page unblocked it. A one-liner in conceptual-framework3.md would save the next person a few minutes.
