### PR TITLE
[codex] Refactor encoder expected value precision

### DIFF
--- a/tests/base/encoder/test_encoder_model_ance.py
+++ b/tests/base/encoder/test_encoder_model_ance.py
@@ -25,7 +25,7 @@ from pyserini.encode._ance import AnceEncoder
 from tests.base.encoder.utils import assert_encode_query_cli_output, assert_query_encoder_output
 
 
-EXPECTED_VALUES = [(-1.34755, -1.22419), (-1.36109, -1.47927)]
+EXPECTED_VALUES = [(-1.34755, -1.22419, 5), (-1.36109, -1.47927, 5)]
 
 
 class TestEncodeAnce(unittest.TestCase):

--- a/tests/base/encoder/test_encoder_model_distilbert_kd.py
+++ b/tests/base/encoder/test_encoder_model_distilbert_kd.py
@@ -20,7 +20,7 @@ from pyserini.encode import AutoQueryEncoder
 from tests.base.encoder.utils import assert_encode_query_cli_output, assert_query_encoder_output
 
 
-EXPECTED_VALUES = [(0.01698, -0.00727), (-0.44893, 0.04673)]
+EXPECTED_VALUES = [(0.01698, -0.00727, 5), (-0.44893, 0.04673, 5)]
 
 
 class TestEncodeDistilBertKd(unittest.TestCase):

--- a/tests/base/encoder/test_encoder_model_distilbert_tasb.py
+++ b/tests/base/encoder/test_encoder_model_distilbert_tasb.py
@@ -20,7 +20,8 @@ from pyserini.encode import AutoQueryEncoder
 from tests.base.encoder.utils import assert_encode_query_cli_output, assert_query_encoder_output
 
 
-EXPECTED_VALUES = [(0.18463, -0.08488), (-0.28631, 0.20652)]
+# For the second vector, there are minor macOS/Linux differences, so back off to 4 places
+EXPECTED_VALUES = [(0.18463, -0.08488, 5), (-0.28631, 0.20652, 4)]
 
 
 class TestEncodeDistilBertTasB(unittest.TestCase):

--- a/tests/base/encoder/test_encoder_model_dpr.py
+++ b/tests/base/encoder/test_encoder_model_dpr.py
@@ -25,7 +25,7 @@ from pyserini.encode._dpr import _load_dpr_tokenizer
 from tests.base.encoder.utils import assert_encode_query_cli_output, assert_query_encoder_output
 
 
-EXPECTED_VALUES = [(-0.39652, 0.25375), (0.06198, -0.49947)]
+EXPECTED_VALUES = [(-0.39652, 0.25375, 5), (0.06198, -0.49947, 5)]
 
 
 class TestEncodeDpr(unittest.TestCase):

--- a/tests/base/encoder/test_encoder_model_sbert.py
+++ b/tests/base/encoder/test_encoder_model_sbert.py
@@ -20,7 +20,7 @@ from pyserini.encode import AutoQueryEncoder
 from tests.base.encoder.utils import assert_encode_query_cli_output, assert_query_encoder_output
 
 
-EXPECTED_VALUES = [(0.01859, -0.02723), (-0.04856, 0.03721)]
+EXPECTED_VALUES = [(0.01859, -0.02723, 5), (-0.04856, 0.03721, 5)]
 
 
 class TestEncodeSBert(unittest.TestCase):

--- a/tests/base/encoder/test_encoder_model_tct.py
+++ b/tests/base/encoder/test_encoder_model_tct.py
@@ -22,21 +22,17 @@ from pyserini.encode import TctColBertDocumentEncoder, TctColBertQueryEncoder
 from tests.base.encoder.utils import assert_encode_query_cli_output, assert_query_encoder_output
 
 
