### PR TITLE
Add reproduction log entries for 5 pyserini onboarding exercises

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -489,3 +489,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
++ Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-13 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -746,3 +746,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
++ Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-14 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -232,3 +232,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-11 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
++ Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-14 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -526,4 +526,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59))
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-09 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
-
++ Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-13 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -533,3 +533,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`0238dc5`](https://github.com/castorini/pyserini/commit/0238dc5e9a845625686b9ff89435dc607eed5f59)
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
++ Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-14 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))


### PR DESCRIPTION
**Environment (all exercises):**
- OS: Windows 11 Pro
- Shell: WSL (Ubuntu)
- Java: OpenJDK 21.0.11
- Python: 3.14.4 (WSL venv)

---

**Exercise: experiments-msmarco-passage.md (BM25 Retrieval with Pyserini)**

All commands in the guide were run successfully. BM25 retrieval with tuned parameters (k1=0.82, b=0.68) produced the expected results — MRR@10: 0.1874, MAP: 0.1957, Recall@1000: 0.8573 (including per-query check: `qid` 1048585, recip_rank: 1.0000). Interactive retrieval using `LuceneSearcher` Python API was also verified — document rankings matched the expected output.

---

**Exercise: conceptual-framework.md (BM25 as a Bi-Encoder)**

All steps completed successfully. Extracted BM25 document vector using `LuceneIndexReader`, computed BM25 term weights, and verified the inner product between query and document representations.

---

**Exercise: experiments-nfcorpus.md (Dense Retrieval on NFCorpus)**

All commands in the guide were run successfully. Encoded the NFCorpus collection using BGE-base-en-v1.5 and Contriever-msmarco, ran dense retrieval, and evaluated results — ndcg_cut_10: 0.3808 (BGE-base-en-v1.5), 0.3306 (Contriever-msmarco). Interactive retrieval using `FaissSearcher` was also verified for both BGE-base-en-v1.5 and Contriever-msmarco.


---

**Exercise: conceptual-framework2.md (Dense Retrieval as a Bi-Encoder)**

All steps completed successfully. For the dense side, loaded BGE-base-en-v1.5 and Contriever-msmarco Faiss indexes, extracted document and query embeddings, computed inner products, and verified brute-force retrieval matches the `FaissSearcher` output. For the sparse side, indexed NFCorpus with BM25 (ndcg_cut_10: 0.3218), reconstructed BM25 document vectors from the Lucene index, and verified that the "by hand" dot-product retrieval matches the `LuceneSearcher` output — confirming that dense and sparse retrieval are both instantiations of the same bi-encoder architecture.

---

**Exercise: conceptual-framework3.md (Learned Sparse Retrieval with SPLADE-v3)**

All steps completed successfully. Encoded NFCorpus with SPLADE-v3, built inverted index, ran retrieval, and evaluated — ndcg_cut_10: 0.3624. Interactive retrieval output matched the expected document rankings.
