### PR TITLE
Add document truncation option for REST API search tool 

### DIFF
--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -139,7 +139,7 @@ If the index cannot be opened, the API responds with **400** and a message such 
 | `parse` | no | `true` | If `true`, parse the stored `raw` field when it is JSON (see `format_lucene_document` / Anserini-style formatting); if `false`, return the raw stored string. |
 | `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and sent together with `b`. |
 | `b` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be in `[0, 1]`, and sent together with `k1`. |
-| `max_doc_chars` | no | — | Return only the first N characters of each candidate document payload. If omitted, the full document payload is returned. |
+| `max_doc_length` | no | — | Maximum characters to return for each parsed candidate document. If omitted, return the full document. Requires `parse=true`. |
 
 **Example**
 
@@ -153,11 +153,15 @@ Custom BM25 parameters (sparse indexes only; both required together):
 curl "http://localhost:8081/v1/cacm/search?query=information%20retrieval&hits=5&k1=0.8&b=0.3"
 ```
 
-Truncate the document payload returned for each hit:
+Limit document text returned for each hit:
 
 ```bash
-curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20a%20lobster%20roll&hits=5&max_doc_chars=500"
+curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20a%20lobster%20roll&hits=5&max_doc_length=500"
 ```
+
+`max_doc_length` is measured in characters. For parsed object documents, only `body`, `content`,
+`contents`, and `text` are limited. Other fields are unchanged. Combining `parse=false` with
+`max_doc_length` returns **400** to avoid returning malformed JSON strings.
 
 With API key auth enabled (`api_keys` in `--config`), for example:
 

--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -139,6 +139,7 @@ If the index cannot be opened, the API responds with **400** and a message such 
 | `parse` | no | `true` | If `true`, parse the stored `raw` field when it is JSON (see `format_lucene_document` / Anserini-style formatting); if `false`, return the raw stored string. |
 | `k1` | no | `0.9` | BM25 k1 for sparse (TF) indexes. Must be finite, non-negative, and sent together with `b`. |
 | `b` | no | `0.4` | BM25 b for sparse (TF) indexes. Must be in `[0, 1]`, and sent together with `k1`. |
+| `max_doc_chars` | no | — | Return only the first N characters of each candidate document payload. If omitted, the full document payload is returned. |
 
 **Example**
 
@@ -150,6 +151,12 @@ Custom BM25 parameters (sparse indexes only; both required together):
 
 ```bash
 curl "http://localhost:8081/v1/cacm/search?query=information%20retrieval&hits=5&k1=0.8&b=0.3"
+```
+
+Truncate the document payload returned for each hit:
+
+```bash
+curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20a%20lobster%20roll&hits=5&max_doc_chars=500"
 ```
 
 With API key auth enabled (`api_keys` in `--config`), for example:

