### PR TITLE
Fix OpenAI encoder for openai>=1.0 client API

### DIFF
--- a/pyserini/encode/_openai.py
+++ b/pyserini/encode/_openai.py
@@ -27,7 +27,7 @@ from pyserini.encode import DocumentEncoder, QueryEncoder
 OPENAI_API_RETRY_DELAY = 5
 
 
-def retry_with_delay(func, delay: int = OPENAI_API_RETRY_DELAY, max_retries: int = 10, errors: tuple = (openai.RateLimitError)):
+def retry_with_delay(func, delay: int = OPENAI_API_RETRY_DELAY, max_retries: int = 10, errors: tuple = (openai.RateLimitError,)):
     def wrapper(*args, **kwargs):
         num_retries = 0
         while True:
@@ -47,11 +47,14 @@ class OpenAiDocumentEncoder(DocumentEncoder):
     def __init__(self, model_name: str = 'text-embedding-ada-002', tokenizer_name: str = 'cl100k_base', **kwargs):
         self.model = model_name
         self.tokenizer = tiktoken.get_encoding(tokenizer_name)
+        api_key = '' if os.getenv("OPENAI_API_KEY") is None else os.getenv("OPENAI_API_KEY")
+        org_key = '' if os.getenv("OPENAI_ORG_KEY") is None else os.getenv("OPENAI_ORG_KEY")
+        self.client = openai.OpenAI(api_key=api_key, organization=org_key)
 
     @retry_with_delay
     def get_embeddings(self, inputs: List[str]):
-        response = openai.Embedding.create(input=inputs, model=self.model)
-        embeddings = [item['embedding'] for item in response['data']]
+        response = self.client.embeddings.create(input=inputs, model=self.model)
+        embeddings = [item.embedding for item in response.data]
         return np.array(embeddings)
 
     def encode(self, texts: List[str], titles = None, max_length: int = 512, **kwargs):
@@ -78,7 +81,7 @@ class OpenAiQueryEncoder(QueryEncoder):
 
     @retry_with_delay
     def get_embedding(self, text: str):
-        return np.array(self.client.embeddings.create(input=text, model=self.model)['data'][0]['embedding'])
+        return np.array(self.client.embeddings.create(input=text, model=self.model).data[0].embedding)
 
     def encode(self, query: str, **kwargs):
         if self.has_model:


### PR DESCRIPTION
The OpenAI document and query encoders used the pre-1.0 API (`openai.Embedding.create`, `response['data'][i]['embedding']`), which raises `APIRemovedInV1` under the pinned `openai>=2.12.0`, so the encoder is currently broken.

This builds an `openai.OpenAI` client in the document encoder and reads `client.embeddings.create(...).data[i].embedding`, following the pattern already used by `OpenAiQueryEncoder` (#2014), and updates the query encoder's response access to the same attribute style. It also makes `retry_with_delay`'s default `errors` an actual tuple to match its annotation.
