### PR TITLE
[codex] Quiet encoder loading diagnostics

### DIFF
--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -22,13 +22,12 @@ from transformers import (
     PreTrainedModel,
     RobertaConfig,
     RobertaModel,
-    RobertaTokenizer,
-    requires_backends
+    requires_backends,
 )
 from transformers import __version__ as transformers_version
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
-from pyserini.encode._base import load_head_weights
+from pyserini.encode._base import load_head_weights, load_roberta_tokenizer
 from pyserini.util import temporary_env
 
 
@@ -100,8 +99,7 @@ class AnceDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name, tokenizer_name=None, device='cuda:0'):
         self.device = device
         self.model = AnceEncoder.load_pretrained_encoder(model_name, device)
-        self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or model_name,
-                                                          clean_up_tokenization_spaces=True)
+        self.tokenizer = load_roberta_tokenizer(tokenizer_name or model_name, clean_up_tokenization_spaces=True)
 
     def encode(self, texts, titles=None,  max_length=256, **kwargs):
         if titles is not None:
@@ -125,12 +123,11 @@ class AnceQueryEncoder(QueryEncoder):
         if encoder_dir:
             self.device = device
             self.model = AnceEncoder.load_pretrained_encoder(encoder_dir, device)
-            self.tokenizer = RobertaTokenizer.from_pretrained(tokenizer_name or encoder_dir,
-                                                              clean_up_tokenization_spaces=True)
+            self.tokenizer = load_roberta_tokenizer(tokenizer_name or encoder_dir, clean_up_tokenization_spaces=True)
             self.has_model = True
             self.tokenizer.do_lower_case = True
         if (not self.has_model) and (not self.has_encoded_query):
-            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
+            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one.')
 
     def encode(self, query: str):
         if self.has_model:

--- a/pyserini/encode/_auto.py
+++ b/pyserini/encode/_auto.py
@@ -16,9 +16,9 @@
 
 import numpy as np
 from sklearn.preprocessing import normalize
-from transformers import AutoModel, AutoTokenizer
+from transformers import AutoModel
 
-from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import DocumentEncoder, QueryEncoder, load_auto_tokenizer
 
 
 class AutoDocumentEncoder(DocumentEncoder):
@@ -26,13 +26,7 @@ class AutoDocumentEncoder(DocumentEncoder):
         self.device = device
         self.model = AutoModel.from_pretrained(model_name)
         self.model.to(self.device)
-        try:
-            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or model_name,
-                                                           clean_up_tokenization_spaces=True)
-        except:
-            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or model_name,
-                                                           use_fast=False,
-                                                           clean_up_tokenization_spaces=True)
+        self.tokenizer = load_auto_tokenizer(tokenizer_name or model_name, clean_up_tokenization_spaces=True)
         self.has_model = True
         self.pooling = pooling
         self.l2_norm = l2_norm
@@ -81,19 +75,13 @@ class AutoQueryEncoder(QueryEncoder):
             self.device = device
             self.model = AutoModel.from_pretrained(encoder_dir)
             self.model.to(self.device)
-            try:
-                self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or encoder_dir,
-                                                               clean_up_tokenization_spaces=True)
-            except:
-                self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or encoder_dir,
-                                                               use_fast=False,
-                                                               clean_up_tokenization_spaces=True)
+            self.tokenizer = load_auto_tokenizer(tokenizer_name or encoder_dir, clean_up_tokenization_spaces=True)
             self.has_model = True
             self.pooling = pooling
             self.l2_norm = l2_norm
             self.prefix = prefix
         if (not self.has_model) and (not self.has_encoded_query):
-            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
+            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one.')
 
     def encode(self, query: str, max_length: int = None):
         if self.has_model:

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -51,7 +51,12 @@ def load_auto_tokenizer(tokenizer_name, **kwargs):
             category=DeprecationWarning,
             module='transformers.models.bert.tokenization_bert',
         )
-        return AutoTokenizer.from_pretrained(tokenizer_name, **kwargs)
+        try:
+            return AutoTokenizer.from_pretrained(tokenizer_name, **kwargs)
+        except Exception:
+            fallback_kwargs = dict(kwargs)
+            fallback_kwargs.setdefault('use_fast', False)
+            return AutoTokenizer.from_pretrained(tokenizer_name, **fallback_kwargs)
 
 
 def load_roberta_tokenizer(tokenizer_name, **kwargs):

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -16,14 +16,55 @@
 
 import json
 import os
+import warnings
 
 import numpy as np
 import pandas as pd
 import torch
 from tqdm import tqdm
+from transformers import AutoTokenizer, BertTokenizer, RobertaTokenizer
+from transformers.utils import cached_file
 
 from pyserini.util import download_encoded_queries