+EXPECTED_VALUES_TCT_COLBERT_MSMARCO = [(0.14085, -0.15662, 5), (-0.14778, 0.10030, 5)]
+EXPECTED_VALUES_TCT_COLBERT_V2_MSMARCO = [(0.18285, -0.10137, 5), (-0.03068, 0.08468, 5)]
+EXPECTED_VALUES_TCT_COLBERT_V2_HN_MSMARCO = [(0.15629, -0.09900, 5), (-0.04446, 0.07603, 5)]
+EXPECTED_VALUES_TCT_COLBERT_V2_HNP_MSMARCO = [(0.15061, -0.08704, 5), (-0.05862, 0.10783, 5)]
+
+
 class TestEncodeTctColBert(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.resource_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'resources'))
-
-    def _assert_encode_query_cli_output(self, topics, encoder, expected_values):
-        assert_encode_query_cli_output(self, topics, encoder, expected_values)
-
-    def _assert_query_encoder_output(self, topics, encoder, expected_values):
-        encoder = TctColBertQueryEncoder(encoder, device='cpu')
-        assert_query_encoder_output(self, topics, encoder, expected_values)
-
     def test_tct_colbert_encoder(self):
         texts = []
-        with open(os.path.join(self.resource_dir, 'simple_cacm_corpus.json')) as f:
+        resource_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'resources', 'simple_cacm_corpus.json'))
+        with open(resource_path) as f:
             for line in f:
                 line = json.loads(line)
                 texts.append(line['contents'])
@@ -49,60 +45,32 @@ class TestEncodeTctColBert(unittest.TestCase):
         self.assertAlmostEqual(vectors[2][-1], 0.05549, places=5)
 
     def test_msmarco_doc_tct_colbert_encode_query_cli(self):
-        self._assert_encode_query_cli_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-msmarco',
-            [(0.14085, -0.15662), (-0.14778, 0.10030)]
-        )
+        assert_encode_query_cli_output(self, 'msmarco-passage-dev-subset', 'castorini/tct_colbert-msmarco', EXPECTED_VALUES_TCT_COLBERT_MSMARCO)
 
     def test_msmarco_doc_tct_colbert_query_encoder(self):
-        self._assert_query_encoder_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-msmarco',
-            [(0.14085, -0.15662), (-0.14778, 0.10030)]
-        )
+        encoder = TctColBertQueryEncoder('castorini/tct_colbert-msmarco', device='cpu')
+        assert_query_encoder_output(self, 'msmarco-passage-dev-subset', encoder, EXPECTED_VALUES_TCT_COLBERT_MSMARCO)
 
     def test_msmarco_passage_tct_colbert_v2_encode_query_cli(self):
-        self._assert_encode_query_cli_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-v2-msmarco',
-            [(0.18285, -0.10137), (-0.03068, 0.08468)]
-        )
+        assert_encode_query_cli_output(self, 'msmarco-passage-dev-subset', 'castorini/tct_colbert-v2-msmarco', EXPECTED_VALUES_TCT_COLBERT_V2_MSMARCO)
 
     def test_msmarco_passage_tct_colbert_v2_query_encoder(self):
-        self._assert_query_encoder_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-v2-msmarco',
-            [(0.18285, -0.10137), (-0.03068, 0.08468)]
-        )
+        encoder = TctColBertQueryEncoder('castorini/tct_colbert-v2-msmarco', device='cpu')
+        assert_query_encoder_output(self, 'msmarco-passage-dev-subset', encoder, EXPECTED_VALUES_TCT_COLBERT_V2_MSMARCO)
 
     def test_msmarco_passage_tct_colbert_v2_hn_encode_query_cli(self):
-        self._assert_encode_query_cli_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-v2-hn-msmarco',
-            [(0.15629, -0.09900), (-0.04446, 0.07603)]
-        )
+        assert_encode_query_cli_output(self, 'msmarco-passage-dev-subset', 'castorini/tct_colbert-v2-hn-msmarco', EXPECTED_VALUES_TCT_COLBERT_V2_HN_MSMARCO)
 
     def test_msmarco_passage_tct_colbert_v2_hn_query_encoder(self):
