### PR TITLE
[codex] Add BPR Hugging Face query encoding support

### DIFF
--- a/bin/run-bpr-otf.sh
+++ b/bin/run-bpr-otf.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+date
+
+python -m pyserini.search.faiss \
+  --index wikipedia-dpr-100w.bpr-single-nq \
+  --topics dpr-nq-test \
+  --encoder castorini/bpr-nq-question-encoder \
+  --encoder-class bpr \
+  --output runs/run.bpr.rerank.nq-test.nq.hash.otf.trec \
+  --batch-size 512 --threads 16 \
+  --hits 100 --binary-hits 1000 \
+  --searcher bpr --rerank
+
+python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
+  --index wikipedia-dpr \
+  --topics dpr-nq-test \
+  --input runs/run.bpr.rerank.nq-test.nq.hash.otf.trec \
+  --output runs/run.bpr.rerank.nq-test.nq.hash.otf.json
+
+python -m pyserini.eval.evaluate_dpr_retrieval \
+  --retrieval runs/run.bpr.rerank.nq-test.nq.hash.otf.json \
+  --topk 20 100
+
+date

--- a/docs/experiments-bpr.md
+++ b/docs/experiments-bpr.md
@@ -6,6 +6,7 @@ Binary passage retriever (BPR) is a two-stage ranking approach that represents t
 
 We have replicated BPR's results and incorporated the model into Pyserini.
 To be clear, we started with model checkpoint and index releases in the official [BPR repo](https://github.com/studio-ousia/bpr) and did _not_ train the query and passage encoders from scratch.
+Both are available on Hugging Face as [`castorini/bpr-nq-question-encoder`](https://huggingface.co/castorini/bpr-nq-question-encoder) and [`castorini/bpr-nq-ctx-encoder`](https://huggingface.co/castorini/bpr-nq-ctx-encoder), respectively.
 
 This guide provides instructions to reproduce the BPR's results.
 

--- a/pyserini/encode/query.py
+++ b/pyserini/encode/query.py
@@ -16,6 +16,7 @@
 
 import argparse
 import inspect
+import os
 from itertools import islice
 
 import numpy as np
@@ -27,6 +28,7 @@ from pyserini.encode import (
     AnceQueryEncoder,
     ArcticQueryEncoder,
     AutoQueryEncoder,
+    BprQueryEncoder,
     CosDprQueryEncoder,
     DprQueryEncoder,
     DseQueryEncoder,
@@ -39,8 +41,10 @@ from pyserini.encode import (
 from pyserini.query_iterator import DefaultQueryIterator
 
 
-def init_encoder(encoder, device, pooling, l2_norm, prefix):
-    if 'dpr' in encoder.lower():
+def init_encoder(encoder, device, pooling, l2_norm, prefix, bpr):
+    if bpr:
+        return BprQueryEncoder(encoder, device=device)
+    elif 'dpr' in encoder.lower():
         return DprQueryEncoder(encoder, device=device)
     elif 'tct' in encoder.lower():
         return TctColBertQueryEncoder(encoder, device=device)
@@ -75,6 +79,12 @@ def encode_query(encoder, text, max_length):
     return encoder.encode(text)
 
 
+def create_output_dir(output):
+    output_dir = os.path.dirname(output)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--topics', type=str, help='path to topics file in tsv format or self-contained topics name', required=True)
@@ -88,12 +98,13 @@ if __name__ == '__main__':
     parser.add_argument('--pooling', type=str, help='pooling strategy', default='cls', choices=['cls', 'mean'], required=False)
     parser.add_argument('--l2-norm', action='store_true', help='whether to normalize embedding', default=False, required=False)
     parser.add_argument('--prefix', type=str, help='prefix query input', default=None, required=False)
+    parser.add_argument('--bpr', action='store_true', help='encode BPR dense and binary query representations', default=False, required=False)
     args = parser.parse_args()
 
     if args.max_queries is not None and args.max_queries < 0:
         raise ValueError('--max-queries must be non-negative')
 
-    encoder = init_encoder(args.encoder, device=args.device, pooling=args.pooling, l2_norm=args.l2_norm, prefix=args.prefix)
+    encoder = init_encoder(args.encoder, device=args.device, pooling=args.pooling, l2_norm=args.l2_norm, prefix=args.prefix, bpr=args.bpr)
     query_iterator = DefaultQueryIterator.from_topics(args.topics)
     if args.max_queries is not None:
         query_iterator = islice(query_iterator, args.max_queries)
@@ -102,8 +113,16 @@ if __name__ == '__main__':
     query_ids = []
     query_texts = []
     query_embeddings = []
+    dense_embeddings = []
+    sparse_embeddings = []
     for topic_id, text in tqdm(query_iterator):
         embedding = encode_query(encoder, text, args.max_length)
+        if args.bpr:
+            query_ids.append(topic_id)
+            query_texts.append(text)
+            dense_embeddings.append(embedding['dense'])
+            sparse_embeddings.append(embedding['sparse'])
+            continue
         if isinstance(embedding, dict):
             is_sparse = True
             pseudo_str = []
@@ -116,10 +135,21 @@ if __name__ == '__main__':
         query_texts.append(text)
         query_embeddings.append(embedding)
 
+    create_output_dir(args.output)
+
     if is_sparse:
         with open(args.output, 'w') as f:
             for i in range(len(query_ids)):
                 f.write(f"{query_ids[i]}\t{query_embeddings[i]}\n")
+    elif args.bpr:
+        embeddings = {
+            'id': query_ids,
+            'text': query_texts,
+            'dense_embedding': dense_embeddings,
+            'sparse_embedding': sparse_embeddings,
+        }
+        embeddings = pd.DataFrame(embeddings)
+        embeddings.to_pickle(args.output)
     else:
         embeddings = {'id': query_ids, 'text': query_texts, 'embedding': query_embeddings}
         embeddings = pd.DataFrame(embeddings)

--- a/pyserini/search/faiss/_searcher.py
+++ b/pyserini/search/faiss/_searcher.py
@@ -383,8 +383,7 @@ class BinaryDenseFaissSearcher(FaissSearcher):
     def __init__(self, index_dir: str, query_encoder: Union[QueryEncoder, str],
                  prebuilt_index_name: Optional[str] = None, normalize_distances: bool = False,
                  faiss_device: str = "cpu"):
-        super().__init__(index_dir, query_encoder, None, normalize_distances, faiss_device)
-        self.ssearcher = None
+        super().__init__(index_dir, query_encoder, prebuilt_index_name, normalize_distances, faiss_device)
 
     def search(self, query: str, k: int = 10, binary_k: int = 100, rerank: bool = True,
                threads: int = 1) -> List[DenseSearchResult]:

--- a/pyserini/search/faiss/_searcher.py
+++ b/pyserini/search/faiss/_searcher.py
@@ -380,22 +380,14 @@ class BinaryDenseFaissSearcher(FaissSearcher):
         Path to faiss index directory.
     """
 
-    def __init__(
-        self,
-        index_dir: str,
-        query_encoder: Union[QueryEncoder, str],
-        prebuilt_index_name: Optional[str] = None,
-    ):
-        super().__init__(index_dir, query_encoder, prebuilt_index_name)
+    def __init__(self, index_dir: str, query_encoder: Union[QueryEncoder, str],
+                 prebuilt_index_name: Optional[str] = None, normalize_distances: bool = False,
+                 faiss_device: str = "cpu"):
+        super().__init__(index_dir, query_encoder, None, normalize_distances, faiss_device)
+        self.ssearcher = None
 
-    def search(
-        self,
-        query: str,
-        k: int = 10,
-        binary_k: int = 100,
-        rerank: bool = True,
-        threads: int = 1,
-    ) -> List[DenseSearchResult]:
+    def search(self, query: str, k: int = 10, binary_k: int = 100, rerank: bool = True,
+               threads: int = 1) -> List[DenseSearchResult]:
         """Search the collection.
 
         Parameters
@@ -424,26 +416,13 @@ class BinaryDenseFaissSearcher(FaissSearcher):
         dense_emb_q = dense_emb_q.reshape((1, len(dense_emb_q)))
         sparse_emb_q = sparse_emb_q.reshape((1, len(sparse_emb_q)))
         faiss.omp_set_num_threads(threads)
-        distances, indexes = self.binary_dense_search(
-            k, binary_k, rerank, dense_emb_q, sparse_emb_q
-        )
+        distances, indexes = self.binary_dense_search(k, binary_k, rerank, dense_emb_q, sparse_emb_q)
         distances = distances.flat
         indexes = indexes.flat
-        return [
-            DenseSearchResult(str(idx), score)
-            for score, idx in zip(distances, indexes)
-            if idx != -1
-        ]
+        return [DenseSearchResult(str(idx), score) for score, idx in zip(distances, indexes) if idx != -1]
 
-    def batch_search(
-        self,
-        queries: List[str],
-        q_ids: List[str],
-        k: int = 10,
-        binary_k: int = 100,
-        rerank: bool = True,
-        threads: int = 1,
-    ) -> Dict[str, List[DenseSearchResult]]:
+    def batch_search(self, queries: List[str], q_ids: List[str], k: int = 10, binary_k: int = 100,
+                     rerank: bool = True, threads: int = 1) -> Dict[str, List[DenseSearchResult]]:
         """
 
         Parameters
@@ -478,38 +457,25 @@ class BinaryDenseFaissSearcher(FaissSearcher):
         n, m = dense_q_embs.shape
         assert m == self.dimension
         faiss.omp_set_num_threads(threads)
-        D, I = self.binary_dense_search(
-            k, binary_k, rerank, dense_q_embs, sparse_q_embs
-        )
+        D, I = self.binary_dense_search(k, binary_k, rerank, dense_q_embs, sparse_q_embs)
         return {
-            key: [
-                DenseSearchResult(str(idx), score)
-                for score, idx in zip(distances, indexes)
-                if idx != -1
-            ]
+            key: [DenseSearchResult(str(idx), score) for score, idx in zip(distances, indexes) if idx != -1]
             for key, distances, indexes in zip(q_ids, D, I)
         }
 
     def binary_dense_search(self, k, binary_k, rerank, dense_emb_q, sparse_emb_q):
         num_queries = dense_emb_q.shape[0]
-        sparse_emb_q = np.packbits(np.where(sparse_emb_q > 0, 1, 0)).reshape(
-            num_queries, -1
-        )
+        sparse_emb_q = np.packbits(np.where(sparse_emb_q > 0, 1, 0)).reshape(num_queries, -1)
 
         if not rerank:
             distances, indexes = self.index.search(sparse_emb_q, k)
         else:
             raw_index = self.index.index
             _, indexes = raw_index.search(sparse_emb_q, binary_k)
-            sparse_emb_p = np.vstack(
-                [
-                    np.unpackbits(raw_index.reconstruct(int(id_)))
-                    for id_ in indexes.reshape(-1)
-                ]
-            )
-            sparse_emb_p = sparse_emb_p.reshape(
-                dense_emb_q.shape[0], binary_k, dense_emb_q.shape[1]
-            )
+            sparse_emb_p = np.vstack([
+                np.unpackbits(raw_index.reconstruct(int(id_))) for id_ in indexes.reshape(-1)
+            ])
+            sparse_emb_p = sparse_emb_p.reshape(dense_emb_q.shape[0], binary_k, dense_emb_q.shape[1])
             sparse_emb_p = sparse_emb_p.astype(np.float32)
             sparse_emb_p = sparse_emb_p * 2 - 1
             distances = np.einsum("ijk,ik->ij", sparse_emb_p, dense_emb_q)
@@ -521,15 +487,51 @@ class BinaryDenseFaissSearcher(FaissSearcher):
                 dtype=np.int32,
             )
             indexes = indexes.reshape(num_queries, -1)[:, :k]
-            distances = distances[np.arange(num_queries)[:, None], sorted_indices][
-                :, :k
-            ]
+            distances = distances[np.arange(num_queries)[:, None], sorted_indices][:, :k]
         return distances, indexes
 
     def load_index(self, index_dir: str):
         index_path = os.path.join(index_dir, 'index')
-        index = faiss.read_index_binary(index_path)
+        try:
+            index = faiss.read_index_binary(index_path)
+        except RuntimeError as e:
+            if "code_size=0" not in str(e):
+                raise
+            try:
+                index = self._read_legacy_binary_idmap_index(index_path)
+            except RuntimeError:
+                raise e
         return index, None
+
+    @staticmethod
+    def _read_legacy_binary_idmap_index(index_path: str):
+        if not hasattr(faiss, 'PyCallbackIOReader'):
+            raise RuntimeError('FAISS PyCallbackIOReader is not available.')
+
+        with open(index_path, 'rb') as f:
+            header = f.read(12)
+            if len(header) < 12 or header[:4] != b'IBMp':
+                raise RuntimeError('Not a legacy FAISS binary ID-map index.')
+            dim = int.from_bytes(header[4:8], byteorder='little')
+            if dim % 8 != 0:
+                raise RuntimeError('Invalid legacy FAISS binary index dimension.')
+            code_size = (dim // 8).to_bytes(4, byteorder='little')
+            f.seek(0)
+
+            def read(size):
+                data = f.read(size)
+                start = read.offset
+                read.offset += len(data)
+                if start < 12 and read.offset > 8:
+                    # Older FAISS binary ID-map indexes omitted code_size in the outer header.
+                    data = bytearray(data)
+                    for pos in range(max(start, 8), min(read.offset, 12)):
+                        data[pos - start] = code_size[pos - 8]
+                    data = bytes(data)
+                return data
+
+            read.offset = 0
+            return faiss.read_index_binary(faiss.PyCallbackIOReader(read))
 
     @staticmethod
     def _init_encoder_from_str(encoder):

--- a/scripts/bpr/encode_queries.py
+++ b/scripts/bpr/encode_queries.py
@@ -15,62 +15,45 @@
 #
 
 import argparse
-import csv
-import json
+import os
 
 import pandas as pd
 from tqdm import tqdm
-import sys
 
-# We're going to explicitly use a local installation of Pyserini.
-sys.path.insert(0, './')
-sys.path.insert(0, '../pyserini/')
-
-from pyserini.dsearch import BprQueryEncoder
-
-def parse_qa_csv_file(location):
-    with open(location) as file:
-        reader = csv.reader(file, delimiter='\t')
-        for row in reader:
-            question = row[0]
-            answers = eval(row[1])
-            yield question, answers
+from pyserini.encode import BprQueryEncoder
+from pyserini.query_iterator import DefaultQueryIterator
 
 
-def parse_qa_json_file(location):
-    with open(location) as file:
-        for line in file:
-            qa = json.loads(line)
-            question = qa['question']
-            answers = qa['answer']
-            yield question, answers
+def parse_topics(topics):
+    for topic_id, text in DefaultQueryIterator.from_topics(topics):
+        yield topic_id, text
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--encoder', type=str, help='encoder name or path',
-                        default='facebook/dpr-question_encoder-multiset-base', required=False)
-    parser.add_argument('--input', type=str, help='qas file, json file by default', required=True)
-    parser.add_argument('--format', type=str, help='qas file format', default='json', required=False)
+    parser.add_argument('--encoder', type=str, help='encoder name or path', default='castorini/bpr-nq-question-encoder', required=False)
+    parser.add_argument('--topics', type=str, help='path to topics file or self-contained topics name', required=True)
     parser.add_argument('--output', type=str, help='path to store query embeddings', required=True)
+    parser.add_argument('--device', type=str, help='device cpu or cuda [cuda:0, cuda:1...]', default='cpu', required=False)
+    parser.add_argument('--batch-size', type=int, help='query encoding batch size', default=256, required=False)
     args = parser.parse_args()
 
-    model = BprQueryEncoder(args.encoder)
-    tokenizer = model.tokenizer
-    
+    model = BprQueryEncoder(encoder_dir=args.encoder, device=args.device)
+
     embeddings = {'id': [], 'text': [], 'dense_embedding': [], 'sparse_embedding': []}
-    qa_parser = None
-    if args.format == 'csv':
-        qa_parser = parse_qa_csv_file
-    elif args.format == 'json':
-        qa_parser = parse_qa_json_file
-    if qa_parser is None:
-        print(f'No QA parser defined for file format: {args.format}, or format not match')
-    for qid, (question, answers) in enumerate(tqdm(list(qa_parser(args.input)))):
+    queries = list(parse_topics(args.topics))
+
+    for qid, question in tqdm(queries):
         embeddings['id'].append(qid)
         embeddings['text'].append(question)
         ret = model.encode(question)
         embeddings['dense_embedding'].append(ret['dense'])
         embeddings['sparse_embedding'].append(ret['sparse'])
+
     embeddings = pd.DataFrame(embeddings)
+    output_dir = os.path.dirname(args.output)
+
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
     embeddings.to_pickle(args.output)

--- a/tests/base/encoder/test_encoder_model_bpr.py
+++ b/tests/base/encoder/test_encoder_model_bpr.py
@@ -1,0 +1,87 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import pandas as pd
+
+from pyserini.encode import BprQueryEncoder
+from pyserini.query_iterator import DefaultQueryIterator
+
+
+EXPECTED_VALUES = [(-0.25418, 0.13869, -1.0, 1.0), (0.15668, -0.28884, 1.0, -1.0)]
+REPO_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+
+def assert_bpr_encode_query_cli_output(testcase, topics, encoder, expected_values, embedding_dim=768):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = os.path.join(temp_dir, 'encoded_queries.pkl')
+        subprocess.run(
+            [
+                sys.executable, '-m', 'pyserini.encode.query',
+                '--topics', topics,
+                '--encoder', encoder,
+                '--bpr',
+                '--output', output_path,
+                '--device', 'cpu',
+                '--max-queries', str(len(expected_values)),
+            ],
+            cwd=REPO_DIR,
+            check=True,
+        )
+
+        encoded = pd.read_pickle(output_path)
+        testcase.assertEqual(encoded.shape, (len(expected_values), 4))
+        testcase.assertEqual(encoded.columns.tolist(), ['id', 'text', 'dense_embedding', 'sparse_embedding'])
+        testcase.assertEqual(len(encoded.iloc[0]['dense_embedding']), embedding_dim)
+        testcase.assertEqual(len(encoded.iloc[0]['sparse_embedding']), embedding_dim)
+        for i, (dense_first, dense_last, sparse_first, sparse_last) in enumerate(expected_values):
+            testcase.assertAlmostEqual(encoded.iloc[i]['dense_embedding'][0], dense_first, places=5)
+            testcase.assertAlmostEqual(encoded.iloc[i]['dense_embedding'][-1], dense_last, places=5)
+            testcase.assertAlmostEqual(encoded.iloc[i]['sparse_embedding'][0], sparse_first, places=5)
+            testcase.assertAlmostEqual(encoded.iloc[i]['sparse_embedding'][-1], sparse_last, places=5)
+
+
+def assert_bpr_query_encoder_output(testcase, topics, encoder, expected_values, embedding_dim=768):
+    query_iterator = DefaultQueryIterator.from_topics(topics)
+    for i, (_, text) in enumerate(query_iterator):
+        if i == len(expected_values):
+            break
+        embedding = encoder.encode(text)
+        testcase.assertEqual(embedding.keys(), {'dense', 'sparse'})
+        testcase.assertEqual(len(embedding['dense']), embedding_dim)
+        testcase.assertEqual(len(embedding['sparse']), embedding_dim)
+        testcase.assertAlmostEqual(embedding['dense'][0], expected_values[i][0], places=5)
+        testcase.assertAlmostEqual(embedding['dense'][-1], expected_values[i][1], places=5)
+        testcase.assertAlmostEqual(embedding['sparse'][0], expected_values[i][2], places=5)
+        testcase.assertAlmostEqual(embedding['sparse'][-1], expected_values[i][3], places=5)
+
+
+class TestEncodeBpr(unittest.TestCase):
+    def test_bpr_encode_query_cli(self):
+        assert_bpr_encode_query_cli_output(self, 'dpr-nq-test', 'castorini/bpr-nq-question-encoder', EXPECTED_VALUES)
+
+    def test_bpr_query_encoder_direct(self):
+        encoder = BprQueryEncoder('castorini/bpr-nq-question-encoder', device='cpu')
+        assert_bpr_query_encoder_output(self, 'dpr-nq-test', encoder, EXPECTED_VALUES)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add BPR query encoding support to `pyserini.encode.query` via `--bpr`, including output-directory creation.
- Update `scripts/bpr/encode_queries.py` to use `castorini/bpr-nq-question-encoder` and Pyserini topics directly.
- Add `bin/run-bpr-otf.sh` for on-the-fly BPR query encoding with the Hugging Face question encoder.
- Add BPR encoder tests covering both the `pyserini.encode.query --bpr` CLI path and direct `BprQueryEncoder` output.
- Document the BPR question and context encoder Hugging Face model references.
- Preserve compatibility with legacy binary FAISS BPR indexes.

## Validation

- `python -m py_compile pyserini/encode/query.py scripts/bpr/encode_queries.py`
- `mamba run -n pyserini-dev3 python -m py_compile tests/base/encoder/test_encoder_model_bpr.py`
- `sh -n bin/run-bpr-otf.sh`
- `mamba run -n pyserini-dev3 python -m unittest tests.base.encoder.test_encoder_model_bpr`
- `mamba run -n pyserini-dev3 bin/run-bpr.sh`
- `mamba run -n pyserini-dev3 bin/run-bpr-otf.sh`

Final effectiveness check:

- `bin/run-bpr.sh`: Top20 `0.7792`, Top100 `0.8571`
- `bin/run-bpr-otf.sh`: Top20 `0.7792`, Top100 `0.8571`