### PR TITLE
Add onboarding reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -482,3 +482,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@david23131](https://github.com/david23131) on 2026-05-17 (commit [`ced4918`](https://github.com/castorini/anserini/commit/ced49181906437191253faf474dcc33ac78e3a7f))
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -739,3 +739,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@david23131](https://github.com/david23131) on 2026-05-18 (commit [`ced4918`](https://github.com/castorini/anserini/commit/ced49181906437191253faf474dcc33ac78e3a7f))
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -225,3 +225,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@david23131](https://github.com/david23131) on 2026-05-18 (commit [`ced4918`](https://github.com/castorini/anserini/commit/ced49181906437191253faf474dcc33ac78e3a7f))
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -519,3 +519,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@david23131](https://github.com/david23131) on 2026-05-17 (commit [`ced4918`](https://github.com/castorini/anserini/commit/ced49181906437191253faf474dcc33ac78e3a7f))
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -526,3 +526,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@david23131](https://github.com/david23131) on 2026-05-17 (commit [`ced4918`](https://github.com/castorini/anserini/commit/ced49181906437191253faf474dcc33ac78e3a7f))
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))


### PR DESCRIPTION
# Summary

Reproduced the Foundations of Retrieval onboarding tasks in Pyserini and added reproduction-log entries.

## Environment

- macOS 15.7.3 on Apple Silicon
- Conda environment: `jimmy-ir`
- Python: 3.12.13
- Pyserini: 2.1.0
- Faiss: 1.10.0
- Java: OpenJDK 21.0.10
- Pyserini commit: `45361866da443a8127bf964f2095703dfd7b19a6`

## Tasks

- `docs/experiments-msmarco-passage.md`
  - MS MARCO MRR@10: `0.18741227770955546`
  - MAP: `0.1958`
  - recall@1000: `0.8573`
  - query `1048585` reciprocal rank: `1.0000`
- `docs/conceptual-framework.md`
  - query tokens: `['what', 'paula', 'deen', 'brother']`
  - manual BM25 dot product: `17.949487686157227`
  - rank 1 document: `7187158`
- `docs/experiments-nfcorpus.md`
  - BGE nDCG@10: `0.3808`
  - interactive rank 1 document: `MED-4555`
- `docs/conceptual-framework2.md`
  - Faiss vector count: 3,633
  - dense manual dot product: `0.7913785`
  - BM25 nDCG@10: `0.3218`
  - sparse manual dot product: `11.9305`
- `docs/conceptual-framework3.md`
  - SPLADE nDCG@10: `0.3624`
  - interactive rank 1 document: `MED-4555`

## Notes

- Only reproduction-log documentation edits are included.
- Datasets, indexes, runs, model files, and caches are not committed.
