### PR TITLE
[codex] Add shared temporary environment helper

### DIFF
--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import os
 from typing import List, Optional
 
 import torch
@@ -30,6 +29,7 @@ from transformers import __version__ as transformers_version
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
 from pyserini.encode._base import load_head_weights
+from pyserini.util import temporary_env
 
 
 class AnceEncoder(PreTrainedModel):
@@ -85,15 +85,8 @@ class AnceEncoder(PreTrainedModel):
     
     @classmethod
     def load_pretrained_encoder(cls, model_name_or_path: str, device: str):
-        previous_disable_conversion = os.environ.get('DISABLE_SAFETENSORS_CONVERSION')
-        os.environ['DISABLE_SAFETENSORS_CONVERSION'] = '1'
-        try:
+        with temporary_env(DISABLE_SAFETENSORS_CONVERSION='1'):
             model = cls.from_pretrained(model_name_or_path, use_safetensors=False)
-        finally:
-            if previous_disable_conversion is None:
-                del os.environ['DISABLE_SAFETENSORS_CONVERSION']
-            else:
-                os.environ['DISABLE_SAFETENSORS_CONVERSION'] = previous_disable_conversion
         if Version(transformers_version) >= Version("5.0.0"):
             load_head_weights(model, model_name_or_path, {
                 'embeddingHead': ['ance_encoder.embeddingHead', 'embeddingHead'],

--- a/pyserini/encode/_splade.py
+++ b/pyserini/encode/_splade.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import os
 from abc import ABC, abstractmethod
 from typing import Dict, List
 
@@ -23,21 +22,15 @@ import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.util import temporary_env
 
 
 def _from_pretrained_without_safetensors_conversion(model_name_or_path):
     # Some SPLADE checkpoints, such as naver/splade-v3, only publish PyTorch
     # weights. Newer Transformers versions still load them successfully, but
     # then spawn a background safetensors conversion thread that can fail noisily.
-    previous_disable_conversion = os.environ.get('DISABLE_SAFETENSORS_CONVERSION')
-    os.environ['DISABLE_SAFETENSORS_CONVERSION'] = '1'
-    try:
+    with temporary_env(DISABLE_SAFETENSORS_CONVERSION='1'):
         return AutoModelForMaskedLM.from_pretrained(model_name_or_path, use_safetensors=False)
-    finally:
-        if previous_disable_conversion is None:
-            del os.environ['DISABLE_SAFETENSORS_CONVERSION']
-        else:
-            os.environ['DISABLE_SAFETENSORS_CONVERSION'] = previous_disable_conversion
 
 
 class SpladeEncoder(ABC):

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import hashlib
 import importlib
 import logging
@@ -34,6 +36,26 @@ from pyserini.prebuilt_index_info import TF_INDEX_INFO, IMPACT_INDEX_INFO, \
     LUCENE_HNSW_INDEX_INFO, LUCENE_FLAT_INDEX_INFO, FAISS_INDEX_INFO
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def temporary_env(**env_vars: str | None) -> Iterator[None]:
+    previous_values = {key: os.environ.get(key) for key in env_vars}
+
+    for key, value in env_vars.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    try:
+        yield
+    finally:
+        for key, previous_value in previous_values.items():
+            if previous_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous_value
 
 
 def _archive_name_to_index_name(archive_name):

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -22,7 +22,13 @@ import unittest
 from unittest.mock import patch
 
 from pyserini.prebuilt_index_info import TF_INDEX_INFO
-from pyserini.util import download_url, download_and_unpack_index, compare_trec_strings_with_tolerance, compare_trec_files_with_tolerance
+from pyserini.util import (
+    compare_trec_files_with_tolerance,
+    compare_trec_strings_with_tolerance,
+    download_and_unpack_index,
+    download_url,
+    temporary_env,
+)
 
 
 class TestIterateCollection(unittest.TestCase):
@@ -104,6 +110,44 @@ class TestIterateCollection(unittest.TestCase):
             self.assertTrue(os.path.isdir(index_path), f"Index path missing: {index_path}")
             self.assertTrue(os.path.exists(os.path.join(index_path, 'marker.txt')))
             self.assertFalse(os.path.exists(os.path.join(cache_dir, 'indexes', 'plain-index.tar')))
+
+
+class TestTemporaryEnv(unittest.TestCase):
+    def test_temporary_env_sets_and_restores_missing_variable(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PYSERINI_TEST_ENV', None)
+
+            with temporary_env(PYSERINI_TEST_ENV='temporary'):
+                self.assertEqual(os.environ['PYSERINI_TEST_ENV'], 'temporary')
+
+            self.assertNotIn('PYSERINI_TEST_ENV', os.environ)
+
+    def test_temporary_env_restores_existing_variable(self):
+        with patch.dict(os.environ, {'PYSERINI_TEST_ENV': 'original'}, clear=False):
+            with temporary_env(PYSERINI_TEST_ENV='temporary'):
+                self.assertEqual(os.environ['PYSERINI_TEST_ENV'], 'temporary')
+
+            self.assertEqual(os.environ['PYSERINI_TEST_ENV'], 'original')
+
+    def test_temporary_env_can_remove_variable_temporarily(self):
+        with patch.dict(os.environ, {'PYSERINI_TEST_ENV': 'original'}, clear=False):
+            with temporary_env(PYSERINI_TEST_ENV=None):
+                self.assertNotIn('PYSERINI_TEST_ENV', os.environ)
+
+            self.assertEqual(os.environ['PYSERINI_TEST_ENV'], 'original')
+
+    def test_temporary_env_restores_multiple_variables_after_exception(self):
+        with patch.dict(os.environ, {'PYSERINI_TEST_ENV': 'original'}, clear=False):
+            os.environ.pop('PYSERINI_TEST_OTHER_ENV', None)
+
+            with self.assertRaises(RuntimeError):
+                with temporary_env(PYSERINI_TEST_ENV='temporary', PYSERINI_TEST_OTHER_ENV='other'):
+                    self.assertEqual(os.environ['PYSERINI_TEST_ENV'], 'temporary')
+                    self.assertEqual(os.environ['PYSERINI_TEST_OTHER_ENV'], 'other')
+                    raise RuntimeError('failed while env was modified')
+
+            self.assertEqual(os.environ['PYSERINI_TEST_ENV'], 'original')
+            self.assertNotIn('PYSERINI_TEST_OTHER_ENV', os.environ)
 
 
 class TestCompareTrecWithTolerance(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add a reusable `temporary_env` context manager for scoped environment variable mutation.
- Use it in ANCE and SPLADE model loading to avoid duplicated save/restore logic.
- Add unit tests covering restore behavior for missing, existing, removed, multiple, and exception cases.

## Validation

- `python -m py_compile pyserini/util.py pyserini/encode/_ance.py pyserini/encode/_splade.py tests/base/test_utils.py tests/base/test_encoder_model_ance.py tests/base/test_encoder_model_splade.py`
- `python -m unittest tests.base.test_utils.TestTemporaryEnv tests.base.test_encoder_model_ance.TestEncodeAnce.test_ance_load_disables_safetensors_conversion tests.base.test_encoder_model_ance.TestEncodeAnce.test_ance_load_restores_existing_safetensors_conversion_setting tests.base.test_encoder_model_splade.TestEncodeSplade.test_splade_load_disables_safetensors_conversion tests.base.test_encoder_model_splade.TestEncodeSplade.test_splade_load_restores_existing_safetensors_conversion_setting`
- `git diff --check`