### PR TITLE
Fix impact searcher .json encoder detection (endswith, not encode)

### DIFF
--- a/pyserini/search/lucene/_impact_searcher.py
+++ b/pyserini/search/lucene/_impact_searcher.py
@@ -373,7 +373,7 @@ class LuceneImpactSearcher:
     def _init_query_encoder_from_str(query_encoder):
         if query_encoder is None:
             return TokFreqQueryEncoder()
-        elif os.path.isfile(query_encoder) and (query_encoder.endswith('jsonl') or query_encoder.encode('json')):
+        elif os.path.isfile(query_encoder) and (query_encoder.endswith('jsonl') or query_encoder.endswith('json')):
             return CachedDataQueryEncoder(query_encoder)
         elif 'unicoil' in query_encoder.lower():
             return UniCoilQueryEncoder(query_encoder)


### PR DESCRIPTION
`_init_query_encoder_from_str` used `query_encoder.encode('json')`, which raises `LookupError: unknown encoding: json` ('json' is not a codec). For an existing encoder file whose name does not end in `jsonl` (e.g. a `.json` cached-query file, the case this branch handles), this crashes instead of routing to `CachedDataQueryEncoder`.

Changed it to `query_encoder.endswith('json')`, which was clearly intended.
