### PR TITLE
Fix predefined query order lookup for file-path and underscore topics

### DIFF
--- a/pyserini/query_iterator.py
+++ b/pyserini/query_iterator.py
@@ -84,7 +84,7 @@ class QueryIterator(ABC):
             # Lazy import:
             from pyserini.query_iterator_order_info import QUERY_IDS
 
-            order = QUERY_IDS[topics_path]
+            order = QUERY_IDS[normalized_path]
         return order
 
 

--- a/tests/base/test_topics_order.py
+++ b/tests/base/test_topics_order.py
@@ -17,7 +17,8 @@
 import tempfile
 import unittest
 
-from pyserini.query_iterator import DefaultQueryIterator
+from pyserini.query_iterator import DefaultQueryIterator, QueryIterator
+from pyserini.query_iterator_order_info import QUERY_IDS
 
 
 class TestEncodedQueries(unittest.TestCase):
@@ -38,6 +39,40 @@ class TestEncodedQueries(unittest.TestCase):
         self.assertTrue(topic_ids[0], 1048585)
         self.assertTrue(topic_ids[1], 2)
         self.assertTrue(topic_ids[-1], 524332)
+
+    def test_get_predefined_order_bare_key(self):
+        # A bare, already-hyphenated predefined name resolves to its QUERY_IDS order.
+        order = QueryIterator.get_predefined_order('msmarco-passage-dev-subset')
+        self.assertEqual(order, QUERY_IDS['msmarco-passage-dev-subset'])
+
+    def test_get_predefined_order_underscore_topics(self):
+        # The underscore form is normalized to hyphens for the membership test, so the
+        # lookup must use that same normalized key, not the raw topics value.
+        # Before the fix this raised KeyError: 'msmarco_passage_dev_subset'.
+        order = QueryIterator.get_predefined_order('msmarco_passage_dev_subset')
+        self.assertEqual(order, QUERY_IDS['msmarco-passage-dev-subset'])
+
+    def test_get_predefined_order_file_path_topics(self):
+        # A --topics value given as a file path (directory + extension) normalizes to
+        # the bare stem, so the lookup must use that stem rather than the raw path.
+        # Before the fix this raised KeyError on the full path.
+        order = QueryIterator.get_predefined_order('/data/topics/msmarco-passage-dev-subset.tsv')
+        self.assertEqual(order, QUERY_IDS['msmarco-passage-dev-subset'])
+
+    def test_get_predefined_order_all_predefined_resolve(self):
+        # Every predefined name must resolve without raising, in its bare, underscore,
+        # and file-path forms, and always to the same order list.
+        for name in QueryIterator.PREDEFINED_ORDER:
+            expected = QUERY_IDS[name]
+            self.assertEqual(QueryIterator.get_predefined_order(name), expected)
+            self.assertEqual(QueryIterator.get_predefined_order(name.replace('-', '_')), expected)
+            self.assertEqual(QueryIterator.get_predefined_order(f'/tmp/{name}.tsv'), expected)
+
+    def test_get_predefined_order_unknown_returns_none(self):
+        # A topics value that is not a predefined order returns None, so the iterator
+        # falls back to sorted-key ordering downstream.
+        self.assertIsNone(QueryIterator.get_predefined_order('core17'))
+        self.assertIsNone(QueryIterator.get_predefined_order('/data/topics/not-predefined.tsv'))
 
     def test_topics_as_int(self):
         topics_int = (


### PR DESCRIPTION
`get_predefined_order` tests membership with a normalized key (`Path(topics_path).stem` with `_` replaced by `-`) but then looks up `QUERY_IDS[topics_path]` using the raw path. `PREDEFINED_ORDER` and `QUERY_IDS` share the same bare hyphenated keys, so a file-path or underscore `--topics` value passes the membership test and then raises `KeyError` on the lookup.

Changed the lookup to use `normalized_path`, matching the membership test.
