### PR TITLE
Add onboarding reproduction log entries

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -491,3 +491,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-13 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -748,3 +748,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-14 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -234,3 +234,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-11 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-14 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -528,3 +528,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-09 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-13 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -535,3 +535,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@zxTomw](https://github.com/zxTomw) on 2026-06-10 (commit [`ab2d0bf`](https://github.com/castorini/pyserini/commit/ab2d0bf571d975c14f9d2b68a9058adebdf8894c))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-12 (commit [`acf1698`](https://github.com/castorini/pyserini/commit/acf1698ea4cef1e76a8a2545b2b490fefa08ffef))
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-14 (commit [`30a1bba`](https://github.com/castorini/pyserini/commit/30a1bba1b409662787404208a0f8d5268a1b31b2))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))


### PR DESCRIPTION
## Summary

This PR adds my reproduction log entries for the Pyserini onboarding path:

- `docs/experiments-msmarco-passage.md`
- `docs/conceptual-framework.md`
- `docs/experiments-nfcorpus.md`
- `docs/conceptual-framework2.md`
- `docs/conceptual-framework3.md`

All entries were reproduced on Pyserini commit `42ff49c1393de811f46674188411a6970e0c85c6`.

## Environment

- macOS
- Python virtual environment with editable Pyserini install
- Java 21 via Homebrew
- SSD-backed cache under `/Volumes/Boss T7/Castorini-Screening-cache`
- Hugging Face CLI auth for gated `naver/splade-v3` access

## Reproduction Notes

- MS MARCO BM25: reproduced `MRR @10: 0.18741227770955546` and TREC `map all 0.1958`, `recall_1000 all 0.8573`.
- Conceptual framework 1: manually reconstructed the BM25 score for passage `7187158`; manual dot product matched the Lucene score.
- NFCorpus dense retrieval: reproduced BGE-base `ndcg_cut_10 all 0.3808` and Contriever `ndcg_cut_10 all 0.3306`.
- Conceptual framework 2: verified dense vector reconstruction/brute-force checks for BGE and Contriever, plus sparse BM25 `ndcg_cut_10 all 0.3218`.
- Conceptual framework 3: reproduced SPLADE-v3 `ndcg_cut_10 all 0.3624`; the interactive top-10 matched the guide.

## Issues Encountered

- For local SPLADE-v3 setup, Hugging Face gated access had to be configured first.
- The default Hugging Face Xet download path stalled locally, so I used `HF_HUB_DISABLE_XET=1`.
- On an 8 GB Mac, the default SPLADE encode batch size was killed by macOS; rerunning with `--batch-size 1` and CPU/thread limits completed successfully.

## Checks

- Verified all documented metrics above.
- Verified SPLADE encoded corpus line count: `3,633`.
- Verified SPLADE impact index: `3,633` indexed, `0` errors.
- Ran `git diff --check` on the modified docs.