### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -477,3 +477,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`e5d3a4a`](https://github.com/castorini/pyserini/commit/e5d3a4ae89c1da8a2ada97293278cd1f7142ee58))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -734,3 +734,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`e5d3a4a`](https://github.com/castorini/pyserini/commit/e5d3a4ae89c1da8a2ada97293278cd1f7142ee58))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -220,3 +220,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`e5d3a4a`](https://github.com/castorini/pyserini/commit/e5d3a4ae89c1da8a2ada97293278cd1f7142ee58))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -513,3 +513,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`e5d3a4a`](https://github.com/castorini/pyserini/commit/e5d3a4ae89c1da8a2ada97293278cd1f7142ee58))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -521,3 +521,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`6adee73`](https://github.com/castorini/pyserini/commit/6adee73cf36255056a1c46dc5ecdb4b29b9ce1c5))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-04 (commit [`7ed1f31`](https://github.com/castorini/pyserini/commit/7ed1f31e74db66e75c41f5f95b92f5ccfeaced31))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`b0bf30c`](https://github.com/castorini/pyserini/commit/b0bf30c9352e3dece016499840ef635fff5e98f3))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`e5d3a4a`](https://github.com/castorini/pyserini/commit/e5d3a4ae89c1da8a2ada97293278cd1f7142ee58))


### PR DESCRIPTION
## Summary

Reproduced both Pyserini onboarding experiments end-to-end on macOS:

- `docs/experiments-msmarco-passage.md` — BM25 baseline on MS MARCO Passage (Lucene via pyjnius), plus interactive retrieval with `LuceneSearcher`.
- `docs/experiments-nfcorpus.md` — BGE-base-en-v1.5 dense baseline on NFCorpus (CPU encoding + Faiss flat index).

## Results

| Doc | Metric | My result | Published target |
|---|---|---|---|
| `experiments-msmarco-passage.md` | MRR@10 (`pyserini.eval.msmarco_passage_eval`) | `0.18741227770955546` | `0.18741227770955546` |
| `experiments-msmarco-passage.md` | MAP (`pyserini.eval.trec_eval`) | `0.1958` | `0.1957` *(see note)* |
| `experiments-msmarco-passage.md` | Recall@1000 (`pyserini.eval.trec_eval`) | `0.8573` | `0.8573` |
| `experiments-msmarco-passage.md` | per-qid 1048585 MRR | `1.0000` | `1.0000` |
| `experiments-nfcorpus.md` | nDCG@10 (`pyserini.eval.trec_eval`) | `0.3808` | `0.3808` |

*Note on MAP*: I got `0.1958` versus the documented `0.1957`. This is a 1-in-2000 difference and almost certainly comes from a Lucene scoring-tie tie-breaking change (the included Anserini fatjar I built is `2.1.1-SNAPSHOT` with Lucene 10.4.0). Anserini's own `experiments-msmarco-passage.md` reports MAP `0.1957` only because that doc converts MS MARCO format → TREC format first, which is lossy on score ties; doing search directly in TREC format here gets one rank-tie resolved differently. The headline MRR@10 is bit-exact, so the retrieval pipeline is correct.

## Environment

- macOS 26.2 (Darwin 25.2.0), Apple Silicon (arm64), 16 GB RAM
- Python 3.12.7 in a fresh venv
- OpenJDK 21.0.11 (Homebrew `openjdk@21`)
- `pip install -e .` for Pyserini (commit `e5d3a4a`)
- `faiss-cpu==1.13.2`
- `torch==2.12.0`, `transformers==5.8.1`, `onnxruntime==1.26.0`, `pyjnius==1.7.0`
- Anserini fatjar: built locally from `castorini/anserini` at commit `4d16490` (i.e. `anserini-2.1.1-SNAPSHOT-fatjar.jar`, Lucene 10.4.0), copied into `pyserini/pyserini/resources/jars/`
- `trec_eval` 9.0.4 and `ndeval` built from `tools/eval/`

## Issues encountered and workarounds

**1. macOS JDK home for pyjnius.** On macOS, the Homebrew `openjdk@21` formula puts the actual JDK home at `/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home/`, not at `/opt/homebrew/opt/openjdk@21/` itself. With `JAVA_HOME` set to the brew root, pyjnius cannot locate `libjvm.dylib` (it only probes `<JAVA_HOME>/{jre/lib/jli,lib/jli,lib}/libjli.dylib`). Setting `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home` and `JVM_PATH=$JAVA_HOME/lib/server/libjvm.dylib` fixed it. May be worth adding a note to `docs/installation.md`'s macOS section.

**2. Dev-install fatjar path.** `docs/installation.md#development-installation` says to copy the Anserini fatjar into `pyserini/resources/jars/`. The actual lookup in `pyserini/pyclass.py` is relative to the Python package (`os.path.split(__file__)[0]`), i.e. `pyserini/pyserini/resources/jars/`. Putting the fatjar into the outer `resources/jars/` doesn't work. Disambiguating this in the docs would save the next reproducer a few minutes.

**3. OpenMP segfault during Faiss search.** `pyserini.search.faiss` segfaulted in `libomp.dylib` (`__kmp_suspend_64`) when run as-is on macOS. This is the classic conflict where multiple OpenMP runtimes (one from PyTorch / Faiss, another loaded into the JVM via pyjnius) collide. The fix:

```bash
export KMP_DUPLICATE_LIB_OK=TRUE
export OMP_NUM_THREADS=1
```

The dense retrieval section of `experiments-nfcorpus.md` runs cleanly with these set. A note in the doc — or setting these defaults inside `pyserini.search.faiss` on macOS — would prevent the segfault for future macOS reproducers.

**4. Memory cap during indexing.** With 16 GB RAM the default `--threads 9` and unbounded JVM heap caused macOS to OOM-kill the indexer (same as in the Anserini reproduction). Using `--threads 3` and `_JAVA_OPTIONS=-Xmx8G` lets indexing complete in 2m11s for 8,841,823 documents.

## Outcome

Everything worked end-to-end. The headline metrics (MRR@10 for MS MARCO Passage BM25, nDCG@10 for NFCorpus dense) reproduce exactly. Interactive retrieval with `LuceneSearcher` and `FaissSearcher` works as documented.