### PR TITLE
[codex] Fix CosDPR encoder loading with newer Transformers

### DIFF
--- a/pyserini/encode/_cosdpr.py
+++ b/pyserini/encode/_cosdpr.py
@@ -17,9 +17,13 @@
 from typing import Optional
 
 import torch
+from packaging.version import Version
 from transformers import PreTrainedModel, BertConfig, BertModel, BertTokenizer
+from transformers import __version__ as transformers_version
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import load_head_weights
+from pyserini.util import temporary_env
 
 
 class CosDprEncoder(PreTrainedModel):
@@ -52,6 +56,18 @@ class CosDprEncoder(PreTrainedModel):
         self.bert.init_weights()
         self.linear.apply(self._init_weights)
 
+    @classmethod
+    def load_pretrained_encoder(cls, model_name_or_path: str, device: str):
+        with temporary_env(DISABLE_SAFETENSORS_CONVERSION='1'):
+            model = cls.from_pretrained(model_name_or_path, use_safetensors=False)
+        if Version(transformers_version) >= Version("5.0.0"):
+            load_head_weights(model, model_name_or_path, {
+                'linear': 'linear'
+            })
+        model.to(device)
+        model.eval()
+        return model
+
     def forward(
             self,
             input_ids: torch.Tensor,
@@ -77,8 +93,7 @@ class CosDprEncoder(PreTrainedModel):
 class CosDprDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
-        self.model = CosDprEncoder.from_pretrained(model_name)
-        self.model.to(self.device)
+        self.model = CosDprEncoder.load_pretrained_encoder(model_name, self.device)
         self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or model_name,
                                                        clean_up_tokenization_spaces=True)
 
@@ -94,15 +109,15 @@ class CosDprDocumentEncoder(DocumentEncoder):
             return_tensors='pt'
         )
         inputs.to(self.device)
-        return self.model(inputs["input_ids"]).detach().cpu().numpy()
+        with torch.no_grad():
+            return self.model(inputs["input_ids"]).detach().cpu().numpy()
 
 
 class CosDprQueryEncoder(QueryEncoder):
 
     def __init__(self, encoder_dir: str, tokenizer_name: str = None, device: str = 'cpu', **kwargs):
         self.device = device
-        self.model = CosDprEncoder.from_pretrained(encoder_dir)
-        self.model.to(self.device)
+        self.model = CosDprEncoder.load_pretrained_encoder(encoder_dir, self.device)
         self.tokenizer = BertTokenizer.from_pretrained(encoder_dir or tokenizer_name,
                                                        clean_up_tokenization_spaces=True)
 
@@ -118,5 +133,6 @@ class CosDprQueryEncoder(QueryEncoder):
             tokenizer_kwargs['max_length'] = max_length
         inputs = self.tokenizer(query, **tokenizer_kwargs)
         inputs.to(self.device)
-        embeddings = self.model(inputs["input_ids"]).detach().cpu().numpy()
+        with torch.no_grad():
+            embeddings = self.model(inputs["input_ids"]).detach().cpu().numpy()
         return embeddings.flatten()

--- a/pyserini/encode/_cosdpr.py
+++ b/pyserini/encode/_cosdpr.py
@@ -27,6 +27,10 @@ class CosDprEncoder(PreTrainedModel):
     base_model_prefix = 'bert'
     load_tf_weights = None
 
+    @property
+    def all_tied_weights_keys(self):
+        return {}
+
     def __init__(self, config: BertConfig):
         super().__init__(config)
         self.config = config

--- a/tests/base/encoder/test_encoder_model_cosdpr.py
+++ b/tests/base/encoder/test_encoder_model_cosdpr.py
@@ -31,8 +31,8 @@ class TestEncodeCosDpr(unittest.TestCase):
 
         self.assertEqual(vector.shape, (768,))
         self.assertAlmostEqual(np.linalg.norm(vector), 1.0, places=4)
-        self.assertAlmostEqual(vector[0], 0.04074, places=5)
-        self.assertAlmostEqual(vector[-1], 0.01294, places=5)
+        self.assertAlmostEqual(vector[0], -0.00313, places=5)
+        self.assertAlmostEqual(vector[-1], -0.00608, places=5)
 
 
 if __name__ == '__main__':

--- a/tests/base/encoder/test_encoder_model_cosdpr.py
+++ b/tests/base/encoder/test_encoder_model_cosdpr.py
@@ -1,0 +1,39 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+import numpy as np
+import torch
+
+from pyserini.encode import CosDprQueryEncoder
+
+
+class TestEncodeCosDpr(unittest.TestCase):
+    def test_cosdpr_query_encoder(self):
+        torch.manual_seed(12345)
+        encoder = CosDprQueryEncoder('castorini/cosdpr-distil', device='cpu')
+        encoder.model.eval()
+        vector = encoder.encode('what is information retrieval?')
+
+        self.assertEqual(vector.shape, (768,))
+        self.assertAlmostEqual(np.linalg.norm(vector), 1.0, places=4)
+        self.assertAlmostEqual(vector[0], 0.04074, places=5)
+        self.assertAlmostEqual(vector[-1], 0.01294, places=5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Load the cosDPR projection head explicitly under Transformers 5.x so checkpoint weights are used instead of random initialization.
- Put cosDPR encoders in eval mode and encode under `torch.no_grad()`.
- Update the cosDPR encoder test expectations to match the checkpoint-loaded vector.

## Validation

- `python -m unittest tests.base.encoder.test_encoder_model_cosdpr`
- `python -m py_compile pyserini/encode/_cosdpr.py tests/base/encoder/test_encoder_model_cosdpr.py`
- `python -m pyserini.search.faiss --threads 16 --batch-size 512 --index msmarco-v1-passage.cosdpr-distil --topics tmp/q2.tsv --encoder castorini/cosdpr-distil --output tmp/run.q2.cosdpr.fixed.txt --hits 1000`

Additional debug note: qid `2` retrieves judged doc `4339068` at rank 1 after the fix. A partial full-dev run showed healthy completed-query `R@1000 = 0.9796`, but was interrupted before producing all `6,980,000` lines.