-        self._assert_query_encoder_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-v2-hn-msmarco',
-            [(0.15629, -0.09900), (-0.04446, 0.07603)]
-        )
+        encoder = TctColBertQueryEncoder('castorini/tct_colbert-v2-hn-msmarco', device='cpu')
+        assert_query_encoder_output(self, 'msmarco-passage-dev-subset', encoder, EXPECTED_VALUES_TCT_COLBERT_V2_HN_MSMARCO)
 
     def test_msmarco_passage_tct_colbert_v2_hnp_encode_query_cli(self):
-        self._assert_encode_query_cli_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-v2-hnp-msmarco',
-            [(0.15061, -0.08704), (-0.05862, 0.10783)]
-        )
+        assert_encode_query_cli_output(self, 'msmarco-passage-dev-subset', 'castorini/tct_colbert-v2-hnp-msmarco', EXPECTED_VALUES_TCT_COLBERT_V2_HNP_MSMARCO)
 
     def test_msmarco_passage_tct_colbert_v2_hnp_query_encoder(self):
-        self._assert_query_encoder_output(
-            'msmarco-passage-dev-subset',
-            'castorini/tct_colbert-v2-hnp-msmarco',
-            [(0.15061, -0.08704), (-0.05862, 0.10783)]
-        )
+        encoder = TctColBertQueryEncoder('castorini/tct_colbert-v2-hnp-msmarco', device='cpu')
+        assert_query_encoder_output(self, 'msmarco-passage-dev-subset', encoder, EXPECTED_VALUES_TCT_COLBERT_V2_HNP_MSMARCO)
 
 
 if __name__ == '__main__':

--- a/tests/base/encoder/utils.py
+++ b/tests/base/encoder/utils.py
@@ -47,9 +47,9 @@ def assert_encode_query_cli_output(testcase, topics, encoder, expected_values, e
         testcase.assertEqual(encoded.shape, (len(expected_values), 3))
         testcase.assertEqual(encoded.columns.tolist(), ['id', 'text', 'embedding'])
         testcase.assertEqual(len(encoded.iloc[0]['embedding']), embedding_dim)
-        for i, (first_value, last_value) in enumerate(expected_values):
-            testcase.assertAlmostEqual(encoded.iloc[i]['embedding'][0], first_value, places=5)
-            testcase.assertAlmostEqual(encoded.iloc[i]['embedding'][-1], last_value, places=5)
+        for i, (first_value, last_value, places) in enumerate(expected_values):
+            testcase.assertAlmostEqual(encoded.iloc[i]['embedding'][0], first_value, places=places)
+            testcase.assertAlmostEqual(encoded.iloc[i]['embedding'][-1], last_value, places=places)
 
 
 def assert_query_encoder_output(testcase, topics, encoder, expected_values, embedding_dim=768):
@@ -59,5 +59,6 @@ def assert_query_encoder_output(testcase, topics, encoder, expected_values, embe
             break
         embedding = encoder.encode(text)
         testcase.assertEqual(len(embedding), embedding_dim)
-        testcase.assertAlmostEqual(embedding[0], expected_values[i][0], places=5)
-        testcase.assertAlmostEqual(embedding[-1], expected_values[i][1], places=5)
+        first_value, last_value, places = expected_values[i]
+        testcase.assertAlmostEqual(embedding[0], first_value, places=places)
+        testcase.assertAlmostEqual(embedding[-1], last_value, places=places)


### PR DESCRIPTION
## Summary

- Add per-expected-value precision to encoder test assertions.
- Convert encoder expected values to `(first, last, places)` triples.
- Relax the second DistilBERT TAS-B expected vector to 4 places for macOS/Linux variation.
- Simplify TCT encoder tests by extracting per-model expected values and removing redundant wrappers.

## Validation

- `mamba run -n pyserini-dev3 python -m py_compile tests/base/encoder/utils.py tests/base/encoder/test_encoder_model_ance.py tests/base/encoder/test_encoder_model_distilbert_kd.py tests/base/encoder/test_encoder_model_distilbert_tasb.py tests/base/encoder/test_encoder_model_dpr.py tests/base/encoder/test_encoder_model_sbert.py tests/base/encoder/test_encoder_model_tct.py`

Unit tests were intentionally not run.