### PR TITLE
[codex] Load qrels alias metadata

### DIFF
--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -31,6 +31,7 @@ JTopicReader = autoclass('io.anserini.search.topicreader.TopicReader')
 
 TOPICS_AND_QRELS_BASE_URL = 'https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/'
 QRELS_METADATA_FILE = '_metadata_qrels.json'
+QRELS_ALIASES_METADATA_FILE = '_metadata_qrels_aliases.json'
 TOPICS_METADATA_FILE = '_metadata_topics.json'
 
 _topics_mapping = None
@@ -39,7 +40,19 @@ _qrels_mapping = None
 
 def _load_qrels_mapping():
     with urlopen(f'{TOPICS_AND_QRELS_BASE_URL}{QRELS_METADATA_FILE}') as response:
-        return json.loads(response.read().decode('utf-8'))
+        qrels_mapping = json.loads(response.read().decode('utf-8'))
+
+    with urlopen(f'{TOPICS_AND_QRELS_BASE_URL}{QRELS_ALIASES_METADATA_FILE}') as response:
+        qrels_aliases_mapping = json.loads(response.read().decode('utf-8'))
+
+    for canonical_name, aliases in qrels_aliases_mapping.items():
+        if canonical_name not in qrels_mapping:
+            continue
+
+        for alias in aliases:
+            qrels_mapping[alias] = qrels_mapping[canonical_name]
+
+    return qrels_mapping
 
 
 def _load_topics_mapping():


### PR DESCRIPTION
## Summary

- Load `_metadata_qrels_aliases.json` alongside `_metadata_qrels.json`
- Expand qrels aliases into the in-memory qrels mapping so alias names resolve to canonical qrels files
- Fix missing-qrels errors for aliased qrels names such as `beir-v1.0.0-trec-covid-test` and `msmarco-passage-dev`

## Validation

- `mamba run -n pyserini-dev3 python -m unittest tests.base.test_load_qrels.TestLoadQrels.test_beir tests.base.test_load_qrels.TestLoadQrels.test_msmarco_passage2`
- `mamba run -n pyserini-dev3 python -m unittest tests.base.test_load_qrels.TestLoadQrels.test_qrels_resource_json_shape tests.base.test_load_qrels.TestLoadQrels.test_get_qrels_file_downloads_once_and_uses_cache`