--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -160,7 +160,7 @@ curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20a%20l
 ```
 
 `max_doc_length` is measured in characters. For parsed object documents, only `body`, `content`,
-`contents`, and `text` are limited. Other fields are unchanged. Combining `parse=false` with
+`contents`, and `text` are truncated. Other fields are unchanged. Combining `parse=false` with
 `max_doc_length` returns **400** to avoid returning malformed JSON strings.
 
 With API key auth enabled (`api_keys` in `--config`), for example:

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -34,7 +34,7 @@ from pyserini.search.faiss import FaissSearcher
 from pyserini.search.lucene import JBagOfWordsQueryGenerator, JCovid19QueryGenerator, JDisjunctionMaxQueryGenerator, JQuerySideBm25QueryGenerator, LuceneFlatDenseSearcher, LuceneHnswDenseSearcher, LuceneImpactSearcher, LuceneSearcher
 from pyserini.server.config import load_server_config
 from pyserini.server.utils import INDEX_TYPE, SHARDS, Bm25Config, Bm25SearcherCacheEntry, IndexConfig, create_searcher, lookup_index_type
-from pyserini.server.document_format import format_lucene_document
+from pyserini.server.document_format import format_lucene_document, truncate_document_payload
 from pyserini.server.errors import BadSearchRequestError, DocumentNotFoundError, IndexNotAvailableError
 from pyserini.util import check_downloaded, download_prebuilt_index, download_url, get_cache_home
 
@@ -134,6 +134,7 @@ class _SearchOptions:
     encoder: str | None = None
     query_generator: str | None = None
     bm25_config: Bm25Config | None = None
+    max_doc_chars: int | None = None
 
 
 class SharedSearchBackend:
@@ -640,6 +641,10 @@ class SharedSearchBackend:
                 docid = result.docid
                 score = float(result.score)
             doc = docs_by_id[docid]
+            doc = truncate_document_payload(
+                doc,
+                max_doc_chars=options.max_doc_chars,
+            )
             candidates.append(
                 {
                     'docid': docid,
@@ -664,6 +669,7 @@ class SharedSearchBackend:
         query_generator: str | None = None,
         k1: float | None = None,
         b: float | None = None,
+        max_doc_chars: int | None = None,
     ) -> dict[str, Any]:
         _validate_bm25_params(k1, b)
         options = _SearchOptions(
@@ -675,6 +681,7 @@ class SharedSearchBackend:
             encoder=encoder,
             query_generator=query_generator,
             bm25_config=_canonical_bm25_config(k1, b),
+            max_doc_chars=max_doc_chars,
         )
         # Cache only REST-style string queries; multimodal dict payloads stay uncached.
         if isinstance(query, str):

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -134,7 +134,7 @@ class _SearchOptions:
     encoder: str | None = None
     query_generator: str | None = None
     bm25_config: Bm25Config | None = None
-    max_doc_chars: int | None = None
+    max_doc_length: int | None = None
 
 
 class SharedSearchBackend:
@@ -641,10 +641,11 @@ class SharedSearchBackend:
                 docid = result.docid
                 score = float(result.score)
             doc = docs_by_id[docid]
-            doc = truncate_document_payload(
-                doc,
-                max_doc_chars=options.max_doc_chars,
-            )
+            if options.parse:
+                doc = truncate_document_payload(
+                    doc,
+                    max_doc_length=options.max_doc_length,
+                )
             candidates.append(
                 {
                     'docid': docid,
@@ -669,7 +670,7 @@ class SharedSearchBackend:
         query_generator: str | None = None,
         k1: float | None = None,
         b: float | None = None,
-        max_doc_chars: int | None = None,
+        max_doc_length: int | None = None,
     ) -> dict[str, Any]:
         _validate_bm25_params(k1, b)
         options = _SearchOptions(
@@ -681,7 +682,7 @@ class SharedSearchBackend:
             encoder=encoder,
             query_generator=query_generator,
             bm25_config=_canonical_bm25_config(k1, b),
-            max_doc_chars=max_doc_chars,
+            max_doc_length=max_doc_length,
         )
         # Cache only REST-style string queries; multimodal dict payloads stay uncached.
         if isinstance(query, str):

--- a/pyserini/server/document_format.py
+++ b/pyserini/server/document_format.py
@@ -75,21 +75,19 @@ def format_lucene_document(document: Document | None, parse: bool) -> Any:
 def truncate_document_payload(
     payload: Any,
     *,
-    max_doc_chars: int | None = None,
+    max_doc_length: int | None = None,
 ) -> Any:
-    if max_doc_chars is None:
+    if max_doc_length is None:
         return payload
     if payload is None:
         return None
     if isinstance(payload, str):
-        if max_doc_chars is not None:
-            payload = payload[:max_doc_chars]
-        return payload
+        return payload[:max_doc_length]
     if isinstance(payload, dict):
         keys_to_truncate = {k for k in payload if str(k).lower() in _TRUNCATABLE_FIELDS}
         if keys_to_truncate:
             return {
-                k: truncate_document_payload(v, max_doc_chars=max_doc_chars)
+                k: truncate_document_payload(v, max_doc_length=max_doc_length)
                 if k in keys_to_truncate
                 else v
                 for k, v in payload.items()
@@ -97,7 +95,7 @@ def truncate_document_payload(
         return payload
     if isinstance(payload, list):
         return [
-            truncate_document_payload(v, max_doc_chars=max_doc_chars)
+            truncate_document_payload(v, max_doc_length=max_doc_length)
             for v in payload
         ]
     return payload

--- a/pyserini/server/document_format.py
+++ b/pyserini/server/document_format.py
@@ -84,18 +84,10 @@ def truncate_document_payload(
     if isinstance(payload, str):
         return payload[:max_doc_length]
     if isinstance(payload, dict):
-        keys_to_truncate = {k for k in payload if str(k).lower() in _TRUNCATABLE_FIELDS}
-        if keys_to_truncate:
-            return {
-                k: truncate_document_payload(v, max_doc_length=max_doc_length)
-                if k in keys_to_truncate
-                else v
-                for k, v in payload.items()
-            }
-        return payload
-    if isinstance(payload, list):
-        return [
-            truncate_document_payload(v, max_doc_length=max_doc_length)
-            for v in payload
-        ]
+        return {
+            k: v[:max_doc_length]
+            if str(k).lower() in _TRUNCATABLE_FIELDS and isinstance(v, str)
+            else v
+            for k, v in payload.items()
+        }
     return payload

--- a/pyserini/server/document_format.py
+++ b/pyserini/server/document_format.py
@@ -28,6 +28,7 @@ from typing import Any
 from pyserini.index.lucene import Document
 
 _SKIP_FIELDS = frozenset({'id', '_id', 'docid'})
+_TRUNCATABLE_FIELDS = frozenset({'body', 'content', 'contents', 'text'})
 
 
 def _convert_json_value(value: Any) -> Any:
@@ -69,3 +70,34 @@ def format_lucene_document(document: Document | None, parse: bool) -> Any:
     if isinstance(data, dict):
         return _normalize_parsed_object(data)
     return data
+
+
+def truncate_document_payload(
+    payload: Any,
+    *,
+    max_doc_chars: int | None = None,
+) -> Any:
+    if max_doc_chars is None:
+        return payload
+    if payload is None:
+        return None
+    if isinstance(payload, str):
+        if max_doc_chars is not None:
+            payload = payload[:max_doc_chars]
+        return payload
+    if isinstance(payload, dict):
+        keys_to_truncate = {k for k in payload if str(k).lower() in _TRUNCATABLE_FIELDS}
+        if keys_to_truncate:
+            return {
+                k: truncate_document_payload(v, max_doc_chars=max_doc_chars)
+                if k in keys_to_truncate
+                else v
+                for k, v in payload.items()
+            }
+        return payload
+    if isinstance(payload, list):
+        return [
+            truncate_document_payload(v, max_doc_chars=max_doc_chars)
+            for v in payload
+        ]
+    return payload

--- a/pyserini/server/rest/openapi.yaml
+++ b/pyserini/server/rest/openapi.yaml
@@ -69,13 +69,15 @@ paths:
             BM25 b for sparse (TF) indexes. Must be finite, in [0, 1], and sent together with k1.
             Omit both for Anserini defaults (0.9 / 0.4).
             Returns 400 on non-sparse indexes.
-        - name: max_doc_chars
+        - name: max_doc_length
           in: query
           required: false
           schema:
             type: integer
             minimum: 1
-          description: Return only the first N characters of each candidate document payload. If omitted, the full document payload is returned.
+          description: >
+            Maximum characters to return for each parsed candidate document. If omitted, return
+            the full document. Returns 400 when combined with parse=false.
       responses:
         "200":
           description: Search results.

--- a/pyserini/server/rest/openapi.yaml
+++ b/pyserini/server/rest/openapi.yaml
@@ -69,6 +69,13 @@ paths:
             BM25 b for sparse (TF) indexes. Must be finite, in [0, 1], and sent together with k1.
             Omit both for Anserini defaults (0.9 / 0.4).
             Returns 400 on non-sparse indexes.
+        - name: max_doc_chars
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          description: Return only the first N characters of each candidate document payload. If omitted, the full document payload is returned.
       responses:
         "200":
           description: Search results.

--- a/pyserini/server/rest/routes/v1.py
+++ b/pyserini/server/rest/routes/v1.py
@@ -60,6 +60,18 @@ def _parse_optional_float(raw: str | None, name: str) -> tuple[float | None, JSO
         return None, _error(400, f"Parameter '{name}' must be a number")
 
 
+def _parse_optional_positive_int(raw: str | None, name: str) -> tuple[int | None, JSONResponse | None]:
+    if raw is None or not str(raw).strip():
+        return None, None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None, _error(400, f"Parameter '{name}' must be an integer")
+    if value <= 0:
+        return None, _error(400, f"Parameter '{name}' must be positive")
+    return value, None
+
+
 def _parse_bm25_params(
     k1_raw: str | None,
     b_raw: str | None,
@@ -86,6 +98,7 @@ async def search_v1(
     parse: str | None = Query(None),
     k1: str | None = Query(None),
     b: str | None = Query(None),
+    max_doc_chars: str | None = Query(None),
 ):
     backend = _backend(request)
     index_token = backend.decode_path_segment(index)
@@ -111,6 +124,10 @@ async def search_v1(
     if bad_bm25 is not None:
         return bad_bm25
 
+    max_doc_chars_val, bad_max_doc_chars = _parse_optional_positive_int(max_doc_chars, 'max_doc_chars')
+    if bad_max_doc_chars is not None:
+        return bad_max_doc_chars
+
     try:
         payload = await asyncio.to_thread(
             backend.search,
@@ -122,6 +139,7 @@ async def search_v1(
             True,
             k1=k1_val,
             b=b_val,
+            max_doc_chars=max_doc_chars_val,
         )
     except IndexNotAvailableError as e:
         return _error(400, str(e))

--- a/pyserini/server/rest/routes/v1.py
+++ b/pyserini/server/rest/routes/v1.py
@@ -98,7 +98,7 @@ async def search_v1(
     parse: str | None = Query(None),
     k1: str | None = Query(None),
     b: str | None = Query(None),
-    max_doc_chars: str | None = Query(None),
+    max_doc_length: str | None = Query(None),
 ):
     backend = _backend(request)
     index_token = backend.decode_path_segment(index)
@@ -124,9 +124,11 @@ async def search_v1(
     if bad_bm25 is not None:
         return bad_bm25
 
-    max_doc_chars_val, bad_max_doc_chars = _parse_optional_positive_int(max_doc_chars, 'max_doc_chars')
-    if bad_max_doc_chars is not None:
-        return bad_max_doc_chars
+    max_doc_length_val, bad_max_doc_length = _parse_optional_positive_int(max_doc_length, 'max_doc_length')
+    if bad_max_doc_length is not None:
+        return bad_max_doc_length
+    if max_doc_length_val is not None and not parse_flag:
+        return _error(400, "Parameter 'max_doc_length' requires parse=true")
 
     try:
         payload = await asyncio.to_thread(
@@ -139,7 +141,7 @@ async def search_v1(
             True,
             k1=k1_val,
             b=b_val,
-            max_doc_chars=max_doc_chars_val,
+            max_doc_length=max_doc_length_val,
         )
     except IndexNotAvailableError as e:
         return _error(400, str(e))

--- a/tests/base/test_document_format.py
+++ b/tests/base/test_document_format.py
@@ -21,6 +21,7 @@ from pyserini.server.document_format import (
     _convert_json_value,
     _normalize_parsed_object,
     format_lucene_document,
+    truncate_document_payload,
 )
 
 
@@ -102,6 +103,21 @@ class TestFormatLuceneDocument(unittest.TestCase):
     def test_parse_true_json_null(self):
         doc = _FakeDocument('null')
         self.assertIsNone(format_lucene_document(doc, parse=True))
+
+
+class TestTruncateDocumentPayload(unittest.TestCase):
+    def test_string_truncated_by_chars(self):
+        self.assertEqual(
+            truncate_document_payload('one two three four', max_doc_chars=9),
+            'one two t',
+        )
+
+    def test_dict_truncates_content_fields_only(self):
+        payload = {'title': 'long title stays intact', 'contents': 'one two three', 'encoded_img': 'abcdef'}
+        self.assertEqual(
+            truncate_document_payload(payload, max_doc_chars=7),
+            {'title': 'long title stays intact', 'contents': 'one two', 'encoded_img': 'abcdef'},
+        )
 
 
 if __name__ == '__main__':

--- a/tests/base/test_document_format.py
+++ b/tests/base/test_document_format.py
@@ -108,14 +108,14 @@ class TestFormatLuceneDocument(unittest.TestCase):
 class TestTruncateDocumentPayload(unittest.TestCase):
     def test_string_truncated_by_chars(self):
         self.assertEqual(
-            truncate_document_payload('one two three four', max_doc_chars=9),
+            truncate_document_payload('one two three four', max_doc_length=9),
             'one two t',
         )
 
     def test_dict_truncates_content_fields_only(self):
         payload = {'title': 'long title stays intact', 'contents': 'one two three', 'encoded_img': 'abcdef'}
         self.assertEqual(
-            truncate_document_payload(payload, max_doc_chars=7),
+            truncate_document_payload(payload, max_doc_length=7),
             {'title': 'long title stays intact', 'contents': 'one two', 'encoded_img': 'abcdef'},
         )
 

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -438,23 +438,31 @@ class TestRestServer(unittest.TestCase):
         self.assertIsInstance(doc, str)
         self.assertIn(_REST_DOC_SUBSTRING, doc)
 
-    def test_search_max_doc_chars_truncates_candidate_doc(self):
+    def test_search_max_doc_length_truncates_candidate_doc_when_parse_true(self):
         response = self.client.get(
             f'/{API_VERSION}/{_REST_INDEX}/search',
-            params={'query': _REST_QUERY, 'hits': 1, 'parse': 'false', 'max_doc_chars': '24'},
+            params={'query': _REST_QUERY, 'hits': 1, 'max_doc_length': '24'},
         )
         self.assertEqual(response.status_code, 200, msg=response.text)
         doc = response.json()['candidates'][0]['doc']
         self.assertIsInstance(doc, str)
         self.assertLessEqual(len(doc), 24)
 
-    def test_search_max_doc_chars_invalid_400(self):
+    def test_search_max_doc_length_with_parse_false_400(self):
         response = self.client.get(
             f'/{API_VERSION}/{_REST_INDEX}/search',
-            params={'query': _REST_QUERY, 'hits': 1, 'max_doc_chars': 'abc'},
+            params={'query': _REST_QUERY, 'hits': 1, 'parse': 'false', 'max_doc_length': '24'},
         )
         self.assertEqual(response.status_code, 400)
-        self.assertIn('max_doc_chars', response.json().get('error', ''))
+        self.assertIn('parse=true', response.json().get('error', ''))
+
+    def test_search_max_doc_length_invalid_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'max_doc_length': 'abc'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('max_doc_length', response.json().get('error', ''))
 
     def test_search_candidate_doc_matches_get_document(self):
         search_resp = self.client.get(

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -438,6 +438,24 @@ class TestRestServer(unittest.TestCase):
         self.assertIsInstance(doc, str)
         self.assertIn(_REST_DOC_SUBSTRING, doc)
 
+    def test_search_max_doc_chars_truncates_candidate_doc(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'parse': 'false', 'max_doc_chars': '24'},
+        )
+        self.assertEqual(response.status_code, 200, msg=response.text)
+        doc = response.json()['candidates'][0]['doc']
+        self.assertIsInstance(doc, str)
+        self.assertLessEqual(len(doc), 24)
+
+    def test_search_max_doc_chars_invalid_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/search',
+            params={'query': _REST_QUERY, 'hits': 1, 'max_doc_chars': 'abc'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('max_doc_chars', response.json().get('error', ''))
+
     def test_search_candidate_doc_matches_get_document(self):
         search_resp = self.client.get(
             f'/{API_VERSION}/{_REST_INDEX}/search',


### PR DESCRIPTION
## Summary

Currently, the search tool returns the raw document contents of the top k retrieved results. This could blow-up context with really long documents and renders the get document tool effectively useless, because the search tool already returns full document contents. This PR adds an optional fix for this.

Adds a `max_doc_chars` query parameter to the REST search API so callers can request truncated document payloads for each search result.

When `max_doc_chars` is omitted, search responses preserve the existing behavior and return the full document payload. When provided, each candidate document payload is truncated to the first N characters.

## Details

- Added `max_doc_chars` parsing and validation to `GET /v1/{index}/search`
- Plumbed `max_doc_chars` through `SharedSearchBackend.search`
- Added document payload truncation helper
- Truncates string payloads directly
- For parsed dict payloads, truncates common text fields only: `body`, `content`, `contents`, and `text`
- Updated REST docs and OpenAPI schema
- Added tests for truncation behavior and invalid parameter handling