### PR TITLE
Add to onboarding reproduction logs for @kenoi1

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -488,3 +488,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-02 (commit [`95e88d0`](https://github.com/castorini/pyserini/commit/95e88d0e09c07a1c30b5aedbca2fc1b7deb95fe0))
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
++ Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -745,3 +745,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-02 (commit [`95e88d0`](https://github.com/castorini/pyserini/commit/95e88d0e09c07a1c30b5aedbca2fc1b7deb95fe0))
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
++ Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -231,3 +231,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-02 (commit [`95e88d0`](https://github.com/castorini/pyserini/commit/95e88d0e09c07a1c30b5aedbca2fc1b7deb95fe0))
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-11 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
++ Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -525,3 +525,5 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-01 (commit [`95e88d0`](https://github.com/castorini/pyserini/commit/95e88d0e09c07a1c30b5aedbca2fc1b7deb95fe0))
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-09 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
++ Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
+

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -532,3 +532,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-02 (commit [`95e88d0`](https://github.com/castorini/pyserini/commit/95e88d0e09c07a1c30b5aedbca2fc1b7deb95fe0))
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59)
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
++ Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))


### PR DESCRIPTION
## Environment:
OS: Fedora 43
Python: 3.12.13
CPU: AMD Ryzen AI 7 PRO 360
Commit: acf1698ea4cef1e76a8a2545b2b490fefa08ffef

## Results
My output matched the expected onboarding document results.

Notes:
- I had some version issues in experiments-msmarco-passage when running make, fixed by adding flags to ignore certain warnings
- Also ran into some incompatibility issues with faiss-cpu and numpy, where I ended up upgrading to a newer version of faiss (1.8.0+) with pip.
- On HuggingFace, make sure to click "Agree and Access" on setup for the naver/splade-v3 project page or you may encounter permission errors even with repo read access on your token
