### PR TITLE
Add BM25 k1 and b configuration for REST API and MCP Server

### DIFF
--- a/docs/usage-mcp.md
+++ b/docs/usage-mcp.md
@@ -137,8 +137,8 @@ Runs retrieval against a Pyserini index (BM25 for standard sparse indexes; dense
 | `ef_search` | `int` | no | `100` | HNSW / dense Lucene HNSW search parameter. |
 | `encoder` | `str` | no | `""` | Encoder id when the index requires one (dense / FAISS / etc.). |
 | `query_generator` | `str` | no | `""` | Sparse (TF) indexes only: `BagOfWords`, `DisjunctionMax` / `dismax`, `QuerySideBm25` / `bm25qs`, `Covid19`. Omit for downstream default (`BagOfWords`). |
-| `k1` | `float \| null` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and set together with `b`. |
-| `b` | `float \| null` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be finite, in `[0, 1]`, and set together with `k1`. |
+| `k1` | `float \| null` | no | — (omit both) | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and set together with `b`. Omit both `k1` and `b` for Anserini defaults (0.9 / 0.4). |
+| `b` | `float \| null` | no | — (omit both) | BM25 b for sparse (TF) indexes. Must be finite, in `[0, 1]`, and set together with `k1`. Omit both for Anserini defaults (0.9 / 0.4). |
 
 **Returns:** `list[Any]` rich content parts, intentionally returned as a list so MCP clients can render mixed text + images correctly.
 Typical layout is:

--- a/docs/usage-mcp.md
+++ b/docs/usage-mcp.md
@@ -137,8 +137,8 @@ Runs retrieval against a Pyserini index (BM25 for standard sparse indexes; dense
 | `ef_search` | `int` | no | `100` | HNSW / dense Lucene HNSW search parameter. |
 | `encoder` | `str` | no | `""` | Encoder id when the index requires one (dense / FAISS / etc.). |
 | `query_generator` | `str` | no | `""` | Sparse (TF) indexes only: `BagOfWords`, `DisjunctionMax` / `dismax`, `QuerySideBm25` / `bm25qs`, `Covid19`. Omit for downstream default (`BagOfWords`). |
-| `k1` | `float \| null` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be set together with `b`. |
-| `b` | `float \| null` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be set together with `k1`. |
+| `k1` | `float \| null` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and set together with `b`. |
+| `b` | `float \| null` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be finite, in `[0, 1]`, and set together with `k1`. |
 
 **Returns:** `list[Any]` rich content parts, intentionally returned as a list so MCP clients can render mixed text + images correctly.
 Typical layout is:

--- a/docs/usage-mcp.md
+++ b/docs/usage-mcp.md
@@ -137,8 +137,8 @@ Runs retrieval against a Pyserini index (BM25 for standard sparse indexes; dense
 | `ef_search` | `int` | no | `100` | HNSW / dense Lucene HNSW search parameter. |
 | `encoder` | `str` | no | `""` | Encoder id when the index requires one (dense / FAISS / etc.). |
 | `query_generator` | `str` | no | `""` | Sparse (TF) indexes only: `BagOfWords`, `DisjunctionMax` / `dismax`, `QuerySideBm25` / `bm25qs`, `Covid19`. Omit for downstream default (`BagOfWords`). |
-| `k1` | `float \| null` | no | `0.9` | BM25 k1 for sparse (TF) indexes (Anserini default). Omit to keep the default. |
-| `b` | `float \| null` | no | `0.4` | BM25 b for sparse (TF) indexes (Anserini default). Omit to keep the default. |
+| `k1` | `float \| null` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be set together with `b`. |
+| `b` | `float \| null` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be set together with `k1`. |
 
 **Returns:** `list[Any]` rich content parts, intentionally returned as a list so MCP clients can render mixed text + images correctly.
 Typical layout is:

--- a/docs/usage-mcp.md
+++ b/docs/usage-mcp.md
@@ -138,7 +138,7 @@ Runs retrieval against a Pyserini index (BM25 for standard sparse indexes; dense
 | `encoder` | `str` | no | `""` | Encoder id when the index requires one (dense / FAISS / etc.). |
 | `query_generator` | `str` | no | `""` | Sparse (TF) indexes only: `BagOfWords`, `DisjunctionMax` / `dismax`, `QuerySideBm25` / `bm25qs`, `Covid19`. Omit for downstream default (`BagOfWords`). |
 | `k1` | `float \| null` | no | — (omit both) | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and set together with `b`. Omit both `k1` and `b` for Anserini defaults (0.9 / 0.4). |
-| `b` | `float \| null` | no | — (omit both) | BM25 b for sparse (TF) indexes. Must be finite, in `[0, 1]`, and set together with `k1`. Omit both for Anserini defaults (0.9 / 0.4). |
+| `b` | `float \| null` | no | — (omit both) | BM25 b for sparse (TF) indexes. Must be in `[0, 1]`, and set together with `k1`. Omit both for Anserini defaults (0.9 / 0.4). |
 
 **Returns:** `list[Any]` rich content parts, intentionally returned as a list so MCP clients can render mixed text + images correctly.
 Typical layout is:

--- a/docs/usage-mcp.md
+++ b/docs/usage-mcp.md
@@ -137,6 +137,8 @@ Runs retrieval against a Pyserini index (BM25 for standard sparse indexes; dense
 | `ef_search` | `int` | no | `100` | HNSW / dense Lucene HNSW search parameter. |
 | `encoder` | `str` | no | `""` | Encoder id when the index requires one (dense / FAISS / etc.). |
 | `query_generator` | `str` | no | `""` | Sparse (TF) indexes only: `BagOfWords`, `DisjunctionMax` / `dismax`, `QuerySideBm25` / `bm25qs`, `Covid19`. Omit for downstream default (`BagOfWords`). |
+| `k1` | `float \| null` | no | `0.9` | BM25 k1 for sparse (TF) indexes (Anserini default). Omit to keep the default. |
+| `b` | `float \| null` | no | `0.4` | BM25 b for sparse (TF) indexes (Anserini default). Omit to keep the default. |
 
 **Returns:** `list[Any]` rich content parts, intentionally returned as a list so MCP clients can render mixed text + images correctly.
 Typical layout is:

--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -137,8 +137,8 @@ If the index cannot be opened, the API responds with **400** and a message such 
 | `query` | yes | — | Search query string. |
 | `hits` | no | `10` | Number of hits (integer ≥ 1). |
 | `parse` | no | `true` | If `true`, parse the stored `raw` field when it is JSON (see `format_lucene_document` / Anserini-style formatting); if `false`, return the raw stored string. |
-| `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be sent together with `b`. |
-| `b` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be sent together with `k1`. |
+| `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and sent together with `b`. |
+| `b` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be finite, in `[0, 1]`, and sent together with `k1`. |
 
 **Example**
 

--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -4,7 +4,7 @@ The Pyserini REST server exposes an **HTTP interface aligned with [Anserini’s 
 
 Implementation uses **`SharedSearchBackend`** (`pyserini/server/backend.py`)—the same process-wide search stack as the MCP server. A request may use a **prebuilt index name** (sparse, dense, impact, FAISS, etc., when Pyserini can open it), a **filesystem path** to an index, or an optional **YAML alias** from `--config`.
 
-**v1 limitations:** The public GET API accepts only a **string** `query` parameter. It does **not** expose multimodal payloads, `encoder`, `ef_search`, or sparse `query_generator` options (those exist on the Python API and MCP). For full control over those knobs, use **MCP** or Pyserini directly.
+**v1 limitations:** The public GET API accepts only a **string** `query` parameter. It does **not** expose multimodal payloads, `encoder`, `ef_search`, or sparse `query_generator` options (those exist on the Python API and MCP). Sparse BM25 retrieval uses **k1=0.9** and **b=0.4** by default (same as Anserini). Optional `k1` and/or `b` override only the parameters you pass; omitted values keep the defaults. For full control over other knobs, use **MCP** or Pyserini directly.
 
 ## Starting the server
 
@@ -137,12 +137,20 @@ If the index cannot be opened, the API responds with **400** and a message such 
 | `query` | yes | — | Search query string. |
 | `hits` | no | `10` | Number of hits (integer ≥ 1). |
 | `parse` | no | `true` | If `true`, parse the stored `raw` field when it is JSON (see `format_lucene_document` / Anserini-style formatting); if `false`, return the raw stored string. |
-
+| `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes (Anserini default). Omit to keep the default. |
+| `b` | no | `0.4` | BM25 b for sparse (TF) indexes (Anserini default). Omit to keep the default. |
 
 **Example**
 
 ```bash
 curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20a%20lobster%20roll&hits=1"
+```
+
+Custom BM25 parameters (sparse indexes only; set either or both):
+
+```bash
+curl "http://localhost:8081/v1/cacm/search?query=information%20retrieval&hits=5&k1=0.8&b=0.3"
+curl "http://localhost:8081/v1/cacm/search?query=information%20retrieval&hits=5&k1=0.8"
 ```
 
 With API key auth enabled (`api_keys` in `--config`), for example:

--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -4,7 +4,7 @@ The Pyserini REST server exposes an **HTTP interface aligned with [Anserini’s 
 
 Implementation uses **`SharedSearchBackend`** (`pyserini/server/backend.py`)—the same process-wide search stack as the MCP server. A request may use a **prebuilt index name** (sparse, dense, impact, FAISS, etc., when Pyserini can open it), a **filesystem path** to an index, or an optional **YAML alias** from `--config`.
 
-**v1 limitations:** The public GET API accepts only a **string** `query` parameter. It does **not** expose multimodal payloads, `encoder`, `ef_search`, or sparse `query_generator` options (those exist on the Python API and MCP). Sparse BM25 retrieval uses **k1=0.9** and **b=0.4** by default (same as Anserini). Optional `k1` and/or `b` override only the parameters you pass; omitted values keep the defaults. For full control over other knobs, use **MCP** or Pyserini directly.
+**v1 limitations:** The public GET API accepts only a **string** `query` parameter. It does **not** expose multimodal payloads, `encoder`, `ef_search`, or sparse `query_generator` options (those exist on the Python API and MCP). Sparse BM25 retrieval uses **k1=0.9** and **b=0.4** by default (same as Anserini). To override BM25, pass **both** `k1` and `b`. For full control over other knobs, use **MCP** or Pyserini directly.
 
 ## Starting the server
 
@@ -137,8 +137,8 @@ If the index cannot be opened, the API responds with **400** and a message such 
 | `query` | yes | — | Search query string. |
 | `hits` | no | `10` | Number of hits (integer ≥ 1). |
 | `parse` | no | `true` | If `true`, parse the stored `raw` field when it is JSON (see `format_lucene_document` / Anserini-style formatting); if `false`, return the raw stored string. |
-| `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes (Anserini default). Omit to keep the default. |
-| `b` | no | `0.4` | BM25 b for sparse (TF) indexes (Anserini default). Omit to keep the default. |
+| `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be sent together with `b`. |
+| `b` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be sent together with `k1`. |
 
 **Example**
 
@@ -146,11 +146,10 @@ If the index cannot be opened, the API responds with **400** and a message such 
 curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20a%20lobster%20roll&hits=1"
 ```
 
-Custom BM25 parameters (sparse indexes only; set either or both):
+Custom BM25 parameters (sparse indexes only; both required together):
 
 ```bash
 curl "http://localhost:8081/v1/cacm/search?query=information%20retrieval&hits=5&k1=0.8&b=0.3"
-curl "http://localhost:8081/v1/cacm/search?query=information%20retrieval&hits=5&k1=0.8"
 ```
 
 With API key auth enabled (`api_keys` in `--config`), for example:

--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -138,7 +138,7 @@ If the index cannot be opened, the API responds with **400** and a message such 
 | `hits` | no | `10` | Number of hits (integer ≥ 1). |
 | `parse` | no | `true` | If `true`, parse the stored `raw` field when it is JSON (see `format_lucene_document` / Anserini-style formatting); if `false`, return the raw stored string. |
 | `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and sent together with `b`. |
-| `b` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be finite, in `[0, 1]`, and sent together with `k1`. |
+| `b` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be in `[0, 1]`, and sent together with `k1`. |
 
 **Example**
 

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -21,6 +21,7 @@ import math
 import os
 import threading
 import traceback
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -32,7 +33,7 @@ from pyserini.prebuilt_index_info import FAISS_INDEX_INFO_M_BEIR
 from pyserini.search.faiss import FaissSearcher
 from pyserini.search.lucene import JBagOfWordsQueryGenerator, JCovid19QueryGenerator, JDisjunctionMaxQueryGenerator, JQuerySideBm25QueryGenerator, LuceneFlatDenseSearcher, LuceneHnswDenseSearcher, LuceneImpactSearcher, LuceneSearcher
 from pyserini.server.config import load_server_config
-from pyserini.server.utils import INDEX_TYPE, SHARDS, Bm25SearcherSlot, IndexConfig, create_searcher, lookup_index_type
+from pyserini.server.utils import INDEX_TYPE, SHARDS, Bm25Config, Bm25SearcherCacheEntry, IndexConfig, create_searcher, lookup_index_type
 from pyserini.server.document_format import format_lucene_document
 from pyserini.server.errors import BadSearchRequestError, DocumentNotFoundError, IndexNotAvailableError
 from pyserini.util import check_downloaded, download_prebuilt_index, download_url, get_cache_home
@@ -47,7 +48,7 @@ _RESULT_SCORE_DECIMALS = 6
 BM25_DEFAULT_K1 = 0.9
 BM25_DEFAULT_B = 0.4
 _BM25_KEY_DECIMALS = 6
-_DEFAULT_BM25_VARIANT_CACHE_SIZE = 4
+_DEFAULT_BM25_SEARCHER_CACHE_SIZE = 4
 
 # Cap for m-beir query images fetched from user-supplied URLs (DoS mitigation: bounded RAM and disk).
 _MAX_M_BEIR_QUERY_IMAGE_BYTES = 50 * 1024 * 1024
@@ -116,11 +117,26 @@ def _validate_bm25_params(k1: float | None, b: float | None) -> None:
         raise BadSearchRequestError('BM25 parameter b must be at most 1')
 
 
-def _canonical_bm25_params(k1: float | None, b: float | None) -> tuple[float | None, float | None]:
+def _canonical_bm25_config(k1: float | None, b: float | None) -> Bm25Config | None:
     if k1 is None and b is None:
-        return None, None
+        return None
     assert k1 is not None and b is not None
-    return round(float(k1), _BM25_KEY_DECIMALS), round(float(b), _BM25_KEY_DECIMALS)
+    return Bm25Config(
+        k1=round(float(k1), _BM25_KEY_DECIMALS),
+        b=round(float(b), _BM25_KEY_DECIMALS),
+    )
+
+
+@dataclass(frozen=True)
+class _SearchOptions:
+    hits: int = 10
+    qid: str = ''
+    parse: bool = True
+    allow_local_index: bool = True
+    ef_search: int | None = None
+    encoder: str | None = None
+    query_generator: str | None = None
+    bm25_config: Bm25Config | None = None
 
 
 class SharedSearchBackend:
@@ -133,10 +149,10 @@ class SharedSearchBackend:
         no_prebuilt_indexes: bool = False,
         search_cache_size: int = 2048,
         document_cache_size: int = 4096,
-        bm25_variant_cache_size: int = _DEFAULT_BM25_VARIANT_CACHE_SIZE,
+        bm25_searcher_cache_size: int = _DEFAULT_BM25_SEARCHER_CACHE_SIZE,
     ):
         self._no_prebuilt_indexes = no_prebuilt_indexes
-        self._bm25_variant_cache_size = max(1, int(bm25_variant_cache_size))
+        self._bm25_searcher_cache_size = max(1, int(bm25_searcher_cache_size))
         self._local_indexes, _ = load_server_config(config_path)
         if self._no_prebuilt_indexes and not self._local_indexes:
             raise ValueError('--no-prebuilt-indexes requires a non-empty index config (indexes: ...)')
@@ -183,39 +199,39 @@ class SharedSearchBackend:
         self,
         index_name: str,
         config: IndexConfig,
-        bm25: tuple[float, float],
-    ) -> tuple[LuceneSearcher, tuple[float, float]]:
+        bm25_config: Bm25Config,
+    ) -> tuple[LuceneSearcher, Bm25Config]:
         to_close: list[LuceneSearcher] = []
         try:
             with self._lock_for_index_name(index_name):
-                slot = config.bm25_searchers.get(bm25)
+                slot = config.bm25_searchers.get(bm25_config)
                 if slot is None:
-                    while len(config.bm25_searchers) >= self._bm25_variant_cache_size:
+                    while len(config.bm25_searchers) >= self._bm25_searcher_cache_size:
                         idle_key = next(
                             (key for key, cached in config.bm25_searchers.items() if cached.active == 0),
                             None,
                         )
                         if idle_key is None:
                             raise BadSearchRequestError(
-                                f'Too many active BM25 variants for index {index_name}; retry when in-flight searches finish'
+                                f'Too many active BM25 configurations for index {index_name}; retry when in-flight searches finish'
                             )
                         to_close.append(config.bm25_searchers.pop(idle_key).searcher)
                     bm25_searcher = self._build_searcher(config, index_type='tf', local_path=config.path)
-                    bm25_searcher.set_bm25(bm25[0], bm25[1])
-                    slot = Bm25SearcherSlot(bm25_searcher)
-                    config.bm25_searchers[bm25] = slot
+                    bm25_searcher.set_bm25(bm25_config.k1, bm25_config.b)
+                    slot = Bm25SearcherCacheEntry(bm25_searcher)
+                    config.bm25_searchers[bm25_config] = slot
                 else:
-                    config.bm25_searchers.move_to_end(bm25)
+                    config.bm25_searchers.move_to_end(bm25_config)
                 slot.active += 1
                 searcher = slot.searcher
         finally:
             for searcher_to_close in to_close:
                 self._close_searcher(searcher_to_close, index_name)
-        return searcher, bm25
+        return searcher, bm25_config
 
-    def _release_bm25_searcher(self, index_name: str, config: IndexConfig, bm25: tuple[float, float]) -> None:
+    def _release_bm25_searcher(self, index_name: str, config: IndexConfig, bm25_config: Bm25Config) -> None:
         with self._lock_for_index_name(index_name):
-            slot = config.bm25_searchers.get(bm25)
+            slot = config.bm25_searchers.get(bm25_config)
             if slot is None:
                 return
             slot.active -= 1
@@ -559,51 +575,40 @@ class SharedSearchBackend:
         self,
         query: str | dict[str, Any],
         index_name: str,
-        hits: int = 10,
-        qid: str = '',
-        parse: bool = True,
-        allow_local_index: bool = True,
-        ef_search: int | None = None,
-        encoder: str | None = None,
-        query_generator: str | None = None,
-        bm25_k1: float | None = None,
-        bm25_b: float | None = None,
+        options: _SearchOptions,
     ) -> dict[str, Any]:
         query = self._prepare_query(query, index_name)
         results: list[Any]
         index_config = self._ensure_index(
             index_name,
-            allow_local=allow_local_index,
-            ef_search=ef_search,
-            encoder=encoder,
+            allow_local=options.allow_local_index,
+            ef_search=options.ef_search,
+            encoder=options.encoder,
         )
 
-        if bm25_k1 is not None and bm25_b is not None and index_config.index_type != 'tf':
+        bm25_config = options.bm25_config
+        if bm25_config is not None and index_config.index_type != 'tf':
             raise BadSearchRequestError('BM25 parameters k1 and b apply only to sparse (tf) indexes')
 
         if 'shard' in index_name and 'msmarco' in index_name and isinstance(query, str):
-            results = self.sharded_search(query, hits, ef_search or 100, encoder or 'ArcticEmbedL')
+            results = self.sharded_search(query, options.hits, options.ef_search or 100, options.encoder or 'ArcticEmbedL')
         elif index_config.index_type == 'tf' and isinstance(index_config.searcher, LuceneSearcher):
-            if bm25_k1 is not None and bm25_b is not None:
-                desired_bm25 = (bm25_k1, bm25_b)
-                if desired_bm25 == (BM25_DEFAULT_K1, BM25_DEFAULT_B):
-                    desired_bm25 = None
-            else:
-                desired_bm25 = None
+            if bm25_config == Bm25Config(k1=BM25_DEFAULT_K1, b=BM25_DEFAULT_B):
+                bm25_config = None
 
-            qg_k1 = bm25_k1 if bm25_k1 is not None else BM25_DEFAULT_K1
-            qg_b = bm25_b if bm25_b is not None else BM25_DEFAULT_B
+            qg_k1 = bm25_config.k1 if bm25_config is not None else BM25_DEFAULT_K1
+            qg_b = bm25_config.b if bm25_config is not None else BM25_DEFAULT_B
 
             def run_tf_search(searcher: LuceneSearcher) -> list[Any]:
-                if query_generator:
+                if options.query_generator:
                     jquery_gen = self._resolve_query_generator(
-                        query_generator, searcher, k1=qg_k1, b=qg_b
+                        options.query_generator, searcher, k1=qg_k1, b=qg_b
                     )
-                    return searcher.search(query, hits, query_generator=jquery_gen)
-                return searcher.search(query, hits)
+                    return searcher.search(query, options.hits, query_generator=jquery_gen)
+                return searcher.search(query, options.hits)
 
-            if desired_bm25 is not None:
-                searcher, bm25_key = self._acquire_bm25_searcher(index_name, index_config, desired_bm25)
+            if bm25_config is not None:
+                searcher, bm25_key = self._acquire_bm25_searcher(index_name, index_config, bm25_config)
                 try:
                     results = run_tf_search(searcher)
                 finally:
@@ -611,10 +616,10 @@ class SharedSearchBackend:
             else:
                 results = run_tf_search(index_config.searcher)
         else:
-            results = index_config.searcher.search(query, hits)
+            results = index_config.searcher.search(query, options.hits)
 
         if isinstance(query, str):
-            query_payload: dict[str, Any] = {'qid': qid, 'query_txt': query}
+            query_payload: dict[str, Any] = {'qid': options.qid, 'query_txt': query}
         else:
             query_payload = query
         response_payload: dict[str, Any] = {'query': query_payload}
@@ -627,7 +632,7 @@ class SharedSearchBackend:
                 ordered_docids.append(result.docid)
         unique_docids = list(dict.fromkeys(ordered_docids))
         docs_by_id = self._bulk_fetch_and_format_documents(
-            unique_docids, doc_index_key, parse=parse, allow_local_index=True
+            unique_docids, doc_index_key, parse=options.parse, allow_local_index=True
         )
         candidates = []
         for rank, result in enumerate(results, start=1):
@@ -664,35 +669,20 @@ class SharedSearchBackend:
         b: float | None = None,
     ) -> dict[str, Any]:
         _validate_bm25_params(k1, b)
-        bm25_k1, bm25_b = _canonical_bm25_params(k1, b)
+        options = _SearchOptions(
+            hits=hits,
+            qid=qid,
+            parse=parse,
+            allow_local_index=allow_local_index,
+            ef_search=ef_search,
+            encoder=encoder,
+            query_generator=query_generator,
+            bm25_config=_canonical_bm25_config(k1, b),
+        )
         # Cache only REST-style string queries; multimodal dict payloads stay uncached.
         if isinstance(query, str):
-            return self._search_cached(
-                query,
-                index_name,
-                hits,
-                qid,
-                parse,
-                allow_local_index,
-                ef_search,
-                encoder,
-                query_generator,
-                bm25_k1,
-                bm25_b,
-            )
-        return self._search_impl(
-            query,
-            index_name,
-            hits,
-            qid,
-            parse,
-            allow_local_index,
-            ef_search,
-            encoder,
-            query_generator,
-            bm25_k1,
-            bm25_b,
-        )
+            return self._search_cached(query, index_name, options)
+        return self._search_impl(query, index_name, options)
 
 
 _backend: SharedSearchBackend | None = None

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -42,6 +42,10 @@ logger = logging.getLogger(__name__)
 # https://github.com/castorini/anserini/blob/master/src/main/java/io/anserini/rerank/lib/ScoreTiesAdjusterReranker.java
 _RESULT_SCORE_DECIMALS = 6
 
+# Anserini / Lucene BM25 defaults (see LuceneSearcher.set_bm25).
+BM25_DEFAULT_K1 = 0.9
+BM25_DEFAULT_B = 0.4
+
 # Cap for m-beir query images fetched from user-supplied URLs (DoS mitigation: bounded RAM and disk).
 _MAX_M_BEIR_QUERY_IMAGE_BYTES = 50 * 1024 * 1024
 _MBEIR_NAME_TO_INSTR_FILE = {
@@ -87,6 +91,20 @@ def _get_uniir_query_encoder():
 
 def _norm_opt_str(value: str | None) -> str:
     return (value or '').strip()
+
+
+def _validate_bm25_params(k1: float | None, b: float | None) -> None:
+    if k1 is not None and k1 < 0:
+        raise BadSearchRequestError('BM25 parameter k1 must be non-negative')
+    if b is not None and b < 0:
+        raise BadSearchRequestError('BM25 parameter b must be non-negative')
+
+
+def _resolve_bm25_params(k1: float | None, b: float | None) -> tuple[float, float]:
+    """Return effective BM25 parameters (Anserini defaults fill in any omitted value)."""
+    resolved_k1 = BM25_DEFAULT_K1 if k1 is None else float(k1)
+    resolved_b = BM25_DEFAULT_B if b is None else float(b)
+    return resolved_k1, resolved_b
 
 
 class SharedSearchBackend:
@@ -349,7 +367,18 @@ class SharedSearchBackend:
             raise DocumentNotFoundError(f'Document {missing[0]} not found in index {start_index_name}')
         return {d: format_lucene_document(batch[d], parse) for d in docids}
 
-    def _resolve_query_generator(self, query_generator_str: str | None, searcher: LuceneSearcher):
+    @staticmethod
+    def _apply_bm25_parameters(searcher: LuceneSearcher, k1: float, b: float) -> None:
+        searcher.set_bm25(k1, b)
+
+    def _resolve_query_generator(
+        self,
+        query_generator_str: str | None,
+        searcher: LuceneSearcher,
+        *,
+        k1: float,
+        b: float,
+    ):
         if not query_generator_str or not query_generator_str.strip():
             return None
         name = query_generator_str.strip().lower()
@@ -358,7 +387,7 @@ class SharedSearchBackend:
         if name in ('disjunctionmax', 'dismax'):
             return JDisjunctionMaxQueryGenerator(0.0)
         if name in ('querysidebm25', 'bm25qs'):
-            return JQuerySideBm25QueryGenerator(0.9, 0.4, searcher.index_reader.reader)
+            return JQuerySideBm25QueryGenerator(k1, b, searcher.index_reader.reader)
         if name == 'covid19':
             return JCovid19QueryGenerator()
         return None
@@ -479,6 +508,9 @@ class SharedSearchBackend:
         ef_search: int | None = None,
         encoder: str | None = None,
         query_generator: str | None = None,
+        bm25_k1: float = BM25_DEFAULT_K1,
+        bm25_b: float = BM25_DEFAULT_B,
+        explicit_bm25: bool = False,
     ) -> dict[str, Any]:
         query = self._prepare_query(query, index_name)
         results: list[Any]
@@ -489,11 +521,18 @@ class SharedSearchBackend:
             encoder=encoder,
         )
 
+        if explicit_bm25 and index_config.index_type != 'tf':
+            raise BadSearchRequestError('BM25 parameters k1 and b apply only to sparse (tf) indexes')
+
         if 'shard' in index_name and 'msmarco' in index_name and isinstance(query, str):
             results = self.sharded_search(query, hits, ef_search or 100, encoder or 'ArcticEmbedL')
         else:
+            if index_config.index_type == 'tf' and isinstance(index_config.searcher, LuceneSearcher):
+                self._apply_bm25_parameters(index_config.searcher, bm25_k1, bm25_b)
             if query_generator and index_config.index_type == 'tf' and isinstance(index_config.searcher, LuceneSearcher):
-                jquery_gen = self._resolve_query_generator(query_generator, index_config.searcher)
+                jquery_gen = self._resolve_query_generator(
+                    query_generator, index_config.searcher, k1=bm25_k1, b=bm25_b
+                )
                 results = index_config.searcher.search(query, hits, query_generator=jquery_gen)
             else:
                 results = index_config.searcher.search(query, hits)
@@ -545,11 +584,42 @@ class SharedSearchBackend:
         ef_search: int | None = None,
         encoder: str | None = None,
         query_generator: str | None = None,
+        k1: float | None = None,
+        b: float | None = None,
     ) -> dict[str, Any]:
+        _validate_bm25_params(k1, b)
+        explicit_bm25 = k1 is not None or b is not None
+        bm25_k1, bm25_b = _resolve_bm25_params(k1, b)
         # Cache only REST-style string queries; multimodal dict payloads stay uncached.
         if isinstance(query, str):
-            return self._search_cached(query, index_name, hits, qid, parse, allow_local_index, ef_search, encoder, query_generator)
-        return self._search_impl(query, index_name, hits, qid, parse, allow_local_index, ef_search, encoder, query_generator)
+            return self._search_cached(
+                query,
+                index_name,
+                hits,
+                qid,
+                parse,
+                allow_local_index,
+                ef_search,
+                encoder,
+                query_generator,
+                bm25_k1,
+                bm25_b,
+                explicit_bm25,
+            )
+        return self._search_impl(
+            query,
+            index_name,
+            hits,
+            qid,
+            parse,
+            allow_local_index,
+            ef_search,
+            encoder,
+            query_generator,
+            bm25_k1,
+            bm25_b,
+            explicit_bm25,
+        )
 
 
 _backend: SharedSearchBackend | None = None

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -98,23 +98,20 @@ def _norm_opt_str(value: str | None) -> str:
 
 
 def _validate_bm25_params(k1: float | None, b: float | None) -> None:
+    # Match pyserini.search.lucene.__main__.set_bm25_parameters (both or neither).
     if (k1 is None) != (b is None):
         raise BadSearchRequestError('BM25 parameters k1 and b must be set together')
+    if k1 is None:
+        return
     try:
-        k1_value = float(k1) if k1 is not None else None
-        b_value = float(b) if b is not None else None
+        k1_value = float(k1)
+        b_value = float(b)
     except (TypeError, ValueError) as e:
         raise BadSearchRequestError('BM25 parameters k1 and b must be numbers') from e
-    if k1_value is not None and not math.isfinite(k1_value):
-        raise BadSearchRequestError('BM25 parameter k1 must be finite')
-    if b_value is not None and not math.isfinite(b_value):
-        raise BadSearchRequestError('BM25 parameter b must be finite')
-    if k1_value is not None and k1_value < 0:
-        raise BadSearchRequestError('BM25 parameter k1 must be non-negative')
-    if b_value is not None and b_value < 0:
-        raise BadSearchRequestError('BM25 parameter b must be non-negative')
-    if b_value is not None and b_value > 1:
-        raise BadSearchRequestError('BM25 parameter b must be at most 1')
+    if math.isnan(k1_value) or k1_value < 0:
+        raise BadSearchRequestError('BM25 parameter k1 must be a non-negative number')
+    if math.isnan(b_value) or not 0 <= b_value <= 1:
+        raise BadSearchRequestError('BM25 parameter b must be between 0 and 1')
 
 
 def _canonical_bm25_config(k1: float | None, b: float | None) -> Bm25Config | None:

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -179,13 +179,6 @@ class SharedSearchBackend:
         self._search_cached.cache_clear()
         self._document_cached.cache_clear()
 
-    def _new_bm25_searcher(self, config: IndexConfig, k1: float, b: float) -> LuceneSearcher:
-        searcher = self._build_searcher(config, index_type='tf', local_path=config.path)
-        if not isinstance(searcher, LuceneSearcher):
-            raise IndexNotAvailableError(f'Unable to open sparse searcher for {config.name}')
-        searcher.set_bm25(k1, b)
-        return searcher
-
     def _acquire_bm25_searcher(
         self,
         index_name: str,
@@ -207,7 +200,8 @@ class SharedSearchBackend:
                                 f'Too many active BM25 variants for index {index_name}; retry when in-flight searches finish'
                             )
                         to_close.append(config.bm25_searchers.pop(idle_key).searcher)
-                    bm25_searcher = self._new_bm25_searcher(config, bm25[0], bm25[1])
+                    bm25_searcher = self._build_searcher(config, index_type='tf', local_path=config.path)
+                    bm25_searcher.set_bm25(bm25[0], bm25[1])
                     slot = Bm25SearcherSlot(bm25_searcher)
                     config.bm25_searchers[bm25] = slot
                 else:

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # https://github.com/castorini/anserini/blob/master/src/main/java/io/anserini/rerank/lib/ScoreTiesAdjusterReranker.java
 _RESULT_SCORE_DECIMALS = 6
 
-# Anserini / Lucene BM25 defaults (see LuceneSearcher.set_bm25).
+# BM25 defaults for sparse (tf) indexes (see LuceneSearcher.set_bm25).
 BM25_DEFAULT_K1 = 0.9
 BM25_DEFAULT_B = 0.4
 
@@ -94,17 +94,12 @@ def _norm_opt_str(value: str | None) -> str:
 
 
 def _validate_bm25_params(k1: float | None, b: float | None) -> None:
+    if (k1 is None) != (b is None):
+        raise BadSearchRequestError('BM25 parameters k1 and b must be set together')
     if k1 is not None and k1 < 0:
         raise BadSearchRequestError('BM25 parameter k1 must be non-negative')
     if b is not None and b < 0:
         raise BadSearchRequestError('BM25 parameter b must be non-negative')
-
-
-def _resolve_bm25_params(k1: float | None, b: float | None) -> tuple[float, float]:
-    """Return effective BM25 parameters (Anserini defaults fill in any omitted value)."""
-    resolved_k1 = BM25_DEFAULT_K1 if k1 is None else float(k1)
-    resolved_b = BM25_DEFAULT_B if b is None else float(b)
-    return resolved_k1, resolved_b
 
 
 class SharedSearchBackend:
@@ -367,10 +362,6 @@ class SharedSearchBackend:
             raise DocumentNotFoundError(f'Document {missing[0]} not found in index {start_index_name}')
         return {d: format_lucene_document(batch[d], parse) for d in docids}
 
-    @staticmethod
-    def _apply_bm25_parameters(searcher: LuceneSearcher, k1: float, b: float) -> None:
-        searcher.set_bm25(k1, b)
-
     def _resolve_query_generator(
         self,
         query_generator_str: str | None,
@@ -508,9 +499,8 @@ class SharedSearchBackend:
         ef_search: int | None = None,
         encoder: str | None = None,
         query_generator: str | None = None,
-        bm25_k1: float = BM25_DEFAULT_K1,
-        bm25_b: float = BM25_DEFAULT_B,
-        explicit_bm25: bool = False,
+        bm25_k1: float | None = None,
+        bm25_b: float | None = None,
     ) -> dict[str, Any]:
         query = self._prepare_query(query, index_name)
         results: list[Any]
@@ -521,21 +511,44 @@ class SharedSearchBackend:
             encoder=encoder,
         )
 
-        if explicit_bm25 and index_config.index_type != 'tf':
+        if bm25_k1 is not None and bm25_b is not None and index_config.index_type != 'tf':
             raise BadSearchRequestError('BM25 parameters k1 and b apply only to sparse (tf) indexes')
 
         if 'shard' in index_name and 'msmarco' in index_name and isinstance(query, str):
             results = self.sharded_search(query, hits, ef_search or 100, encoder or 'ArcticEmbedL')
-        else:
-            if index_config.index_type == 'tf' and isinstance(index_config.searcher, LuceneSearcher):
-                self._apply_bm25_parameters(index_config.searcher, bm25_k1, bm25_b)
-            if query_generator and index_config.index_type == 'tf' and isinstance(index_config.searcher, LuceneSearcher):
-                jquery_gen = self._resolve_query_generator(
-                    query_generator, index_config.searcher, k1=bm25_k1, b=bm25_b
-                )
-                results = index_config.searcher.search(query, hits, query_generator=jquery_gen)
+        elif index_config.index_type == 'tf' and isinstance(index_config.searcher, LuceneSearcher):
+            searcher = index_config.searcher
+            if bm25_k1 is not None and bm25_b is not None:
+                desired_bm25 = (bm25_k1, bm25_b)
+            elif index_config.bm25_applied is None or index_config.bm25_applied == (
+                BM25_DEFAULT_K1,
+                BM25_DEFAULT_B,
+            ):
+                desired_bm25 = None
             else:
-                results = index_config.searcher.search(query, hits)
+                desired_bm25 = (BM25_DEFAULT_K1, BM25_DEFAULT_B)
+
+            qg_k1 = bm25_k1 if bm25_k1 is not None else BM25_DEFAULT_K1
+            qg_b = bm25_b if bm25_b is not None else BM25_DEFAULT_B
+
+            def run_tf_search() -> list[Any]:
+                if query_generator:
+                    jquery_gen = self._resolve_query_generator(
+                        query_generator, searcher, k1=qg_k1, b=qg_b
+                    )
+                    return searcher.search(query, hits, query_generator=jquery_gen)
+                return searcher.search(query, hits)
+
+            if desired_bm25 is not None and index_config.bm25_applied != desired_bm25:
+                with self._lock_for_index_name(index_name):
+                    if index_config.bm25_applied != desired_bm25:
+                        searcher.set_bm25(desired_bm25[0], desired_bm25[1])
+                        index_config.bm25_applied = desired_bm25
+                    results = run_tf_search()
+            else:
+                results = run_tf_search()
+        else:
+            results = index_config.searcher.search(query, hits)
 
         if isinstance(query, str):
             query_payload: dict[str, Any] = {'qid': qid, 'query_txt': query}
@@ -588,8 +601,8 @@ class SharedSearchBackend:
         b: float | None = None,
     ) -> dict[str, Any]:
         _validate_bm25_params(k1, b)
-        explicit_bm25 = k1 is not None or b is not None
-        bm25_k1, bm25_b = _resolve_bm25_params(k1, b)
+        bm25_k1 = float(k1) if k1 is not None else None
+        bm25_b = float(b) if b is not None else None
         # Cache only REST-style string queries; multimodal dict payloads stay uncached.
         if isinstance(query, str):
             return self._search_cached(
@@ -604,7 +617,6 @@ class SharedSearchBackend:
                 query_generator,
                 bm25_k1,
                 bm25_b,
-                explicit_bm25,
             )
         return self._search_impl(
             query,
@@ -618,7 +630,6 @@ class SharedSearchBackend:
             query_generator,
             bm25_k1,
             bm25_b,
-            explicit_bm25,
         )
 
 

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -17,9 +17,10 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
-import traceback
 import threading
+import traceback
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -31,7 +32,7 @@ from pyserini.prebuilt_index_info import FAISS_INDEX_INFO_M_BEIR
 from pyserini.search.faiss import FaissSearcher
 from pyserini.search.lucene import JBagOfWordsQueryGenerator, JCovid19QueryGenerator, JDisjunctionMaxQueryGenerator, JQuerySideBm25QueryGenerator, LuceneFlatDenseSearcher, LuceneHnswDenseSearcher, LuceneImpactSearcher, LuceneSearcher
 from pyserini.server.config import load_server_config
-from pyserini.server.utils import INDEX_TYPE, SHARDS, IndexConfig, create_searcher, lookup_index_type
+from pyserini.server.utils import INDEX_TYPE, SHARDS, Bm25SearcherSlot, IndexConfig, create_searcher, lookup_index_type
 from pyserini.server.document_format import format_lucene_document
 from pyserini.server.errors import BadSearchRequestError, DocumentNotFoundError, IndexNotAvailableError
 from pyserini.util import check_downloaded, download_prebuilt_index, download_url, get_cache_home
@@ -45,6 +46,8 @@ _RESULT_SCORE_DECIMALS = 6
 # BM25 defaults for sparse (tf) indexes (see LuceneSearcher.set_bm25).
 BM25_DEFAULT_K1 = 0.9
 BM25_DEFAULT_B = 0.4
+_BM25_KEY_DECIMALS = 6
+_DEFAULT_BM25_VARIANT_CACHE_SIZE = 4
 
 # Cap for m-beir query images fetched from user-supplied URLs (DoS mitigation: bounded RAM and disk).
 _MAX_M_BEIR_QUERY_IMAGE_BYTES = 50 * 1024 * 1024
@@ -96,10 +99,28 @@ def _norm_opt_str(value: str | None) -> str:
 def _validate_bm25_params(k1: float | None, b: float | None) -> None:
     if (k1 is None) != (b is None):
         raise BadSearchRequestError('BM25 parameters k1 and b must be set together')
-    if k1 is not None and k1 < 0:
+    try:
+        k1_value = float(k1) if k1 is not None else None
+        b_value = float(b) if b is not None else None
+    except (TypeError, ValueError) as e:
+        raise BadSearchRequestError('BM25 parameters k1 and b must be numbers') from e
+    if k1_value is not None and not math.isfinite(k1_value):
+        raise BadSearchRequestError('BM25 parameter k1 must be finite')
+    if b_value is not None and not math.isfinite(b_value):
+        raise BadSearchRequestError('BM25 parameter b must be finite')
+    if k1_value is not None and k1_value < 0:
         raise BadSearchRequestError('BM25 parameter k1 must be non-negative')
-    if b is not None and b < 0:
+    if b_value is not None and b_value < 0:
         raise BadSearchRequestError('BM25 parameter b must be non-negative')
+    if b_value is not None and b_value > 1:
+        raise BadSearchRequestError('BM25 parameter b must be at most 1')
+
+
+def _canonical_bm25_params(k1: float | None, b: float | None) -> tuple[float | None, float | None]:
+    if k1 is None and b is None:
+        return None, None
+    assert k1 is not None and b is not None
+    return round(float(k1), _BM25_KEY_DECIMALS), round(float(b), _BM25_KEY_DECIMALS)
 
 
 class SharedSearchBackend:
@@ -112,8 +133,10 @@ class SharedSearchBackend:
         no_prebuilt_indexes: bool = False,
         search_cache_size: int = 2048,
         document_cache_size: int = 4096,
+        bm25_variant_cache_size: int = _DEFAULT_BM25_VARIANT_CACHE_SIZE,
     ):
         self._no_prebuilt_indexes = no_prebuilt_indexes
+        self._bm25_variant_cache_size = max(1, int(bm25_variant_cache_size))
         self._local_indexes, _ = load_server_config(config_path)
         if self._no_prebuilt_indexes and not self._local_indexes:
             raise ValueError('--no-prebuilt-indexes requires a non-empty index config (indexes: ...)')
@@ -132,21 +155,76 @@ class SharedSearchBackend:
                 self._index_locks[index_name] = lock
             return lock
 
+    @staticmethod
+    def _close_searcher(searcher: Any, index_name: str) -> None:
+        close_fn = getattr(searcher, 'close', None)
+        if not callable(close_fn):
+            return
+        try:
+            close_fn()
+        except Exception:
+            logger.warning('Failed to close searcher for index %s.', index_name, exc_info=True)
+
+    def _close_index_config(self, config: IndexConfig) -> None:
+        if config.searcher is not None:
+            self._close_searcher(config.searcher, config.name)
+        for slot in config.bm25_searchers.values():
+            self._close_searcher(slot.searcher, config.name)
+        config.bm25_searchers.clear()
+
     def close_all(self) -> None:
         for config in self.indexes.values():
-            searcher = config.searcher
-            if searcher is None:
-                continue
-            close_fn = getattr(searcher, 'close', None)
-            if not callable(close_fn):
-                continue
-            try:
-                close_fn()
-            except Exception:
-                logger.warning('Failed to close searcher for index %s during backend shutdown.', config.name, exc_info=True)
+            self._close_index_config(config)
         self.indexes.clear()
         self._search_cached.cache_clear()
         self._document_cached.cache_clear()
+
+    def _new_bm25_searcher(self, config: IndexConfig, k1: float, b: float) -> LuceneSearcher:
+        searcher = self._build_searcher(config, index_type='tf', local_path=config.path)
+        if not isinstance(searcher, LuceneSearcher):
+            raise IndexNotAvailableError(f'Unable to open sparse searcher for {config.name}')
+        searcher.set_bm25(k1, b)
+        return searcher
+
+    def _acquire_bm25_searcher(
+        self,
+        index_name: str,
+        config: IndexConfig,
+        bm25: tuple[float, float],
+    ) -> tuple[LuceneSearcher, tuple[float, float]]:
+        to_close: list[LuceneSearcher] = []
+        try:
+            with self._lock_for_index_name(index_name):
+                slot = config.bm25_searchers.get(bm25)
+                if slot is None:
+                    while len(config.bm25_searchers) >= self._bm25_variant_cache_size:
+                        idle_key = next(
+                            (key for key, cached in config.bm25_searchers.items() if cached.active == 0),
+                            None,
+                        )
+                        if idle_key is None:
+                            raise BadSearchRequestError(
+                                f'Too many active BM25 variants for index {index_name}; retry when in-flight searches finish'
+                            )
+                        to_close.append(config.bm25_searchers.pop(idle_key).searcher)
+                    bm25_searcher = self._new_bm25_searcher(config, bm25[0], bm25[1])
+                    slot = Bm25SearcherSlot(bm25_searcher)
+                    config.bm25_searchers[bm25] = slot
+                else:
+                    config.bm25_searchers.move_to_end(bm25)
+                slot.active += 1
+                searcher = slot.searcher
+        finally:
+            for searcher_to_close in to_close:
+                self._close_searcher(searcher_to_close, index_name)
+        return searcher, bm25
+
+    def _release_bm25_searcher(self, index_name: str, config: IndexConfig, bm25: tuple[float, float]) -> None:
+        with self._lock_for_index_name(index_name):
+            slot = config.bm25_searchers.get(bm25)
+            if slot is None:
+                return
+            slot.active -= 1
 
     def decode_path_segment(self, value: str) -> str:
         return unquote(value)
@@ -229,12 +307,7 @@ class SharedSearchBackend:
                     config, ef_search=ef_search, encoder=encoder
                 )
                 if need_rebuild:
-                    close_fn = getattr(config.searcher, 'close', None)
-                    try:
-                        if callable(close_fn):
-                            close_fn()
-                    except Exception:
-                        logger.warning('Failed to close existing searcher for index %s before rebuild.', index_name, exc_info=True)
+                    self._close_index_config(config)
                     del self.indexes[index_name]
                     config = None
                 else:
@@ -517,21 +590,17 @@ class SharedSearchBackend:
         if 'shard' in index_name and 'msmarco' in index_name and isinstance(query, str):
             results = self.sharded_search(query, hits, ef_search or 100, encoder or 'ArcticEmbedL')
         elif index_config.index_type == 'tf' and isinstance(index_config.searcher, LuceneSearcher):
-            searcher = index_config.searcher
             if bm25_k1 is not None and bm25_b is not None:
                 desired_bm25 = (bm25_k1, bm25_b)
-            elif index_config.bm25_applied is None or index_config.bm25_applied == (
-                BM25_DEFAULT_K1,
-                BM25_DEFAULT_B,
-            ):
-                desired_bm25 = None
+                if desired_bm25 == (BM25_DEFAULT_K1, BM25_DEFAULT_B):
+                    desired_bm25 = None
             else:
-                desired_bm25 = (BM25_DEFAULT_K1, BM25_DEFAULT_B)
+                desired_bm25 = None
 
             qg_k1 = bm25_k1 if bm25_k1 is not None else BM25_DEFAULT_K1
             qg_b = bm25_b if bm25_b is not None else BM25_DEFAULT_B
 
-            def run_tf_search() -> list[Any]:
+            def run_tf_search(searcher: LuceneSearcher) -> list[Any]:
                 if query_generator:
                     jquery_gen = self._resolve_query_generator(
                         query_generator, searcher, k1=qg_k1, b=qg_b
@@ -539,14 +608,14 @@ class SharedSearchBackend:
                     return searcher.search(query, hits, query_generator=jquery_gen)
                 return searcher.search(query, hits)
 
-            if desired_bm25 is not None and index_config.bm25_applied != desired_bm25:
-                with self._lock_for_index_name(index_name):
-                    if index_config.bm25_applied != desired_bm25:
-                        searcher.set_bm25(desired_bm25[0], desired_bm25[1])
-                        index_config.bm25_applied = desired_bm25
-                    results = run_tf_search()
+            if desired_bm25 is not None:
+                searcher, bm25_key = self._acquire_bm25_searcher(index_name, index_config, desired_bm25)
+                try:
+                    results = run_tf_search(searcher)
+                finally:
+                    self._release_bm25_searcher(index_name, index_config, bm25_key)
             else:
-                results = run_tf_search()
+                results = run_tf_search(index_config.searcher)
         else:
             results = index_config.searcher.search(query, hits)
 
@@ -601,8 +670,7 @@ class SharedSearchBackend:
         b: float | None = None,
     ) -> dict[str, Any]:
         _validate_bm25_params(k1, b)
-        bm25_k1 = float(k1) if k1 is not None else None
-        bm25_b = float(b) if b is not None else None
+        bm25_k1, bm25_b = _canonical_bm25_params(k1, b)
         # Cache only REST-style string queries; multimodal dict payloads stay uncached.
         if isinstance(query, str):
             return self._search_cached(

--- a/pyserini/server/mcp/tools.py
+++ b/pyserini/server/mcp/tools.py
@@ -64,8 +64,8 @@ def register_tools(mcp: FastMCP, controller: SharedSearchBackend):
             ef_search: ef_search parameter for HNSW indexes (default: 100)
             encoder: Encoder to use for encoding the query
             query_generator: For sparse (tf) indexes only: how to build the Lucene query. One of: BagOfWords, DisjunctionMax (dismax), QuerySideBm25 (bm25qs), Covid19. Omit or None for default.
-            k1: BM25 k1 for sparse (tf) indexes (default 0.9, matching Anserini). Omit to use the default; b may still be set.
-            b: BM25 b for sparse (tf) indexes (default 0.4, matching Anserini). Omit to use the default; k1 may still be set.
+            k1: BM25 k1 for sparse (tf) indexes. Must be set together with b.
+            b: BM25 b for sparse (tf) indexes. Must be set together with k1.
 
         Returns:
             List of search results with docid, score, and raw contents in text or image form

--- a/pyserini/server/mcp/tools.py
+++ b/pyserini/server/mcp/tools.py
@@ -64,8 +64,8 @@ def register_tools(mcp: FastMCP, controller: SharedSearchBackend):
             ef_search: ef_search parameter for HNSW indexes (default: 100)
             encoder: Encoder to use for encoding the query
             query_generator: For sparse (tf) indexes only: how to build the Lucene query. One of: BagOfWords, DisjunctionMax (dismax), QuerySideBm25 (bm25qs), Covid19. Omit or None for default.
-            k1: BM25 k1 for sparse (tf) indexes. Must be set together with b.
-            b: BM25 b for sparse (tf) indexes. Must be set together with k1.
+            k1: BM25 k1 for sparse (tf) indexes. Must be finite, non-negative, and set together with b.
+            b: BM25 b for sparse (tf) indexes. Must be finite, in [0, 1], and set together with k1.
 
         Returns:
             List of search results with docid, score, and raw contents in text or image form

--- a/pyserini/server/mcp/tools.py
+++ b/pyserini/server/mcp/tools.py
@@ -65,7 +65,7 @@ def register_tools(mcp: FastMCP, controller: SharedSearchBackend):
             encoder: Encoder to use for encoding the query
             query_generator: For sparse (tf) indexes only: how to build the Lucene query. One of: BagOfWords, DisjunctionMax (dismax), QuerySideBm25 (bm25qs), Covid19. Omit or None for default.
             k1: BM25 k1 for sparse (tf) indexes. Must be finite, non-negative, and set together with b.
-            b: BM25 b for sparse (tf) indexes. Must be finite, in [0, 1], and set together with k1.
+            b: BM25 b for sparse (tf) indexes. Must be in [0, 1], and set together with k1.
 
         Returns:
             List of search results with docid, score, and raw contents in text or image form

--- a/pyserini/server/mcp/tools.py
+++ b/pyserini/server/mcp/tools.py
@@ -43,7 +43,9 @@ def register_tools(mcp: FastMCP, controller: SharedSearchBackend):
         parse: bool = True,
         ef_search: int = 100,
         encoder: str = "",
-        query_generator: str = ""
+        query_generator: str = "",
+        k1: float | None = None,
+        b: float | None = None,
     ):
         """
         Search the Pyserini index with the appropriate method for the type of the index provided and return top-k hits.
@@ -62,6 +64,8 @@ def register_tools(mcp: FastMCP, controller: SharedSearchBackend):
             ef_search: ef_search parameter for HNSW indexes (default: 100)
             encoder: Encoder to use for encoding the query
             query_generator: For sparse (tf) indexes only: how to build the Lucene query. One of: BagOfWords, DisjunctionMax (dismax), QuerySideBm25 (bm25qs), Covid19. Omit or None for default.
+            k1: BM25 k1 for sparse (tf) indexes (default 0.9, matching Anserini). Omit to use the default; b may still be set.
+            b: BM25 b for sparse (tf) indexes (default 0.4, matching Anserini). Omit to use the default; k1 may still be set.
 
         Returns:
             List of search results with docid, score, and raw contents in text or image form
@@ -75,6 +79,8 @@ def register_tools(mcp: FastMCP, controller: SharedSearchBackend):
             ef_search=ef_search,
             encoder=encoder if encoder else None,
             query_generator=query_generator if query_generator else None,
+            k1=k1,
+            b=b,
         )
 
     @mcp.tool()

--- a/pyserini/server/rest/app.py
+++ b/pyserini/server/rest/app.py
@@ -23,7 +23,7 @@ Usage:
 
 Endpoints:
     GET /openapi.yaml     : OpenAPI specification (same document as Anserini).
-    GET /v1/{index}/search?query=...&hits=10&parse=true
+    GET /v1/{index}/search?query=...&hits=10&parse=true&k1=0.9&b=0.4
     GET /v1/{index}/doc/{docid}?parse=true
     GET /docs             : Swagger UI (FastAPI).
 """

--- a/pyserini/server/rest/openapi.yaml
+++ b/pyserini/server/rest/openapi.yaml
@@ -50,9 +50,11 @@ paths:
           schema:
             type: number
             format: float
+            minimum: 0
             default: 0.9
           description: >
-            BM25 k1 for sparse (TF) indexes. Must be sent together with b. Omit both for Anserini defaults (0.9 / 0.4).
+            BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and sent together with b.
+            Omit both for Anserini defaults (0.9 / 0.4).
             Returns 400 on non-sparse indexes.
         - name: b
           in: query
@@ -60,9 +62,12 @@ paths:
           schema:
             type: number
             format: float
+            minimum: 0
+            maximum: 1
             default: 0.4
           description: >
-            BM25 b for sparse (TF) indexes. Must be sent together with k1. Omit both for Anserini defaults (0.9 / 0.4).
+            BM25 b for sparse (TF) indexes. Must be finite, in [0, 1], and sent together with k1.
+            Omit both for Anserini defaults (0.9 / 0.4).
             Returns 400 on non-sparse indexes.
       responses:
         "200":

--- a/pyserini/server/rest/openapi.yaml
+++ b/pyserini/server/rest/openapi.yaml
@@ -51,7 +51,9 @@ paths:
             type: number
             format: float
             default: 0.9
-          description: BM25 k1 for sparse indexes (default 0.9, matching Anserini). Omit to use the default; b may still be set.
+          description: >
+            BM25 k1 for sparse (TF) indexes. Must be sent together with b. Omit both for Anserini defaults (0.9 / 0.4).
+            Returns 400 on non-sparse indexes.
         - name: b
           in: query
           required: false
@@ -59,7 +61,9 @@ paths:
             type: number
             format: float
             default: 0.4
-          description: BM25 b for sparse indexes (default 0.4, matching Anserini). Omit to use the default; k1 may still be set.
+          description: >
+            BM25 b for sparse (TF) indexes. Must be sent together with k1. Omit both for Anserini defaults (0.9 / 0.4).
+            Returns 400 on non-sparse indexes.
       responses:
         "200":
           description: Search results.

--- a/pyserini/server/rest/openapi.yaml
+++ b/pyserini/server/rest/openapi.yaml
@@ -44,6 +44,22 @@ paths:
             type: boolean
             default: true
           description: If true, try to return parsed document contents; if false, return the raw stored document string.
+        - name: k1
+          in: query
+          required: false
+          schema:
+            type: number
+            format: float
+            default: 0.9
+          description: BM25 k1 for sparse indexes (default 0.9, matching Anserini). Omit to use the default; b may still be set.
+        - name: b
+          in: query
+          required: false
+          schema:
+            type: number
+            format: float
+            default: 0.4
+          description: BM25 b for sparse indexes (default 0.4, matching Anserini). Omit to use the default; k1 may still be set.
       responses:
         "200":
           description: Search results.

--- a/pyserini/server/rest/routes/v1.py
+++ b/pyserini/server/rest/routes/v1.py
@@ -51,6 +51,28 @@ def _parse_bool(raw: str | None, default: bool, name: str) -> tuple[bool | None,
     return None, _error(400, f"Parameter '{name}' must be 'true' or 'false'")
 
 
+def _parse_optional_float(raw: str | None, name: str) -> tuple[float | None, JSONResponse | None]:
+    if raw is None or not str(raw).strip():
+        return None, None
+    try:
+        return float(raw), None
+    except ValueError:
+        return None, _error(400, f"Parameter '{name}' must be a number")
+
+
+def _parse_bm25_params(
+    k1_raw: str | None,
+    b_raw: str | None,
+) -> tuple[float | None, float | None, JSONResponse | None]:
+    k1, bad_k1 = _parse_optional_float(k1_raw, 'k1')
+    if bad_k1 is not None:
+        return None, None, bad_k1
+    b, bad_b = _parse_optional_float(b_raw, 'b')
+    if bad_b is not None:
+        return None, None, bad_b
+    return k1, b, None
+
+
 def _backend(request: Request) -> SharedSearchBackend:
     return request.app.state.search_backend
 
@@ -62,6 +84,8 @@ async def search_v1(
     query: str | None = Query(None),
     hits: str | None = Query(None),
     parse: str | None = Query(None),
+    k1: str | None = Query(None),
+    b: str | None = Query(None),
 ):
     backend = _backend(request)
     index_token = backend.decode_path_segment(index)
@@ -83,6 +107,10 @@ async def search_v1(
         return bad_parse
     assert parse_flag is not None
 
+    k1_val, b_val, bad_bm25 = _parse_bm25_params(k1, b)
+    if bad_bm25 is not None:
+        return bad_bm25
+
     try:
         payload = await asyncio.to_thread(
             backend.search,
@@ -92,6 +120,8 @@ async def search_v1(
             '',
             parse_flag,
             True,
+            k1=k1_val,
+            b=b_val,
         )
     except IndexNotAvailableError as e:
         return _error(400, str(e))

--- a/pyserini/server/utils.py
+++ b/pyserini/server/utils.py
@@ -36,9 +36,17 @@ from pyserini.search.lucene import (
 )
 
 
+@dataclass(frozen=True)
+class Bm25Config:
+    """BM25 scoring configuration for sparse search."""
+
+    k1: float
+    b: float
+
+
 @dataclass
-class Bm25SearcherSlot:
-    """Cached immutable LuceneSearcher for a specific BM25 setting."""
+class Bm25SearcherCacheEntry:
+    """Cached immutable LuceneSearcher for a BM25 configuration."""
 
     searcher: LuceneSearcher
     active: int = 0
@@ -56,7 +64,7 @@ class IndexConfig:
     base_index: str | None = None
     index_type: str | None = ''
     # Custom BM25 searchers are immutable after creation; the default searcher remains at open-time defaults.
-    bm25_searchers: OrderedDict[tuple[float, float], Bm25SearcherSlot] = field(default_factory=OrderedDict)
+    bm25_searchers: OrderedDict[Bm25Config, Bm25SearcherCacheEntry] = field(default_factory=OrderedDict)
 
 
 SHARDS = {

--- a/pyserini/server/utils.py
+++ b/pyserini/server/utils.py
@@ -46,6 +46,8 @@ class IndexConfig:
     encoder: str | None = ''
     base_index: str | None = None
     index_type: str | None = ''
+    # BM25 (k1, b) last applied to a TF LuceneSearcher, or None if the searcher is still at open-time defaults.
+    bm25_applied: tuple[float, float] | None = None
 
 
 SHARDS = {

--- a/pyserini/server/utils.py
+++ b/pyserini/server/utils.py
@@ -16,7 +16,8 @@
 
 """Shared helpers for the search server (prebuilt index catalogs and per-connection index types)."""
 
-from dataclasses import dataclass
+from collections import OrderedDict
+from dataclasses import dataclass, field
 from typing import Any
 
 from pyserini.prebuilt_index_info import (
@@ -36,6 +37,14 @@ from pyserini.search.lucene import (
 
 
 @dataclass
+class Bm25SearcherSlot:
+    """Cached immutable LuceneSearcher for a specific BM25 setting."""
+
+    searcher: LuceneSearcher
+    active: int = 0
+
+
+@dataclass
 class IndexConfig:
     """Configuration for a managed search index."""
 
@@ -46,8 +55,8 @@ class IndexConfig:
     encoder: str | None = ''
     base_index: str | None = None
     index_type: str | None = ''
-    # BM25 (k1, b) last applied to a TF LuceneSearcher, or None if the searcher is still at open-time defaults.
-    bm25_applied: tuple[float, float] | None = None
+    # Custom BM25 searchers are immutable after creation; the default searcher remains at open-time defaults.
+    bm25_searchers: OrderedDict[tuple[float, float], Bm25SearcherSlot] = field(default_factory=OrderedDict)
 
 
 SHARDS = {

--- a/tests/core/test_mcp.py
+++ b/tests/core/test_mcp.py
@@ -129,6 +129,22 @@ class TestMCPyseriniServer(unittest.TestCase):
             self._run_async(call_k1_only())
         self.assertIn('together', str(ctx.exception).lower())
 
+    def test_search_bm25_b_only_raises_tool_error(self):
+        async def call_b_only():
+            mcp = _make_mcp_server()
+            async with run_server_async(mcp, transport='streamable-http') as url:
+                async with Client(StreamableHttpTransport(url)) as client:
+                    await client.call_tool('search', {
+                        'query': {'query_txt': 'information retrieval'},
+                        'index': 'cacm',
+                        'hits': 1,
+                        'b': 0.3,
+                    })
+
+        with self.assertRaises(ToolError) as ctx:
+            self._run_async(call_b_only())
+        self.assertIn('together', str(ctx.exception).lower())
+
     def test_search_bm25_custom_params_change_score(self):
         default_result = self._run_async(self._call_tool('search', {
             'query': {'query_txt': 'information retrieval'},

--- a/tests/core/test_mcp.py
+++ b/tests/core/test_mcp.py
@@ -99,6 +99,40 @@ class TestMCPyseriniServer(unittest.TestCase):
         doc_lines = [t for t in payload if isinstance(t, str) and t.startswith('DocID: ')]
         self.assertEqual(len(doc_lines), 3)
 
+    def test_search_bm25_k1_b_params(self):
+        result = self._run_async(self._call_tool('search', {
+            'query': {'query_txt': 'information retrieval'},
+            'index': 'cacm',
+            'hits': 1,
+            'k1': 0.8,
+            'b': 0.3,
+        }))
+        self.assertFalse(result.is_error, msg=getattr(result, 'content', result))
+        payload = self._single_json_content(result)
+        doc_lines = [t for t in payload if isinstance(t, str) and t.startswith('DocID: ')]
+        self.assertEqual(len(doc_lines), 1)
+        self.assertIn('CACM-3134', doc_lines[0])
+
+    def test_search_bm25_k1_only_uses_default_b(self):
+        default_result = self._run_async(self._call_tool('search', {
+            'query': {'query_txt': 'information retrieval'},
+            'index': 'cacm',
+            'hits': 1,
+        }))
+        k1_only_result = self._run_async(self._call_tool('search', {
+            'query': {'query_txt': 'information retrieval'},
+            'index': 'cacm',
+            'hits': 1,
+            'k1': 0.1,
+        }))
+        self.assertFalse(default_result.is_error, msg=getattr(default_result, 'content', default_result))
+        self.assertFalse(k1_only_result.is_error, msg=getattr(k1_only_result, 'content', k1_only_result))
+        default_payload = self._single_json_content(default_result)
+        k1_only_payload = self._single_json_content(k1_only_result)
+        default_line = next(t for t in default_payload if isinstance(t, str) and t.startswith('DocID: '))
+        k1_only_line = next(t for t in k1_only_payload if isinstance(t, str) and t.startswith('DocID: '))
+        self.assertNotEqual(default_line, k1_only_line)
+
     def test_get_index_tool(self):
         result = self._run_async(self._call_tool('get_index', {
             'index_name': 'msmarco-v1-passage',

--- a/tests/core/test_mcp.py
+++ b/tests/core/test_mcp.py
@@ -113,25 +113,46 @@ class TestMCPyseriniServer(unittest.TestCase):
         self.assertEqual(len(doc_lines), 1)
         self.assertIn('CACM-3134', doc_lines[0])
 
-    def test_search_bm25_k1_only_uses_default_b(self):
+    def test_search_bm25_k1_only_raises_tool_error(self):
+        async def call_k1_only():
+            mcp = _make_mcp_server()
+            async with run_server_async(mcp, transport='streamable-http') as url:
+                async with Client(StreamableHttpTransport(url)) as client:
+                    await client.call_tool('search', {
+                        'query': {'query_txt': 'information retrieval'},
+                        'index': 'cacm',
+                        'hits': 1,
+                        'k1': 0.1,
+                    })
+
+        with self.assertRaises(ToolError) as ctx:
+            self._run_async(call_k1_only())
+        self.assertIn('together', str(ctx.exception).lower())
+
+    def test_search_bm25_custom_params_change_score(self):
         default_result = self._run_async(self._call_tool('search', {
             'query': {'query_txt': 'information retrieval'},
             'index': 'cacm',
             'hits': 1,
         }))
-        k1_only_result = self._run_async(self._call_tool('search', {
+        tuned_result = self._run_async(self._call_tool('search', {
             'query': {'query_txt': 'information retrieval'},
             'index': 'cacm',
             'hits': 1,
             'k1': 0.1,
+            'b': 0.1,
         }))
         self.assertFalse(default_result.is_error, msg=getattr(default_result, 'content', default_result))
-        self.assertFalse(k1_only_result.is_error, msg=getattr(k1_only_result, 'content', k1_only_result))
-        default_payload = self._single_json_content(default_result)
-        k1_only_payload = self._single_json_content(k1_only_result)
-        default_line = next(t for t in default_payload if isinstance(t, str) and t.startswith('DocID: '))
-        k1_only_line = next(t for t in k1_only_payload if isinstance(t, str) and t.startswith('DocID: '))
-        self.assertNotEqual(default_line, k1_only_line)
+        self.assertFalse(tuned_result.is_error, msg=getattr(tuned_result, 'content', tuned_result))
+        default_line = next(
+            t for t in self._single_json_content(default_result)
+            if isinstance(t, str) and t.startswith('DocID: ')
+        )
+        tuned_line = next(
+            t for t in self._single_json_content(tuned_result)
+            if isinstance(t, str) and t.startswith('DocID: ')
+        )
+        self.assertNotEqual(default_line, tuned_line)
 
     def test_get_index_tool(self):
         result = self._run_async(self._call_tool('get_index', {

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -39,6 +39,10 @@ _REST_DOC_SUBSTRING = 'Information Storage and Retrieval'
 class _FakeSearcher:
     def __init__(self):
         self.closed = False
+        self.bm25 = None
+
+    def set_bm25(self, k1, b):
+        self.bm25 = (k1, b)
 
     def close(self):
         self.closed = True
@@ -328,7 +332,7 @@ class TestRestServer(unittest.TestCase):
 
         with unittest.mock.patch.object(
             backend,
-            '_new_bm25_searcher',
+            '_build_searcher',
             side_effect=[first, second, third],
         ):
             searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
@@ -350,27 +354,30 @@ class TestRestServer(unittest.TestCase):
         self.assertTrue(first.closed)
         self.assertFalse(second.closed)
         self.assertFalse(third.closed)
+        self.assertEqual(first.bm25, (0.1, 0.1))
+        self.assertEqual(second.bm25, (0.2, 0.2))
+        self.assertEqual(third.bm25, (0.3, 0.3))
         self.assertEqual(list(config.bm25_searchers.keys()), [(0.2, 0.2), (0.3, 0.3)])
 
     def test_bm25_variant_pool_preserves_active_searcher(self):
         backend = SharedSearchBackend(bm25_variant_cache_size=1)
         config = IndexConfig(name='fake-tf', index_type='tf')
         first = _FakeSearcher()
-        second = _FakeSearcher()
 
         with unittest.mock.patch.object(
             backend,
-            '_new_bm25_searcher',
-            side_effect=[first, second],
-        ):
+            '_build_searcher',
+            return_value=first,
+        ) as build_searcher:
             searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
             self.assertIs(searcher, first)
             with self.assertRaises(BadSearchRequestError):
                 backend._acquire_bm25_searcher('fake-tf', config, (0.2, 0.2))
             backend._release_bm25_searcher('fake-tf', config, key)
 
+        self.assertEqual(build_searcher.call_count, 1)
         self.assertFalse(first.closed)
-        self.assertFalse(second.closed)
+        self.assertEqual(first.bm25, (0.1, 0.1))
         self.assertEqual(list(config.bm25_searchers.keys()), [(0.1, 0.1)])
 
     def test_post_to_search_not_allowed_405(self):

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -24,7 +24,7 @@ import hashlib
 import yaml
 from fastapi.testclient import TestClient
 
-from pyserini.server.backend import BM25_DEFAULT_B, BM25_DEFAULT_K1
+from pyserini.server.backend import BM25_DEFAULT_B, BM25_DEFAULT_K1, SharedSearchBackend
 from pyserini.server.errors import BadSearchRequestError
 from pyserini.server.rest.app import API_VERSION, ROUTE_ERROR, app, create_app
 from pyserini.server.utils import IndexConfig
@@ -34,6 +34,14 @@ _REST_INDEX = 'cacm'
 _REST_QUERY = 'information retrieval'
 _REST_TOP_DOCID = 'CACM-3134'
 _REST_DOC_SUBSTRING = 'Information Storage and Retrieval'
+
+
+class _FakeSearcher:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
 
 
 class TestRestServer(unittest.TestCase):
@@ -246,6 +254,22 @@ class TestRestServer(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('k1', response.json().get('error', ''))
 
+    def test_search_bm25_b_above_one_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.8', 'b': '1.1'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('b', response.json().get('error', ''))
+
+    def test_search_bm25_nan_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': 'nan', 'b': '0.3'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('finite', response.json().get('error', ''))
+
     def test_search_bm25_custom_params_change_score(self):
         default_resp = self.client.get(
             f'/{API_VERSION}/{_REST_INDEX}/search',
@@ -304,6 +328,60 @@ class TestRestServer(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn('k1', response.json().get('error', ''))
+
+    def test_bm25_variant_pool_reuses_and_evicts_idle_searchers(self):
+        backend = SharedSearchBackend(bm25_variant_cache_size=2)
+        config = IndexConfig(name='fake-tf', index_type='tf')
+        first = _FakeSearcher()
+        second = _FakeSearcher()
+        third = _FakeSearcher()
+
+        with unittest.mock.patch.object(
+            backend,
+            '_new_bm25_searcher',
+            side_effect=[first, second, third],
+        ):
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
+            self.assertIs(searcher, first)
+            backend._release_bm25_searcher('fake-tf', config, key)
+
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
+            self.assertIs(searcher, first)
+            backend._release_bm25_searcher('fake-tf', config, key)
+
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.2, 0.2))
+            self.assertIs(searcher, second)
+            backend._release_bm25_searcher('fake-tf', config, key)
+
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.3, 0.3))
+            self.assertIs(searcher, third)
+            backend._release_bm25_searcher('fake-tf', config, key)
+
+        self.assertTrue(first.closed)
+        self.assertFalse(second.closed)
+        self.assertFalse(third.closed)
+        self.assertEqual(list(config.bm25_searchers.keys()), [(0.2, 0.2), (0.3, 0.3)])
+
+    def test_bm25_variant_pool_preserves_active_searcher(self):
+        backend = SharedSearchBackend(bm25_variant_cache_size=1)
+        config = IndexConfig(name='fake-tf', index_type='tf')
+        first = _FakeSearcher()
+        second = _FakeSearcher()
+
+        with unittest.mock.patch.object(
+            backend,
+            '_new_bm25_searcher',
+            side_effect=[first, second],
+        ):
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
+            self.assertIs(searcher, first)
+            with self.assertRaises(BadSearchRequestError):
+                backend._acquire_bm25_searcher('fake-tf', config, (0.2, 0.2))
+            backend._release_bm25_searcher('fake-tf', config, key)
+
+        self.assertFalse(first.closed)
+        self.assertFalse(second.closed)
+        self.assertEqual(list(config.bm25_searchers.keys()), [(0.1, 0.1)])
 
     def test_post_to_search_not_allowed_405(self):
         response = self.client.post(f'/{API_VERSION}/{_REST_INDEX}/search', params={'query': 'x'})

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -272,7 +272,7 @@ class TestRestServer(unittest.TestCase):
             params={'query': _REST_QUERY, 'hits': 1, 'k1': 'nan', 'b': '0.3'},
         )
         self.assertEqual(response.status_code, 400)
-        self.assertIn('finite', response.json().get('error', ''))
+        self.assertIn('k1', response.json().get('error', ''))
 
     def test_search_bm25_custom_params_change_score(self):
         default_resp = self.client.get(
@@ -323,7 +323,7 @@ class TestRestServer(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('k1', response.json().get('error', ''))
 
-    def test_bm25_config_pool_reuses_and_evicts_idle_searchers(self):
+    def test_bm25_config_pool_reuses_and_evicts_least_recently_used_idle_searcher(self):
         backend = SharedSearchBackend(bm25_searcher_cache_size=2)
         config = IndexConfig(name='fake-tf', index_type='tf')
         first = _FakeSearcher()
@@ -342,25 +342,25 @@ class TestRestServer(unittest.TestCase):
             self.assertIs(searcher, first)
             backend._release_bm25_searcher('fake-tf', config, key)
 
-            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_a)
-            self.assertIs(searcher, first)
-            backend._release_bm25_searcher('fake-tf', config, key)
-
             searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_b)
             self.assertIs(searcher, second)
+            backend._release_bm25_searcher('fake-tf', config, key)
+
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_a)
+            self.assertIs(searcher, first)
             backend._release_bm25_searcher('fake-tf', config, key)
 
             searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_c)
             self.assertIs(searcher, third)
             backend._release_bm25_searcher('fake-tf', config, key)
 
-        self.assertTrue(first.closed)
-        self.assertFalse(second.closed)
+        self.assertFalse(first.closed)
+        self.assertTrue(second.closed)
         self.assertFalse(third.closed)
         self.assertEqual(first.bm25, (0.1, 0.1))
         self.assertEqual(second.bm25, (0.2, 0.2))
         self.assertEqual(third.bm25, (0.3, 0.3))
-        self.assertEqual(list(config.bm25_searchers.keys()), [bm25_b, bm25_c])
+        self.assertEqual(list(config.bm25_searchers.keys()), [bm25_a, bm25_c])
 
     def test_bm25_config_pool_preserves_active_searcher(self):
         backend = SharedSearchBackend(bm25_searcher_cache_size=1)

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -27,7 +27,7 @@ from fastapi.testclient import TestClient
 from pyserini.server.backend import SharedSearchBackend
 from pyserini.server.errors import BadSearchRequestError
 from pyserini.server.rest.app import API_VERSION, ROUTE_ERROR, app, create_app
-from pyserini.server.utils import IndexConfig
+from pyserini.server.utils import Bm25Config, IndexConfig
 
 # Small prebuilt TF index (see TF_INDEX_INFO["cacm"]); stable BM25 top-1 for this query.
 _REST_INDEX = 'cacm'
@@ -323,31 +323,34 @@ class TestRestServer(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('k1', response.json().get('error', ''))
 
-    def test_bm25_variant_pool_reuses_and_evicts_idle_searchers(self):
-        backend = SharedSearchBackend(bm25_variant_cache_size=2)
+    def test_bm25_config_pool_reuses_and_evicts_idle_searchers(self):
+        backend = SharedSearchBackend(bm25_searcher_cache_size=2)
         config = IndexConfig(name='fake-tf', index_type='tf')
         first = _FakeSearcher()
         second = _FakeSearcher()
         third = _FakeSearcher()
+        bm25_a = Bm25Config(k1=0.1, b=0.1)
+        bm25_b = Bm25Config(k1=0.2, b=0.2)
+        bm25_c = Bm25Config(k1=0.3, b=0.3)
 
         with unittest.mock.patch.object(
             backend,
             '_build_searcher',
             side_effect=[first, second, third],
         ):
-            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_a)
             self.assertIs(searcher, first)
             backend._release_bm25_searcher('fake-tf', config, key)
 
-            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_a)
             self.assertIs(searcher, first)
             backend._release_bm25_searcher('fake-tf', config, key)
 
-            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.2, 0.2))
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_b)
             self.assertIs(searcher, second)
             backend._release_bm25_searcher('fake-tf', config, key)
 
-            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.3, 0.3))
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_c)
             self.assertIs(searcher, third)
             backend._release_bm25_searcher('fake-tf', config, key)
 
@@ -357,28 +360,30 @@ class TestRestServer(unittest.TestCase):
         self.assertEqual(first.bm25, (0.1, 0.1))
         self.assertEqual(second.bm25, (0.2, 0.2))
         self.assertEqual(third.bm25, (0.3, 0.3))
-        self.assertEqual(list(config.bm25_searchers.keys()), [(0.2, 0.2), (0.3, 0.3)])
+        self.assertEqual(list(config.bm25_searchers.keys()), [bm25_b, bm25_c])
 
-    def test_bm25_variant_pool_preserves_active_searcher(self):
-        backend = SharedSearchBackend(bm25_variant_cache_size=1)
+    def test_bm25_config_pool_preserves_active_searcher(self):
+        backend = SharedSearchBackend(bm25_searcher_cache_size=1)
         config = IndexConfig(name='fake-tf', index_type='tf')
         first = _FakeSearcher()
+        bm25_a = Bm25Config(k1=0.1, b=0.1)
+        bm25_b = Bm25Config(k1=0.2, b=0.2)
 
         with unittest.mock.patch.object(
             backend,
             '_build_searcher',
             return_value=first,
         ) as build_searcher:
-            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, (0.1, 0.1))
+            searcher, key = backend._acquire_bm25_searcher('fake-tf', config, bm25_a)
             self.assertIs(searcher, first)
             with self.assertRaises(BadSearchRequestError):
-                backend._acquire_bm25_searcher('fake-tf', config, (0.2, 0.2))
+                backend._acquire_bm25_searcher('fake-tf', config, bm25_b)
             backend._release_bm25_searcher('fake-tf', config, key)
 
         self.assertEqual(build_searcher.call_count, 1)
         self.assertFalse(first.closed)
         self.assertEqual(first.bm25, (0.1, 0.1))
-        self.assertEqual(list(config.bm25_searchers.keys()), [(0.1, 0.1)])
+        self.assertEqual(list(config.bm25_searchers.keys()), [bm25_a])
 
     def test_post_to_search_not_allowed_405(self):
         response = self.client.post(f'/{API_VERSION}/{_REST_INDEX}/search', params={'query': 'x'})

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -24,6 +24,7 @@ import hashlib
 import yaml
 from fastapi.testclient import TestClient
 
+from pyserini.server.backend import BM25_DEFAULT_B, BM25_DEFAULT_K1, SharedSearchBackend
 from pyserini.server.rest.app import API_VERSION, ROUTE_ERROR, app, create_app
 
 # Small prebuilt TF index (see TF_INDEX_INFO["cacm"]); stable BM25 top-1 for this query.
@@ -210,6 +211,47 @@ class TestRestServer(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn('query', response.json().get('error', ''))
+
+    def test_search_bm25_k1_b_accepted(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.8', 'b': '0.3'},
+        )
+        self.assertEqual(response.status_code, 200, msg=response.text)
+        self.assertEqual(response.json()['candidates'][0].get('docid'), _REST_TOP_DOCID)
+
+    def test_search_bm25_k1_only_uses_default_b(self):
+        default_resp = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1},
+        )
+        k1_only_resp = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.1'},
+        )
+        self.assertEqual(default_resp.status_code, 200, msg=default_resp.text)
+        self.assertEqual(k1_only_resp.status_code, 200, msg=k1_only_resp.text)
+        default_score = default_resp.json()['candidates'][0]['score']
+        k1_only_score = k1_only_resp.json()['candidates'][0]['score']
+        self.assertNotEqual(default_score, k1_only_score)
+
+    def test_apply_bm25_parameters_changes_scores_on_reused_searcher(self):
+        backend = self.client.app.state.search_backend
+        config = backend._ensure_index(_REST_INDEX, allow_local=True)
+        searcher = config.searcher
+        SharedSearchBackend._apply_bm25_parameters(searcher, BM25_DEFAULT_K1, BM25_DEFAULT_B)
+        score_default = searcher.search(_REST_QUERY, 1)[0].score
+        SharedSearchBackend._apply_bm25_parameters(searcher, 0.1, 0.1)
+        score_tuned = searcher.search(_REST_QUERY, 1)[0].score
+        self.assertNotAlmostEqual(float(score_default), float(score_tuned), places=4)
+
+    def test_search_bm25_k1_not_number_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': 'x', 'b': '0.3'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('k1', response.json().get('error', ''))
 
     def test_post_to_search_not_allowed_405(self):
         response = self.client.post(f'/{API_VERSION}/{_REST_INDEX}/search', params={'query': 'x'})

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -24,8 +24,10 @@ import hashlib
 import yaml
 from fastapi.testclient import TestClient
 
-from pyserini.server.backend import BM25_DEFAULT_B, BM25_DEFAULT_K1, SharedSearchBackend
+from pyserini.server.backend import BM25_DEFAULT_B, BM25_DEFAULT_K1
+from pyserini.server.errors import BadSearchRequestError
 from pyserini.server.rest.app import API_VERSION, ROUTE_ERROR, app, create_app
+from pyserini.server.utils import IndexConfig
 
 # Small prebuilt TF index (see TF_INDEX_INFO["cacm"]); stable BM25 top-1 for this query.
 _REST_INDEX = 'cacm'
@@ -220,28 +222,78 @@ class TestRestServer(unittest.TestCase):
         self.assertEqual(response.status_code, 200, msg=response.text)
         self.assertEqual(response.json()['candidates'][0].get('docid'), _REST_TOP_DOCID)
 
-    def test_search_bm25_k1_only_uses_default_b(self):
+    def test_search_bm25_k1_only_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.1'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('together', response.json().get('error', ''))
+
+    def test_search_bm25_b_only_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'b': '0.3'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('together', response.json().get('error', ''))
+
+    def test_search_bm25_negative_k1_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '-1', 'b': '0.3'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('k1', response.json().get('error', ''))
+
+    def test_search_bm25_custom_params_change_score(self):
         default_resp = self.client.get(
             f'/{API_VERSION}/{_REST_INDEX}/search',
             params={'query': _REST_QUERY, 'hits': 1},
         )
-        k1_only_resp = self.client.get(
+        tuned_resp = self.client.get(
             f'/{API_VERSION}/{_REST_INDEX}/search',
-            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.1'},
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.1', 'b': '0.1'},
         )
         self.assertEqual(default_resp.status_code, 200, msg=default_resp.text)
-        self.assertEqual(k1_only_resp.status_code, 200, msg=k1_only_resp.text)
+        self.assertEqual(tuned_resp.status_code, 200, msg=tuned_resp.text)
         default_score = default_resp.json()['candidates'][0]['score']
-        k1_only_score = k1_only_resp.json()['candidates'][0]['score']
-        self.assertNotEqual(default_score, k1_only_score)
+        tuned_score = tuned_resp.json()['candidates'][0]['score']
+        self.assertNotEqual(default_score, tuned_score)
 
-    def test_apply_bm25_parameters_changes_scores_on_reused_searcher(self):
+    def test_search_bm25_cache_respects_different_k1_b(self):
+        backend = self.client.app.state.search_backend
+        backend._search_cached.cache_clear()
+        r1 = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.8', 'b': '0.3'},
+        )
+        r2 = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'k1': '0.1', 'b': '0.1'},
+        )
+        self.assertEqual(r1.status_code, 200, msg=r1.text)
+        self.assertEqual(r2.status_code, 200, msg=r2.text)
+        self.assertNotEqual(
+            r1.json()['candidates'][0]['score'],
+            r2.json()['candidates'][0]['score'],
+        )
+
+    def test_search_bm25_on_non_sparse_index_400(self):
+        backend = self.client.app.state.search_backend
+        fake_config = IndexConfig(name='fake-dense', index_type='faiss', searcher=object())
+        with unittest.mock.patch.object(backend, '_ensure_index', return_value=fake_config):
+            with self.assertRaises(BadSearchRequestError) as ctx:
+                backend.search(_REST_QUERY, 'fake-dense', k1=0.8, b=0.3)
+        self.assertIn('sparse', str(ctx.exception).lower())
+
+    def test_set_bm25_changes_scores_on_reused_searcher(self):
         backend = self.client.app.state.search_backend
         config = backend._ensure_index(_REST_INDEX, allow_local=True)
         searcher = config.searcher
-        SharedSearchBackend._apply_bm25_parameters(searcher, BM25_DEFAULT_K1, BM25_DEFAULT_B)
+        searcher.set_bm25(BM25_DEFAULT_K1, BM25_DEFAULT_B)
         score_default = searcher.search(_REST_QUERY, 1)[0].score
-        SharedSearchBackend._apply_bm25_parameters(searcher, 0.1, 0.1)
+        searcher.set_bm25(0.1, 0.1)
         score_tuned = searcher.search(_REST_QUERY, 1)[0].score
         self.assertNotAlmostEqual(float(score_default), float(score_tuned), places=4)
 

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -24,7 +24,7 @@ import hashlib
 import yaml
 from fastapi.testclient import TestClient
 
-from pyserini.server.backend import BM25_DEFAULT_B, BM25_DEFAULT_K1, SharedSearchBackend
+from pyserini.server.backend import SharedSearchBackend
 from pyserini.server.errors import BadSearchRequestError
 from pyserini.server.rest.app import API_VERSION, ROUTE_ERROR, app, create_app
 from pyserini.server.utils import IndexConfig
@@ -310,16 +310,6 @@ class TestRestServer(unittest.TestCase):
             with self.assertRaises(BadSearchRequestError) as ctx:
                 backend.search(_REST_QUERY, 'fake-dense', k1=0.8, b=0.3)
         self.assertIn('sparse', str(ctx.exception).lower())
-
-    def test_set_bm25_changes_scores_on_reused_searcher(self):
-        backend = self.client.app.state.search_backend
-        config = backend._ensure_index(_REST_INDEX, allow_local=True)
-        searcher = config.searcher
-        searcher.set_bm25(BM25_DEFAULT_K1, BM25_DEFAULT_B)
-        score_default = searcher.search(_REST_QUERY, 1)[0].score
-        searcher.set_bm25(0.1, 0.1)
-        score_tuned = searcher.search(_REST_QUERY, 1)[0].score
-        self.assertNotAlmostEqual(float(score_default), float(score_tuned), places=4)
 
     def test_search_bm25_k1_not_number_400(self):
         response = self.client.get(


### PR DESCRIPTION
Inspired by https://arxiv.org/abs/2605.10848

## Summary

Adds optional BM25 tuning (`k1`, `b`) to the Pyserini REST and MCP search APIs for sparse (TF) indexes. Parameters must be sent together (matching Pyserini Lucene CLI behaviour); omit both to use Anserini defaults (0.9 / 0.4). Custom settings use a thread-safe pool of immutable `LuceneSearcher` instances so the default searcher is never mutated under concurrency.

## Changes

### API
- **REST:** `GET /v1/{index}/search?k1=...&b=...` — query parsing, validation, and 400s for invalid or partial params; OpenAPI updated.
- **MCP:** `search` tool accepts optional `k1` and `b`, forwarded through `SharedSearchBackend.search`.
- **Docs:** `usage-rest.md` and `usage-mcp.md` document sparse-only behavior and “omit both” semantics.

### Backend (`SharedSearchBackend`)
- Central validation: paired params, finite numbers, `k1 ≥ 0`, `b ∈ [0, 1]`.
- Canonical rounding (6 decimals) for cache keys and variant pool keys.
- Default path: omit both (or explicit 0.9 / 0.4) → shared index searcher.
- Custom path: per-`(k1, b)` searcher with an active-use count, LRU eviction (default pool size 4), and safe close on eviction/shutdown.
- LRU search cache includes `bm25_k1` / `bm25_b` so different settings do not share cached results.
- Rejects `k1` / `b` on non-`tf` index types with a clear error.

### Tests
- REST: acceptance, validation (partial params, bounds, NaN, non-numeric), score differences, cache isolation, non-sparse rejection, variant pool reuse/eviction.
- MCP: happy path, `k1`-only / `b`-only errors, custom params change ranking line.