-from transformers.utils import cached_file
+
+
+def load_bert_tokenizer(tokenizer_name, **kwargs):
+    # The upstream tokenizers WordPiece implementation emits this warning while
+    # constructing BERT WordPiece tokenizers; tokenization behavior is unchanged.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message='Deprecated in 0.9.0: WordPiece.__init__ will not create from files anymore.*',
+            category=DeprecationWarning,
+            module='transformers.models.bert.tokenization_bert',
+        )
+        return BertTokenizer.from_pretrained(tokenizer_name, **kwargs)
+
+
+def load_auto_tokenizer(tokenizer_name, **kwargs):
+    # Some AutoTokenizer paths resolve to BERT WordPiece tokenizers and emit the
+    # same upstream tokenizers deprecation; tokenization behavior is unchanged.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message='Deprecated in 0.9.0: WordPiece.__init__ will not create from files anymore.*',
+            category=DeprecationWarning,
+            module='transformers.models.bert.tokenization_bert',
+        )
+        return AutoTokenizer.from_pretrained(tokenizer_name, **kwargs)
+
+
+def load_roberta_tokenizer(tokenizer_name, **kwargs):
+    # The upstream tokenizers BPE implementation emits this warning while
+    # constructing file-backed RoBERTa tokenizers; tokenization behavior is unchanged.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message='Deprecated in 0.9.0: BPE.__init__ will not create from files anymore.*',
+            category=DeprecationWarning,
+            module='transformers.models.roberta.tokenization_roberta',
+        )
+        return RobertaTokenizer.from_pretrained(tokenizer_name, **kwargs)
 
 
 class DocumentEncoder:

--- a/pyserini/encode/_dkrr.py
+++ b/pyserini/encode/_dkrr.py
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-
 import torch
-from transformers import (BertModel, BertTokenizerFast)
+from transformers import BertModel
 
-from pyserini.encode import QueryEncoder
+from pyserini.encode._base import QueryEncoder, load_bert_tokenizer
 
 
 class DkrrDprQueryEncoder(QueryEncoder):
@@ -28,8 +26,7 @@ class DkrrDprQueryEncoder(QueryEncoder):
         self.device = device
         self.model = BertModel.from_pretrained(encoder_dir)
         self.model.to(self.device)
-        self.tokenizer = BertTokenizerFast.from_pretrained('bert-base-uncased',
-                                                           clean_up_tokenization_spaces=True)
+        self.tokenizer = load_bert_tokenizer('bert-base-uncased', clean_up_tokenization_spaces=True)
         self.has_model = True
         self.prefix = prefix
 

--- a/pyserini/encode/_tct_colbert.py
+++ b/pyserini/encode/_tct_colbert.py
@@ -17,13 +17,38 @@
 import numpy as np
 import torch
 
-if torch.cuda.is_available():
-    from torch.cuda.amp import autocast
+from transformers import BertModel
+from transformers.utils import logging as transformers_logging
 
-from transformers import BertModel, BertTokenizer, BertTokenizerFast
+from pyserini.encode._base import DocumentEncoder, QueryEncoder, load_bert_tokenizer
 
-from pyserini.encode import DocumentEncoder, QueryEncoder
-from onnxruntime import SessionOptions, InferenceSession
+
+def _load_bert_backbone(model_name):
+    # TCT-ColBERT checkpoints include BERT pretraining heads, but these encoders
+    # only use the BERT backbone. Suppress the expected Transformers load report
+    # for those extra cls.* weights while preserving diagnostics for real issues.
+    verbosity = transformers_logging.get_verbosity()
+    transformers_logging.set_verbosity_error()
+    try:
+        model, loading_info = BertModel.from_pretrained(model_name, output_loading_info=True)
+    finally:
+        transformers_logging.set_verbosity(verbosity)
+
+    has_only_bert_pretraining_head_unexpected_keys = all(
+        key.startswith('cls.predictions.') or key.startswith('cls.seq_relationship.')
+        for key in loading_info['unexpected_keys']
+    )
+    if (
+        loading_info['missing_keys']
+        or loading_info['mismatched_keys']
+        or loading_info['error_msgs']
+        or not has_only_bert_pretraining_head_unexpected_keys
+    ):
+        transformers_logging.get_logger(__name__).warning(
+            'BertModel load from %s had non-benign loading info: %s', model_name, loading_info
+        )
+
+    return model
 
 
 class TctColBertDocumentEncoder(DocumentEncoder):
@@ -31,16 +56,22 @@ class TctColBertDocumentEncoder(DocumentEncoder):
         self.device = device
         self.onnx = False
         if model_name.endswith('onnx'):
+            from onnxruntime import InferenceSession, SessionOptions
+
             options = SessionOptions()
             self.session = InferenceSession(model_name, options)
             self.onnx = True
