### PR TITLE
Add unified JSONL REST request logging

### DIFF
--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -88,9 +88,11 @@ REST server logging options:
   uvicorn access logs are disabled because the JSONL request log is the canonical access log.
   If combined with `--log-file`, uvicorn text access lines are appended to the same file.
 
-Each JSONL request record includes the timestamp, client, method, path, full query string,
-status, latency, auth outcome, and a non-reversible API-key fingerprint when credentials are present.
-Auth failures and load-shedding responses are written to the same log as successful requests.
+Each JSONL request record includes the timestamp, request ID, client, method, path, query string
+(capped at 1000 characters), status, latency, auth outcome, and a non-reversible API-key fingerprint
+when credentials are present. Auth failures and load-shedding responses are written to the same log as
+successful requests. The server generates a request ID for each request, logs it, and returns it as
+`X-Request-ID`.
 
 Example:
 
@@ -116,7 +118,7 @@ lines.
 Example request log line:
 
 ```json
-{"auth":"authenticated","client":"127.0.0.1","event":"request","key_id":"7f83b1657ff1","latency_ms":14.217,"method":"GET","path":"/v1/cacm/search","query":"query=information+retrieval&hits=1","status":200,"ts":"2026-05-31T16:42:03.123Z"}
+{"auth":"authenticated","client":"127.0.0.1","event":"request","key_id":"7f83b1657ff1","latency_ms":14.217,"method":"GET","path":"/v1/cacm/search","query":"query=information+retrieval&hits=1","query_truncated":false,"request_id":"8dd7f6fa4b7a4a04a029a70c7cf4ec75","status":200,"ts":"2026-05-31T16:42:03.123Z"}
 ```
 
 ## Discovery and documentation

--- a/docs/usage-rest.md
+++ b/docs/usage-rest.md
@@ -83,9 +83,14 @@ python -m pyserini.server.rest --search-cache-size 4096 --document-cache-size 81
 
 REST server logging options:
 
-- `--server-log-file <path>` writes uvicorn error + access logs to a file.
-- `--auth-log-file <path>` writes auth request attribution logs (client, route, status, key fingerprint) to a file.
-- `--no-access-log` disables uvicorn request access logging.
+- `--log-file <path>` writes unified JSONL request logs, one request per line.
+- `--keep-uvicorn-logs` keeps uvicorn's default text request access logging. By default,
+  uvicorn access logs are disabled because the JSONL request log is the canonical access log.
+  If combined with `--log-file`, uvicorn text access lines are appended to the same file.
+
+Each JSONL request record includes the timestamp, client, method, path, full query string,
+status, latency, auth outcome, and a non-reversible API-key fingerprint when credentials are present.
+Auth failures and load-shedding responses are written to the same log as successful requests.
 
 Example:
 
@@ -93,8 +98,25 @@ Example:
 python -m pyserini.server.rest \
   --config /path/to/server.yaml \
   --no-prebuilt-indexes \
