### PR TITLE
Add max_doc_length to REST document fetch

### DIFF
--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -203,12 +203,23 @@ The `doc` field may be `null`, a string, or a JSON value depending on the index 
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
 | `parse` | no | `true` | Same meaning as for search. |
+| `max_doc_length` | no | — | Maximum characters to return for the parsed document. If omitted, return the full document. Requires `parse=true`. |
 
 **Example**
 
 ```bash
 curl "http://localhost:8081/v1/msmarco-v1-passage/doc/7157707"
 ```
+
+Limit document text returned:
+
+```bash
+curl "http://localhost:8081/v1/msmarco-v1-passage/doc/7157707?max_doc_length=500"
+```
+
+`max_doc_length` is measured in characters. For parsed object documents, only `body`, `content`,
+`contents`, and `text` are limited. Other fields are unchanged. Combining `parse=false` with
+`max_doc_length` returns **400** to avoid returning malformed JSON strings.
 
 With API key auth enabled (`api_keys` in `--config`), for example:
 

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -566,8 +566,12 @@ class SharedSearchBackend:
         index_name: str,
         parse: bool = True,
         allow_local_index: bool = True,
+        max_doc_length: int | None = None,
     ) -> dict[str, Any] | str:
-        return self._document_cached(docid, index_name, parse, allow_local_index)
+        doc = self._document_cached(docid, index_name, parse, allow_local_index)
+        if parse:
+            doc = truncate_document_payload(doc, max_doc_length=max_doc_length)
+        return doc
 
     def _search_impl(
         self,

--- a/pyserini/server/rest/openapi.yaml
+++ b/pyserini/server/rest/openapi.yaml
@@ -153,6 +153,15 @@ paths:
             type: boolean
             default: true
           description: If true, try to return parsed document contents; if false, return the raw stored document string.
+        - name: max_doc_length
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          description: >
+            Maximum characters to return for the parsed document. If omitted, return the full
+            document. Returns 400 when combined with parse=false.
       responses:
         "200":
           description: Document found.

--- a/pyserini/server/rest/routes/v1.py
+++ b/pyserini/server/rest/routes/v1.py
@@ -172,6 +172,7 @@ async def get_document_v1(
     index: str,
     docid: str,
     parse: str | None = Query(None),
+    max_doc_length: str | None = Query(None),
 ):
     backend = _backend(request)
     index_token = backend.decode_path_segment(index)
@@ -185,8 +186,21 @@ async def get_document_v1(
         return bad_parse
     assert parse_flag is not None
 
+    max_doc_length_val, bad_max_doc_length = _parse_optional_positive_int(max_doc_length, 'max_doc_length')
+    if bad_max_doc_length is not None:
+        return bad_max_doc_length
+    if max_doc_length_val is not None and not parse_flag:
+        return _error(400, "Parameter 'max_doc_length' requires parse=true")
+
     try:
-        doc = await asyncio.to_thread(backend.get_document, docid_token, index_token, parse_flag, True)
+        doc = await asyncio.to_thread(
+            backend.get_document,
+            docid_token,
+            index_token,
+            parse_flag,
+            True,
+            max_doc_length=max_doc_length_val,
+        )
         return {
             'api': 'v1',
             'index': index_token,

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -164,6 +164,32 @@ class TestRestServer(unittest.TestCase):
             self.assertIsNotNone(contents)
             self.assertIn(_REST_DOC_SUBSTRING, contents)
 
+    def test_get_doc_max_doc_length_truncates_doc_when_parse_true(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/doc/{_REST_TOP_DOCID}',
+            params={'max_doc_length': '24'},
+        )
+        self.assertEqual(response.status_code, 200, msg=response.text)
+        doc = response.json()['doc']
+        self.assertIsInstance(doc, str)
+        self.assertLessEqual(len(doc), 24)
+
+    def test_get_doc_max_doc_length_with_parse_false_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/doc/{_REST_TOP_DOCID}',
+            params={'parse': 'false', 'max_doc_length': '24'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('parse=true', response.json().get('error', ''))
+
+    def test_get_doc_max_doc_length_invalid_400(self):
+        response = self.client.get(
+            f'/{API_VERSION}/{_REST_INDEX}/doc/{_REST_TOP_DOCID}',
+            params={'max_doc_length': 'abc'},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('max_doc_length', response.json().get('error', ''))
+
     def test_get_doc_repeated_request_uses_backend_cache(self):
         backend = self.client.app.state.search_backend
         backend._document_cached.cache_clear()


### PR DESCRIPTION
## Summary

Adds max_doc_length to GET /v1/{index}/doc/{docid} so callers can limit returned parsed document text by character count.

This mirrors the existing REST search behavior:

- omitted max_doc_length returns the full document
- max_doc_length is measured in characters
- parsed string documents are sliced directly
- parsed object documents limit only body, content, contents, and text
- parse=false with max_doc_length returns 400 to avoid returning malformed raw JSON strings

## Tests

python -m pytest tests/core/test_rest.py tests/base/test_document_format.py -q

Result: 68 passed.