### PR TITLE
Add reproduction log entries for onboarding lessons (BM25, conceptual frameworks, NFCorpus)

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -484,3 +484,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -741,3 +741,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -227,3 +227,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -521,4 +521,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
-+ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/anserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -521,3 +521,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/anserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -528,3 +528,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`21a411a`](https://github.com/castorini/pyserini/commit/21a411aa65b88b01ed415ee6469df7a871537b43))
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`4536186`](https://github.com/castorini/pyserini/commit/45361866da443a8127bf964f2095703dfd7b19a6))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))


### PR DESCRIPTION
 Hi!  Companion PR to my Anserini onboarding PR # [3302](https://github.com/castorini/anserini/pull/3302)
 
 This PR adds reproduction log entries for:
 - `docs/experiments-msmarco-passage.md` (BM25 in Pyserini)
 - `docs/conceptual-framework.md`
 - `docs/conceptual-framework2.md`
 - `docs/conceptual-framework3.md`
 - `docs/experiments-nfcorpus.md` (Contriever + SPLADE)
 
 ### Setup
 - OS: Ubuntu 22.04 on WSL2 (Windows 11)
 - Python: 3.11 (conda env), Pyserini: latest from source
 - Java: Temurin 21.0.4 (Anserini fat-jar bundled into pyserini/resources/jars/)
 
 ### Reproduction results
 - All metrics matched documented values within rounding.
 
 A small note: SPLADE-v3 encoding on CPU OOM'd at default WSL2 memory limits - bumping WSL2 to 12 GB resolved it. Could be worth a one-line note in the SPLADE doc if helpful.
 
 Everything otherwise worked without issues.