-  --server-log-file logs/rest.server.log \
-  --auth-log-file logs/rest.auth.log
+  --log-file logs/rest.requests.jsonl
+```
+
+To keep uvicorn's text access logs anyway:
+
+```bash
+python -m pyserini.server.rest \
+  --config /path/to/server.yaml \
+  --log-file logs/rest.requests.jsonl \
+  --keep-uvicorn-logs
+```
+
+In this mode, `logs/rest.requests.jsonl` contains both JSONL request records and uvicorn text access
+lines.
+
+Example request log line:
+
+```json
+{"auth":"authenticated","client":"127.0.0.1","event":"request","key_id":"7f83b1657ff1","latency_ms":14.217,"method":"GET","path":"/v1/cacm/search","query":"query=information+retrieval&hits=1","status":200,"ts":"2026-05-31T16:42:03.123Z"}
 ```
 
 ## Discovery and documentation

--- a/pyserini/server/rest/app.py
+++ b/pyserini/server/rest/app.py
@@ -37,6 +37,7 @@ import logging
 import hashlib
 import threading
 import time
+import uuid
 from collections import deque
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -61,6 +62,8 @@ API_VERSION = 'v1'
 DESCRIPTION = 'REST API aligned with Anserini (Lucene indexes via Pyserini).'
 ROUTE_ERROR = 'Expected route /v1/{index}/search or /v1/{index}/doc/{docid}'
 AUTH_TOKEN_REQUEST_EMAIL = 'get-pyserini@googlegroups.com'
+MAX_LOGGED_QUERY_CHARS = 1000
+REQUEST_ID_HEADER = 'X-Request-ID'
 
 
 # Hint for clients when we return 429 (also sent as ``Retry-After`` header).
@@ -227,8 +230,15 @@ def _compute_token_fingerprint(token: str | None) -> str:
     return hashlib.sha256(t.encode('utf-8')).hexdigest()[:12]
 
 
-def _request_query(request: Request) -> str:
-    return request.url.query
+def _request_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _request_query_for_log(request: Request) -> tuple[str, bool]:
+    query = request.url.query
+    if len(query) <= MAX_LOGGED_QUERY_CHARS:
+        return query, False
+    return query[:MAX_LOGGED_QUERY_CHARS], True
 
 
 def _build_uvicorn_log_config(
@@ -336,13 +346,17 @@ def create_app(
     async def rest_api_key_and_access_log(request: Request, call_next):
         t0 = time.perf_counter()
         client = request.client.host if request.client else ''
+        request_id = _request_id()
+        query, query_truncated = _request_query_for_log(request)
         log_entry: dict[str, object] = {
             'ts': _now_iso8601(),
             'event': 'request',
+            'request_id': request_id,
             'client': client,
             'method': request.method,
             'path': request.url.path,
-            'query': _request_query(request),
+            'query': query,
+            'query_truncated': query_truncated,
             'status': 500,
             'latency_ms': 0.0,
             'auth': 'not_configured',
@@ -367,6 +381,7 @@ def create_app(
                                 f'email {AUTH_TOKEN_REQUEST_EMAIL}.'
                             )
                         },
+                        headers={REQUEST_ID_HEADER: request_id},
                     )
                 else:
                     log_entry['auth'] = 'authenticated'
@@ -376,7 +391,10 @@ def create_app(
                         response = JSONResponse(
                             status_code=429,
                             content={'error': _LOAD_SHED_ERROR_BODY},
-                            headers={'Retry-After': str(_LOAD_SHED_RETRY_AFTER_SEC)},
+                            headers={
+                                'Retry-After': str(_LOAD_SHED_RETRY_AFTER_SEC),
+                                REQUEST_ID_HEADER: request_id,
+                            },
                         )
                     else:
                         response = await call_next(request)
@@ -386,6 +404,7 @@ def create_app(
             else:
                 response = await call_next(request)
             log_entry['status'] = response.status_code
+            response.headers[REQUEST_ID_HEADER] = request_id
             return response
         except Exception:
             logger.warning(

--- a/pyserini/server/rest/app.py
+++ b/pyserini/server/rest/app.py
@@ -19,7 +19,8 @@ FastAPI server exposing the same REST surface as Anserini (``openapi.yaml``).
 
 Usage:
     python -m pyserini.server.rest [--host HOST] [--port PORT] [--config PATH] [--no-prebuilt-indexes] 
-                                   [--load-shedding-threshold MS] [--search-cache-size N] [--document-cache-size N]
+                                   [--log-file PATH] [--keep-uvicorn-logs] [--load-shedding-threshold MS]
+                                   [--search-cache-size N] [--document-cache-size N]
 
 Endpoints:
     GET /openapi.yaml     : OpenAPI specification (same document as Anserini).
@@ -38,6 +39,7 @@ import threading
 import time
 from collections import deque
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from functools import lru_cache
 from importlib import resources
 
@@ -52,7 +54,7 @@ from pyserini.server.config import AcceptedApiTokens, load_server_config
 from pyserini.server.rest.routes import v1
 
 logger = logging.getLogger(__name__)
-auth_logger = logging.getLogger('pyserini.server.rest.auth')
+request_logger = logging.getLogger('pyserini.server.rest.request')
 
 SERVER_NAME = 'Pyserini API'
 API_VERSION = 'v1'
@@ -169,17 +171,12 @@ class RestBackpressure:
             self._prune_latencies(now)
 
 
-def _log_auth_attribution(event: str, client: str, request: Request, query: str, key_id: str, status: int) -> None:
-    auth_logger.info(
-        '%s client=%s method=%s path=%s query=%s key_id=%s status=%s',
-        event,
-        client,
-        request.method,
-        request.url.path,
-        query,
-        key_id,
-        status,
-    )
+def _now_iso8601() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00', 'Z')
+
+
+def _log_request_jsonl(entry: dict[str, object]) -> None:
+    request_logger.info(json.dumps(entry, sort_keys=True, separators=(',', ':')))
 
 
 def _error_message(detail: object) -> str:
@@ -230,16 +227,15 @@ def _compute_token_fingerprint(token: str | None) -> str:
     return hashlib.sha256(t.encode('utf-8')).hexdigest()[:12]
 
 
-def _truncate_request_query(request: Request) -> str:
-    raw = request.url.query
-    if not raw:
-        return '-'
-    if len(raw) <= 256:
-        return raw
-    return f'{raw[:256]}...'
+def _request_query(request: Request) -> str:
+    return request.url.query
 
 
-def _build_uvicorn_log_config(server_log_file: str | None, auth_log_file: str | None) -> dict[str, object]:
+def _build_uvicorn_log_config(
+    request_log_file: str | None,
+    *,
+    keep_uvicorn_logs: bool = False,
+) -> dict[str, object]:
     from uvicorn.config import LOGGING_CONFIG
 
     config = copy.deepcopy(LOGGING_CONFIG)
@@ -247,50 +243,39 @@ def _build_uvicorn_log_config(server_log_file: str | None, auth_log_file: str | 
     handlers = config.setdefault('handlers', {})
     loggers = config.setdefault('loggers', {})
 
-    formatters['auth'] = {
-        'format': '%(asctime)s %(levelname)s %(name)s %(message)s',
-        'datefmt': '%Y-%m-%d %H:%M:%S',
+    formatters['jsonl'] = {
+        'format': '%(message)s',
     }
 
-    if server_log_file:
-        handlers['server_default_file'] = {
+    if request_log_file:
+        handlers['request_jsonl_file'] = {
             'class': 'logging.FileHandler',
-            'formatter': 'default',
-            'filename': server_log_file,
+            'formatter': 'jsonl',
+            'filename': request_log_file,
             'encoding': 'utf-8',
         }
-        handlers['server_access_file'] = {
-            'class': 'logging.FileHandler',
-            'formatter': 'access',
-            'filename': server_log_file,
-            'encoding': 'utf-8',
-        }
-        if 'uvicorn.error' in loggers:
-            loggers['uvicorn.error']['handlers'] = ['server_default_file']
-        if 'uvicorn.access' in loggers:
-            loggers['uvicorn.access']['handlers'] = ['server_access_file']
-
-    if auth_log_file:
-        handlers['auth_file'] = {
-            'class': 'logging.FileHandler',
-            'formatter': 'auth',
-            'filename': auth_log_file,
-            'encoding': 'utf-8',
-        }
-        auth_handlers = ['auth_file']
+        request_handlers = ['request_jsonl_file']
     else:
-        handlers['auth_console'] = {
+        handlers['request_jsonl_console'] = {
             'class': 'logging.StreamHandler',
-            'formatter': 'auth',
+            'formatter': 'jsonl',
             'stream': 'ext://sys.stderr',
         }
-        auth_handlers = ['auth_console']
+        request_handlers = ['request_jsonl_console']
 
-    loggers['pyserini.server.rest.auth'] = {
-        'handlers': auth_handlers,
+    loggers['pyserini.server.rest.request'] = {
+        'handlers': request_handlers,
         'level': 'INFO',
         'propagate': False,
     }
+    if keep_uvicorn_logs and request_log_file and 'uvicorn.access' in loggers:
+        handlers['uvicorn_access_request_file'] = {
+            'class': 'logging.FileHandler',
+            'formatter': 'access',
+            'filename': request_log_file,
+            'encoding': 'utf-8',
+        }
+        loggers['uvicorn.access']['handlers'] = ['uvicorn_access_request_file']
     return config
 
 
@@ -349,46 +334,58 @@ def create_app(
 
     @app.middleware('http')
     async def rest_api_key_and_access_log(request: Request, call_next):
+        t0 = time.perf_counter()
+        client = request.client.host if request.client else ''
+        log_entry: dict[str, object] = {
+            'ts': _now_iso8601(),
+            'event': 'request',
+            'client': client,
+            'method': request.method,
+            'path': request.url.path,
+            'query': _request_query(request),
+            'status': 500,
+            'latency_ms': 0.0,
+            'auth': 'not_configured',
+            'key_id': None,
+        }
         prefix = f'/{API_VERSION}/'
         tokens: AcceptedApiTokens | None = getattr(request.app.state, 'accepted_api_tokens', None)
-        if tokens is None or not request.url.path.startswith(prefix):
-            return await call_next(request)
-
-        client = request.client.host if request.client else '-'
-        query = _truncate_request_query(request)
-        credentials = _extract_api_tokens(request)
-        matched_token = next((token for token in credentials if tokens.is_valid(token)), None)
-        key_id = _compute_token_fingerprint(matched_token or (credentials[0] if credentials else None))
-        if matched_token is None:
-            _log_auth_attribution('auth_failed', client, request, query, key_id, 401)
-            return JSONResponse(
-                status_code=401,
-                content={
-                    'error': (
-                        'Unauthorized. To request an access token, '
-                        f'email {AUTH_TOKEN_REQUEST_EMAIL}.'
-                    )
-                },
-            )
-
-        bp: RestBackpressure | None = getattr(request.app.state, 'rest_backpressure', None)
-        t0 = time.perf_counter()
-        if bp is not None and bp.should_shed(key_id, t0):
-            _log_auth_attribution('auth_request', client, request, query, key_id, 429)
-            return JSONResponse(
-                status_code=429,
-                content={'error': _LOAD_SHED_ERROR_BODY},
-                headers={'Retry-After': str(_LOAD_SHED_RETRY_AFTER_SEC)},
-            )
-
-        status = 500
         response = None
         try:
-            response = await call_next(request)
-            status = response.status_code
-            if bp is not None:
-                now = time.perf_counter()
-                bp.record_latency((now - t0) * 1000.0, now)
+            if tokens is not None and request.url.path.startswith(prefix):
+                credentials = _extract_api_tokens(request)
+                matched_token = next((token for token in credentials if tokens.is_valid(token)), None)
+                key_id = _compute_token_fingerprint(matched_token or (credentials[0] if credentials else None))
+                log_entry['key_id'] = key_id
+                if matched_token is None:
+                    log_entry['auth'] = 'invalid' if credentials else 'missing'
+                    response = JSONResponse(
+                        status_code=401,
+                        content={
+                            'error': (
+                                'Unauthorized. To request an access token, '
+                                f'email {AUTH_TOKEN_REQUEST_EMAIL}.'
+                            )
+                        },
+                    )
+                else:
+                    log_entry['auth'] = 'authenticated'
+                    bp: RestBackpressure | None = getattr(request.app.state, 'rest_backpressure', None)
+                    if bp is not None and bp.should_shed(key_id, t0):
+                        log_entry['auth'] = 'load_shed'
+                        response = JSONResponse(
+                            status_code=429,
+                            content={'error': _LOAD_SHED_ERROR_BODY},
+                            headers={'Retry-After': str(_LOAD_SHED_RETRY_AFTER_SEC)},
+                        )
+                    else:
+                        response = await call_next(request)
+                        if bp is not None:
+                            now = time.perf_counter()
+                            bp.record_latency((now - t0) * 1000.0, now)
+            else:
+                response = await call_next(request)
+            log_entry['status'] = response.status_code
             return response
         except Exception:
             logger.warning(
@@ -399,7 +396,8 @@ def create_app(
             )
             raise
         finally:
-            _log_auth_attribution('auth_request', client, request, query, key_id, status)
+            log_entry['latency_ms'] = round((time.perf_counter() - t0) * 1000.0, 3)
+            _log_request_jsonl(log_entry)
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):
@@ -464,21 +462,15 @@ def main():
         help='Only allow indexes declared in --config (disable prebuilt names and arbitrary filesystem paths).',
     )
     parser.add_argument(
-        '--server-log-file',
+        '--log-file',
         type=str,
         default=None,
-        help='Optional file path for uvicorn server logs (error/access).',
+        help='Optional file path for unified JSONL request logs (one request per line).',
     )
     parser.add_argument(
-        '--auth-log-file',
-        type=str,
-        default=None,
-        help='Optional file path for timestamped auth attribution logs.',
-    )
-    parser.add_argument(
-        '--no-access-log',
+        '--keep-uvicorn-logs',
         action='store_true',
-        help='Disable uvicorn default request access logs.',
+        help='Keep uvicorn text access logs. If --log-file is set, these are appended to the JSONL request log.',
     )
     parser.add_argument(
         '--load-shedding-threshold',
@@ -530,8 +522,11 @@ def main():
         ),
         host=args.host,
         port=args.port,
-        access_log=not args.no_access_log,
-        log_config=_build_uvicorn_log_config(args.server_log_file, args.auth_log_file),
+        access_log=args.keep_uvicorn_logs,
+        log_config=_build_uvicorn_log_config(
+            args.log_file,
+            keep_uvicorn_logs=args.keep_uvicorn_logs,
+        ),
     )
 
 

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -679,6 +679,8 @@ class TestRestServerNoPrebuiltIndexesAuthenticated(unittest.TestCase):
                 self.assertEqual(record.get('key_id'), expected_key_id)
                 self.assertEqual(record.get('method'), 'GET')
                 self.assertEqual(record.get('path'), f'/{API_VERSION}/cacm_alias/search')
+                self.assertEqual(record.get('request_id'), ok.headers.get('X-Request-ID'))
+                self.assertFalse(record.get('query_truncated'))
                 self.assertIn('latency_ms', record)
         finally:
             os.unlink(path)
@@ -703,6 +705,7 @@ class TestRestServerNoPrebuiltIndexesAuthenticated(unittest.TestCase):
                 self.assertEqual(record.get('auth'), 'invalid')
                 self.assertEqual(record.get('status'), 401)
                 self.assertEqual(record.get('key_id'), hashlib.sha256(b'bad-token').hexdigest()[:12])
+                self.assertEqual(record.get('request_id'), denied.headers.get('X-Request-ID'))
         finally:
             os.unlink(path)
 
@@ -716,6 +719,34 @@ class TestRestServerNoPrebuiltIndexesAuthenticated(unittest.TestCase):
         self.assertEqual(record.get('auth'), 'not_configured')
         self.assertEqual(record.get('status'), 200)
         self.assertEqual(record.get('path'), '/')
+        self.assertEqual(record.get('request_id'), response.headers.get('X-Request-ID'))
+        self.assertFalse(record.get('query_truncated'))
+
+    def test_request_id_is_server_generated_and_ignores_incoming_headers(self):
+        client_request_id = 'req-test-123'
+        with TestClient(create_app()) as client:
+            with self.assertLogs('pyserini.server.rest.request', level='INFO') as cm:
+                response = client.get(
+                    '/',
+                    headers={
+                        'X-Request-ID': client_request_id,
+                        'X-Correlation-ID': 'corr-test-123',
+                    },
+                )
+            self.assertEqual(response.status_code, 200, msg=response.text)
+            self.assertNotEqual(response.headers.get('X-Request-ID'), client_request_id)
+        record = json.loads(cm.records[-1].getMessage())
+        self.assertEqual(record.get('request_id'), response.headers.get('X-Request-ID'))
+
+    def test_long_query_string_is_truncated_in_request_log(self):
+        query = 'q=' + ('x' * 1200)
+        with TestClient(create_app()) as client:
+            with self.assertLogs('pyserini.server.rest.request', level='INFO') as cm:
+                response = client.get('/?' + query)
+            self.assertEqual(response.status_code, 200, msg=response.text)
+        record = json.loads(cm.records[-1].getMessage())
+        self.assertEqual(len(record.get('query')), 1000)
+        self.assertTrue(record.get('query_truncated'))
 
     def test_keep_uvicorn_logs_routes_access_to_request_log_file(self):
         config = _build_uvicorn_log_config(

--- a/tests/core/test_rest.py
+++ b/tests/core/test_rest.py
@@ -20,6 +20,7 @@ import time
 import unittest
 import unittest.mock
 import hashlib
+import json
 
 import yaml
 from fastapi.testclient import TestClient
@@ -27,7 +28,7 @@ from fastapi.testclient import TestClient
 # Keep this test in tests/core: the REST server imports search backends including Faiss.
 from pyserini.server.backend import SharedSearchBackend
 from pyserini.server.errors import BadSearchRequestError
-from pyserini.server.rest.app import API_VERSION, ROUTE_ERROR, app, create_app
+from pyserini.server.rest.app import API_VERSION, ROUTE_ERROR, app, create_app, _build_uvicorn_log_config
 from pyserini.server.utils import Bm25Config, IndexConfig
 
 # Small prebuilt TF index (see TF_INDEX_INFO["cacm"]); stable BM25 top-1 for this query.
@@ -655,7 +656,7 @@ class TestRestServerNoPrebuiltIndexesAuthenticated(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_no_prebuilt_indexes_logs_key_fingerprint_for_authenticated_requests(self):
+    def test_no_prebuilt_indexes_logs_jsonl_key_fingerprint_for_authenticated_requests(self):
         token = 'no-prebuilt-indexes-integration-test-token-log'
         expected_key_id = hashlib.sha256(token.encode('utf-8')).hexdigest()[:12]
         cfg = {'indexes': {'cacm_alias': self._index_path}, 'api_keys': [token]}
@@ -664,19 +665,66 @@ class TestRestServerNoPrebuiltIndexesAuthenticated(unittest.TestCase):
             path = f.name
         try:
             with TestClient(create_app(path, no_prebuilt_indexes=True)) as client:
-                with self.assertLogs('pyserini.server.rest.auth', level='INFO') as cm:
+                with self.assertLogs('pyserini.server.rest.request', level='INFO') as cm:
                     ok = client.get(
                         f'/{API_VERSION}/cacm_alias/search',
                         params={'query': _REST_QUERY, 'hits': 1},
                         headers={'X-API-Key': token},
                     )
                 self.assertEqual(ok.status_code, 200, msg=ok.text)
-                self.assertTrue(
-                    any(f'auth_request' in line and f'key_id={expected_key_id}' in line for line in cm.output),
-                    msg='\n'.join(cm.output),
-                )
+                record = json.loads(cm.records[-1].getMessage())
+                self.assertEqual(record.get('event'), 'request')
+                self.assertEqual(record.get('auth'), 'authenticated')
+                self.assertEqual(record.get('status'), 200)
+                self.assertEqual(record.get('key_id'), expected_key_id)
+                self.assertEqual(record.get('method'), 'GET')
+                self.assertEqual(record.get('path'), f'/{API_VERSION}/cacm_alias/search')
+                self.assertIn('latency_ms', record)
         finally:
             os.unlink(path)
+
+    def test_no_prebuilt_indexes_logs_jsonl_auth_failure_in_same_request_log(self):
+        token = 'no-prebuilt-indexes-integration-test-token-deny-log'
+        cfg = {'indexes': {'cacm_alias': self._index_path}, 'api_keys': [token]}
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False, encoding='utf-8') as f:
+            yaml.safe_dump(cfg, f, default_flow_style=False)
+            path = f.name
+        try:
+            with TestClient(create_app(path, no_prebuilt_indexes=True)) as client:
+                with self.assertLogs('pyserini.server.rest.request', level='INFO') as cm:
+                    denied = client.get(
+                        f'/{API_VERSION}/cacm_alias/search',
+                        params={'query': _REST_QUERY, 'hits': 1},
+                        headers={'X-API-Key': 'bad-token'},
+                    )
+                self.assertEqual(denied.status_code, 401, msg=denied.text)
+                record = json.loads(cm.records[-1].getMessage())
+                self.assertEqual(record.get('event'), 'request')
+                self.assertEqual(record.get('auth'), 'invalid')
+                self.assertEqual(record.get('status'), 401)
+                self.assertEqual(record.get('key_id'), hashlib.sha256(b'bad-token').hexdigest()[:12])
+        finally:
+            os.unlink(path)
+
+    def test_anonymous_routes_log_jsonl_request(self):
+        with TestClient(create_app()) as client:
+            with self.assertLogs('pyserini.server.rest.request', level='INFO') as cm:
+                response = client.get('/')
+            self.assertEqual(response.status_code, 200, msg=response.text)
+        record = json.loads(cm.records[-1].getMessage())
+        self.assertEqual(record.get('event'), 'request')
+        self.assertEqual(record.get('auth'), 'not_configured')
+        self.assertEqual(record.get('status'), 200)
+        self.assertEqual(record.get('path'), '/')
+
+    def test_keep_uvicorn_logs_routes_access_to_request_log_file(self):
+        config = _build_uvicorn_log_config(
+            'requests.jsonl',
+            keep_uvicorn_logs=True,
+        )
+        access_handlers = config['loggers']['uvicorn.access']['handlers']
+        self.assertEqual(access_handlers, ['uvicorn_access_request_file'])
+        self.assertEqual(config['handlers']['uvicorn_access_request_file']['filename'], 'requests.jsonl')
 
 
 class TestRestBackpressure(unittest.TestCase):


### PR DESCRIPTION
basically, before we had two log file options, one for default uvicorn logs and one for the auth/access logs we're interested in
now it's just one log file with the interesting auth/access logs and uvicorn logs are discarded by default with a flag to opt in and send them to the same log file.
the auth/access logs are now in jsonl as well

codex:
## Summary
- replace separate REST auth/access logging with one JSONL request logger
- log auth failures, load shedding, anonymous requests, and successful requests in one stream
- simplify REST logging CLI to --log-file and opt-in --keep-uvicorn-logs
- update REST usage docs and request logging tests

## Tests
- python -m py_compile pyserini/server/rest/app.py tests/core/test_rest.py
- python -m unittest tests.core.test_rest