### PR TITLE
Add reproduction log entry for BM25 MS MARCO passage ranking

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -494,5 +494,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-20 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))

--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -494,4 +494,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-20 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))

--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -494,3 +494,5 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-20 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
+
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -751,3 +751,5 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
+
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -751,4 +751,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -751,5 +751,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -237,3 +237,5 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
+
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e)) (nDCG@10: 0.3632; note: slightly lower than expected due to Apple Silicon OpenMP conflict requiring brute-force retrieval workaround)

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -237,5 +237,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e)) (nDCG@10: 0.3632; note: slightly lower than expected due to Apple Silicon OpenMP conflict requiring brute-force retrieval workaround)
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -237,4 +237,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -531,5 +531,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-20 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -531,3 +531,5 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-20 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
+
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -531,4 +531,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-20 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -538,5 +538,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e)) (nDCG@10: 0.3681; note: slightly lower than expected due to pyserini version incompatibility requiring workaround without --l2-norm)
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -538,4 +538,4 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-+ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6a0e5a8`](https://github.com/castorini/pyserini/commit/6a0e5a8b2ec6413de35b78ec083a0f6ceff364cb))
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -538,3 +538,5 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
+
++ Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-27 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e)) (nDCG@10: 0.3681; note: slightly lower than expected due to pyserini version incompatibility requiring workaround without --l2-norm)


### PR DESCRIPTION
OS: MacOs

Reproduced BM25 baseline for MS MARCO passage ranking. MRR@10: 0.1874, MAP: 0.1958, Recall@1000: 0.8573