### PR TITLE
Add reproduction log for MS MARCO passage BM25 on Narval

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -519,3 +519,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@david23131](https://github.com/david23131) on 2026-05-17 (commit [`ced4918`](https://github.com/castorini/anserini/commit/ced49181906437191253faf474dcc33ac78e3a7f))
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
++ Results reproduced by [@ReyhanehAhani](https://github.com/ReyhanehAhani) on 2026-05-25 (commit [`6c3df1c`](https://github.com/castorini/pyserini/commit/6c3df1c5bf0407781d9f4752dee0641010e16891))


### PR DESCRIPTION
## Summary
- Reproduced `docs/experiments-msmarco-passage.md` (MS MARCO passage BM25 baseline) on Alliance Canada Narval.
- Added reproduction log entry for commit `6c3df1c`.

## Environment
- Cluster: Narval (Alliance Canada / Compute Canada)
- Slurm job: 9 CPUs, 32G RAM, compute node via `sbatch`
- Modules: StdEnv/2023, gcc/12.3, arrow/21.0.0, Java 21, Python 3.12
- Pyserini dev install (`pip install -e .`) with Anserini fatjar in `pyserini/resources/jars/`
- MS MARCO data reused from Anserini clone (symlink); indexing/search/eval on compute node

## Results
- Queries: 6980
- MRR @10: `0.18741227770955546`
- QueriesRanked: 6980

## Notes
- On Narval compute nodes, GitHub downloads are blocked; topic cache and local `tools/scripts/msmarco/msmarco_passage_eval.py` were used instead of remote downloads.
- Full Slurm log attached as `pyserini_repro_log.txt`.

## Test plan
- [x] Index built (8,841,823 documents)
- [x] BM25 retrieval run completed (~6.97M lines in run file)
- [x] Evaluation metrics match expected baseline