-            self.tokenizer = BertTokenizerFast.from_pretrained(tokenizer_name or model_name[:-5],
-                                                               clean_up_tokenization_spaces=True)
+            self.tokenizer = load_bert_tokenizer(
+                tokenizer_name or model_name[:-5],
+                clean_up_tokenization_spaces=True
+            )
         else:
-            self.model = BertModel.from_pretrained(model_name)
+            self.model = _load_bert_backbone(model_name)
             self.model.to(self.device)
-            self.tokenizer = BertTokenizerFast.from_pretrained(tokenizer_name or model_name,
-                                                               clean_up_tokenization_spaces=True)
+            self.tokenizer = load_bert_tokenizer(
+                tokenizer_name or model_name,
+                clean_up_tokenization_spaces=True
+            )
 
     def encode(self, texts, titles=None, fp16=False,  max_length=512, **kwargs):
         if titles is not None:
@@ -63,12 +94,12 @@ class TctColBertDocumentEncoder(DocumentEncoder):
             embeddings = self._mean_pooling(outputs[:, 4:, :], inputs['attention_mask'][:, 4:])
         else:
             inputs.to(self.device)
-            if fp16:
-                with autocast():
-                    with torch.no_grad():
+            with torch.no_grad():
+                if fp16 and str(self.device).startswith('cuda'):
+                    with torch.amp.autocast('cuda'):
                         outputs = self.model(**inputs)
-            else:
-                outputs = self.model(**inputs)
+                else:
+                    outputs = self.model(**inputs)
             embeddings = self._mean_pooling(outputs["last_hidden_state"][:, 4:, :], inputs['attention_mask'][:, 4:])
         return embeddings.detach().cpu().numpy()
 
@@ -79,13 +110,15 @@ class TctColBertQueryEncoder(QueryEncoder):
         super().__init__(encoded_query_dir)
         if encoder_dir:
             self.device = device
-            self.model = BertModel.from_pretrained(encoder_dir)
+            self.model = _load_bert_backbone(encoder_dir)
             self.model.to(self.device)
-            self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or encoder_dir,
-                                                           clean_up_tokenization_spaces=True)
+            self.tokenizer = load_bert_tokenizer(
+                tokenizer_name or encoder_dir,
+                clean_up_tokenization_spaces=True
+            )
             self.has_model = True
         if (not self.has_model) and (not self.has_encoded_query):
-            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
+            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one.')
 
     def encode(self, query: str):
         if self.has_model:

--- a/scripts/dkrr/encode_queries.py
+++ b/scripts/dkrr/encode_queries.py
@@ -19,9 +19,11 @@ import argparse
 import pandas as pd
 
 from tqdm import tqdm
+from pyserini.encode._base import load_bert_tokenizer
 from pyserini.query_iterator import get_query_iterator, TopicsFormat
-from transformers import BertModel,  BertTokenizerFast
+from transformers import BertModel
 import torch
+
 
 class DkrrDprQueryEncoder():
 
@@ -29,7 +31,7 @@ class DkrrDprQueryEncoder():
         self.device = device
         self.model = BertModel.from_pretrained(encoder)
         self.model.to(self.device)
-        self.tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
+        self.tokenizer = load_bert_tokenizer("bert-base-uncased")
         self.prefix = prefix
 
     @staticmethod


### PR DESCRIPTION
## Summary

- Add internal tokenizer loader helpers that narrowly suppress upstream `tokenizers` deprecation warnings for BERT WordPiece and RoBERTa BPE construction.
- Route TCT-ColBERT, ANCE, Auto, and DKRR encoder tokenizer construction through those helpers.
- Suppress the expected TCT-ColBERT BERT backbone load report for benign pretraining-head weights while preserving warnings for non-benign loading issues.
- Update TCT-ColBERT fp16 autocast usage for current PyTorch and lazy-load `onnxruntime` only for the ONNX path.

## Validation

- `mamba run -n pyserini-dev3 python -m py_compile pyserini/encode/_base.py pyserini/encode/_auto.py pyserini/encode/_tct_colbert.py pyserini/encode/_dkrr.py scripts/dkrr/encode_queries.py`
- `mamba run -n pyserini-dev3 python -m unittest tests.base.encoder.test_encoder_model_tct tests/base/encoder/test_encoder_model_distilbert_kd.py tests/base/encoder/test_encoder_model_distilbert_tasb.py tests/core/test_hybrid_search.py tests/core/test_fusion.py`
- `mamba run -n pyserini-dev3 python -m unittest tests.base.encoder.test_encoder_model_ance`
- `mamba run -n pyserini-dev3 python -m unittest discover -s tests/`

Full discovery passed: `Ran 549 tests in 993.018s OK`.