### PR TITLE
[codex] Clarify onboarding reproduction instructions

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -164,7 +164,7 @@ multihot_query_weights = {k: 1 for k in query_tokens}
 
 The query tokens (`query_tokens`) are:
 
-```
+```text
 ['what', 'paula', 'deen', 'brother']
 ```
 
@@ -270,7 +270,17 @@ We'll save a more complete exploration of this design space for some other time,
 
 Okay, that's it for this lesson.
 Next, you're going to play with [an actual dense retrieval model](experiments-nfcorpus.md).
-Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page, following the same format: use `yyyy-mm-dd`, make sure you're using a commit id that's on the main trunk of Pyserini, and use its 7-hexadecimal prefix for the link anchor text.
+
+Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page:
+
++ Follow the same format as the existing entries: make sure you use a commit id that's on the main trunk of Pyserini. Use its 7-hexadecimal prefix for the link anchor text (but the URL should contain the full commit hash).
++ Provide some details about your setup in the description of your pull request (e.g., operating system, environment and configuration, etc.).
++ Provide some indication of success (e.g., everything worked) or document issues you encountered.
++ Confirm that your new entry is chronologically sorted.
++ Include additional edits in the pull request if you think this exercise can be improved (e.g., you caught a typo or think a clarification is warranted).
+
+Do not send a separate pull request for each exercise in the onboarding path; instead, send a single pull request for all edits to the Pyserini repository.
+If you have any questions, look at previous pull requests for examples.
 
 ## Reproduction Log[*](reproducibility.md)
 
@@ -450,7 +460,7 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MehdiJmlkh](https://github.com/MehdiJmlkh) on 2025-12-10 (commit [`d26c2fd`](https://github.com/castorini/pyserini/commit/d26c2fd224439ca564fe9d2b9e2be580391f1275))
 + Results reproduced by [@MuhammadAli13562](https://github.com/MuhammadAli13562) on 2025-12-18 (commit [`e4bf66e`](https://github.com/castorini/pyserini/commit/e4bf66e77eadcfff29637fd10b31fc4b236a9be7))
 + Results reproduced by [@Hossein-Molaeian](https://github.com/Hossein-Molaeian) on 2025-12-19 (commit [`fee9962`](https://github.com/castorini/pyserini/commit/fee9962f97ba4b2f362c0f4c84908f15f61424e6))
-+ Results reproduced by [@anjanpa](https://github.com/anjanpa) on 2025-12-22 (commit [`d12db6a`](https://github.com/castorini/pyserini/commit/d12db6abed1cc9e7a20f8d5685d2e133005aa0a9)) 
++ Results reproduced by [@anjanpa](https://github.com/anjanpa) on 2025-12-22 (commit [`d12db6a`](https://github.com/castorini/pyserini/commit/d12db6abed1cc9e7a20f8d5685d2e133005aa0a9))
 + Results reproduced by [@nli33](https://github.com/nli33) on 2025-12-25 (commit [`d12db6a`](https://github.com/castorini/pyserini/commit/d12db6abed1cc9e7a20f8d5685d2e133005aa0a9))
 + Results reproduced by [@VarnitOS](https://github.com/VarnitOS) on 2025-12-29 (commit [`4106eed`](https://github.com/castorini/pyserini/commit/4106eed08a62f9c2631a267eb4863649ee2b748e))
 + Results reproduced by [@zizimind](https://github.com/zizimind) on 2026-01-06 (commit [`74d7182`](https://github.com/castorini/pyserini/commit/74d7182004e4380e3cf0caf993375a25c1bcc5dc))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -192,7 +192,7 @@ for i in range(0, 10):
 
 And the result will be:
 
-```
+```text
  1 MED-4555 0.791379
  2 MED-4560 0.710725
  3 MED-4421 0.688938
@@ -223,7 +223,7 @@ for i in range(0, 10):
 
 And the result will be:
 
-```
+```text
  1 MED-4555 1.472201
  2 MED-3180 1.125014
  3 MED-1309 1.067153
@@ -333,7 +333,6 @@ Again, the output is the same as search with `FaissSearcher` above.
 </details>
 <br/>
 
-
 ## Sparse Retrieval Models
 
 Now, we're going to basically do the same thing, but with BM25.
@@ -392,7 +391,7 @@ python -m pyserini.eval.trec_eval \
 
 The expected results are:
 
-```
+```text
 Results:
 ndcg_cut_10           	all	0.3218
 ```
@@ -411,7 +410,7 @@ for i in range(0, 10):
 
 The results should be as follows:
 
-```
+```text
  1 MED-4555 11.9305
  2 MED-4423 8.4771
  3 MED-3180 7.1896
@@ -528,7 +527,17 @@ To recap, what's the point for this exercise?
 Okay, that's it for this lesson.
 
 The next lesson will provide [a deeper dive into learned sparse representations](conceptual-framework3.md).
-Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page, following the same format: use `yyyy-mm-dd`, make sure you're using a commit id that's on the main trunk of Pyserini, and use its 7-hexadecimal prefix for the link anchor text.
+
+Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page:
+
++ Follow the same format as the existing entries: make sure you use a commit id that's on the main trunk of Pyserini. Use its 7-hexadecimal prefix for the link anchor text (but the URL should contain the full commit hash).
++ Provide some details about your setup in the description of your pull request (e.g., operating system, environment and configuration, etc.).
++ Provide some indication of success (e.g., everything worked) or document issues you encountered.
++ Confirm that your new entry is chronologically sorted.
++ Include additional edits in the pull request if you think this exercise can be improved (e.g., you caught a typo or think a clarification is warranted).
+
+Do not send a separate pull request for each exercise in the onboarding path; instead, send a single pull request for all edits to the Pyserini repository.
+If you have any questions, look at previous pull requests for examples.
 
 ## Reproduction Log[*](reproducibility.md)
 
@@ -749,7 +758,7 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-21 (commit [`42ff49c`](https://github.com/castorini/pyserini/commit/42ff49c1393de811f46674188411a6970e0c85c6))
 + Results reproduced by [@farhadmoradi66](https://github.com/farhadmoradi66) on 2026-06-19 (commit [`08fd23b`](https://github.com/castorini/pyserini/commit/08fd23b1262213c63661948f7b084fb3eb23ac2a))
-+ Results reproduced by [@sparshshah19](https://github.com/sparshshah19) on 2026-06-25 (commit [`6f48030`](https://github.com/castorini/pyserini/commit/6f48030cf786280625bc3ed6d2743374bd099e57)) 
++ Results reproduced by [@sparshshah19](https://github.com/sparshshah19) on 2026-06-25 (commit [`6f48030`](https://github.com/castorini/pyserini/commit/6f48030cf786280625bc3ed6d2743374bd099e57))
 + Results reproduced by [@k22mitta](https://github.com/k22mitta) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))
 + Results reproduced by [@Fustigate8933](https://github.com/Fustigate8933) on 2026-07-01 (commit [`ef7398b`](https://github.com/castorini/pyserini/commit/ef7398baec47c18a90757ce6d1cc815682432e1a))
 + Results reproduced by [@yashs33244](https://github.com/yashs33244) on 2026-07-05 (commit [`ef7398b`](https://github.com/castorini/pyserini/commit/ef7398baec47c18a90757ce6d1cc815682432e1a))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -13,7 +13,8 @@ Following the onboarding path, this lesson does **not** introduce any new concep
 Rather, the focus is to solidify previously introduced concepts and to connect the bi-encoder architecture to implementations in Pyserini.
 Informally, we're "peeling back the covers".
 
-**Learning outcomes** for this guide, building on previous steps in the onboarding path, are divided into three parts.
+**Learning outcomes** for this guide, building on previous steps in the onboarding path, are as follows:
+
 1. Be able to encode a corpus into its sparse vector representations with SPLADE-v3.
 2. Be able to index them into a retrieval system using Lucene inverted index.
 3. Be able to compute query-document scores (i.e., retrieval scores) with pyserini for SPLADE retrieval.
@@ -50,6 +51,7 @@ cd ..
 
 We can then setup to use SPLADE-v3:
 First, we need to request access to SPLADE-v3 model on Hugging Face since it is gated:
+
 1. Create an account for Hugging Face: https://huggingface.co/join
 2. Go to the model page on Hugging Face: [Splade-v3](https://huggingface.co/naver/splade-v3)
 3. Click the "Log In" button.
@@ -68,6 +70,7 @@ hf auth login
 ```
 
 You’ll be prompted to enter your Hugging Face API token. You can generate a token from your Hugging Face account settings:
+
 1. Go to https://huggingface.co/settings/tokens.
 2. Click **"New token"** to generate a token.
 3. For your token's permissions, give “Read access to contents of all public gated repos you can access”.
@@ -119,7 +122,8 @@ python -m pyserini.search.lucene \
   --impact \
   --threads 4
 ```
-The runs will be stored in runs/run.splade.txt.
+
+The runs will be stored in `runs/run.splade.txt`.
 
 And evaluate the retrieval run:
 
@@ -131,7 +135,7 @@ python -m pyserini.eval.trec_eval \
 
 The expected results are:
 
-```
+```text
 ndcg_cut_10           	all	0.3624
 ```
 
@@ -152,7 +156,7 @@ for i in range(0, 10):
 
 The results should be as follows:
 
-```
+```text
  1 MED-4555 51131.000000
  2 MED-4423 36854.000000
  3 MED-3180 30411.000000
@@ -164,7 +168,7 @@ The results should be as follows:
  9 MED-4030 27699.000000
 10 MED-1194 27588.000000
 ```
-     
+
 To recap, what's the point for this exercise?
 
 + We see that a machine learning model can also be applied to generate sparse vectors.
@@ -172,7 +176,17 @@ To recap, what's the point for this exercise?
 + You now know how to encode a query into a query vector.
 
 Okay, that's it for this lesson.
-Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page, following the same format: use `yyyy-mm-dd`, make sure you're using a commit id that's on the main trunk of Pyserini, and use its 7-hexadecimal prefix for the link anchor text.
+
+Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page:
+
++ Follow the same format as the existing entries: make sure you use a commit id that's on the main trunk of Pyserini. Use its 7-hexadecimal prefix for the link anchor text (but the URL should contain the full commit hash).
++ Provide some details about your setup in the description of your pull request (e.g., operating system, environment and configuration, etc.).
++ Provide some indication of success (e.g., everything worked) or document issues you encountered.
++ Confirm that your new entry is chronologically sorted.
++ Include additional edits in the pull request if you think this exercise can be improved (e.g., you caught a typo or think a clarification is warranted).
+
+Do not send a separate pull request for each exercise in the onboarding path; instead, send a single pull request for all edits to the Pyserini repository.
+If you have any questions, look at previous pull requests for examples.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -217,7 +217,7 @@ In the code snippet above, we're issuing the query about Paula Deen's brother (f
 Note that we're explicitly setting the BM25 parameters, which are not the default parameters.
 We get back a list of results (`hits`), which we then iterate through and print out:
 
-```
+```text
  1 7187158 18.811600
  2 7187157 18.333401
  3 7187163 17.878799
@@ -254,14 +254,23 @@ hits[0].lucene_document.get('raw')
 
 And you should get:
 
-```
+```text
 '{\n  "id" : "7187158",\n  "contents" : "Paula Deen and her brother Earl W. Bubba Hiers are being sued by a former general manager at Uncle Bubba\'sâ\x80¦ Paula Deen and her brother Earl W. Bubba Hiers are being sued by a former general manager at Uncle Bubba\'sâ\x80¦"\n}'
 ```
 
 Everything make sense?
 If so, now you're truly done with this guide and are ready to move on and [learn about the relationship between sparse and dense retrieval](conceptual-framework.md)!
 
-Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page, following the same format: use `yyyy-mm-dd`, make sure you're using a commit id that's on the main trunk of Pyserini, and use its 7-hexadecimal prefix for the link anchor text.
+Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page:
+
++ Follow the same format as the existing entries: make sure you use a commit id that's on the main trunk of Pyserini. Use its 7-hexadecimal prefix for the link anchor text (but the URL should contain the full commit hash).
++ Provide some details about your setup in the description of your pull request (e.g., operating system, environment and configuration, etc.).
++ Provide some indication of success (e.g., everything worked) or document issues you encountered.
++ Confirm that your new entry is chronologically sorted.
++ Include additional edits in the pull request if you think this exercise can be improved (e.g., you caught a typo or think a clarification is warranted).
+
+Do not send a separate pull request for each exercise in the onboarding path; instead, send a single pull request for all edits to the Pyserini repository.
+If you have any questions, look at previous pull requests for examples.
 
 ## Reproduction Log[*](reproducibility.md)
 
@@ -488,7 +497,7 @@ Before you move on, however, add an entry in the "Reproduction Log" at the botto
 + Results reproduced by [@Hossein-Molaeian](https://github.com/Hossein-Molaeian) on 2025-12-19 (commit [`fee9962`](https://github.com/castorini/pyserini/commit/fee9962f97ba4b2f362c0f4c84908f15f61424e6))
 + Results reproduced by [@anjanpa](https://github.com/anjanpa) on 2025-12-20 (commit [`d12db6a`](https://github.com/castorini/pyserini/commit/d12db6abed1cc9e7a20f8d5685d2e133005aa0a9))
 + Results reproduced by [@nli33](https://github.com/nli33) on 2025-12-25 (commit [`d12db6a`](https://github.com/castorini/pyserini/commit/d12db6abed1cc9e7a20f8d5685d2e133005aa0a9))
-+ Results reproduced by [@VarnitOS](https://github.com/VarnitOS) on 2025-12-29 (commit [`4106eed`](https://github.com/castorini/pyserini/commit/4106eed08a62f9c2631a267eb4863649ee2b748e)) 
++ Results reproduced by [@VarnitOS](https://github.com/VarnitOS) on 2025-12-29 (commit [`4106eed`](https://github.com/castorini/pyserini/commit/4106eed08a62f9c2631a267eb4863649ee2b748e))
 + Results reproduced by [@zizimind](https://github.com/zizimind) on 2026-01-06 (commit [`74d7182`](https://github.com/castorini/pyserini/commit/74d7182004e4380e3cf0caf993375a25c1bcc5dc))
 + Results reproduced by [@izzat5233](https://github.com/izzat5233) on 2026-01-17 (commit [`4bfbb9e`](https://github.com/castorini/pyserini/commit/4bfbb9e144872b9223359ee6bac0bc595c0734d6))
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-27 (commit [`9e92b42`](https://github.com/castorini/pyserini/commit/9e92b4291fd30faad4b64bdd0ddba2d106694ed5))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -177,9 +177,10 @@ python -m pyserini.eval.trec_eval \
   -c -m ndcg_cut.10 collections/nfcorpus/qrels/test.qrels \
   runs/run.beir.bge-base-en-v1.5.nfcorpus.txt
 ```
+
 The results will be something like:
 
-```
+```text
 Results:
 ndcg_cut_10           	all	0.3808
 ```
@@ -196,7 +197,7 @@ python -m pyserini.eval.trec_eval \
 
 The results will be something like:
 
-```
+```text
 Results:
 ndcg_cut_10           	all	0.3306
 ```
@@ -229,7 +230,7 @@ for i in range(0, 10):
 The `FaissSearcher` provides search capabilities using Faiss as its underlying implementation.
 The `AutoQueryEncoder` allows us to initialize an encoder using a HuggingFace model.
 
-```
+```text
  1 MED-4555 0.791379
  2 MED-4560 0.710725
  3 MED-4421 0.688938
@@ -279,7 +280,7 @@ for i in range(0, 10):
 The `FaissSearcher` provides search capabilities using Faiss as its underlying implementation.
 The `AutoQueryEncoder` allows us to initialize an encoder using a HuggingFace model.
 
-```
+```text
  1 MED-4555 1.472201
  2 MED-3180 1.125014
  3 MED-1309 1.067153
@@ -314,7 +315,17 @@ PLAIN-3074 Q0 MED-2587 10 1.010811 Faiss
 And that's it!
 
 The next lesson will provide [a deeper dive into dense and sparse representations](conceptual-framework2.md).
-Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page, following the same format: use `yyyy-mm-dd`, make sure you're using a commit id that's on the main trunk of Pyserini, and use its 7-hexadecimal prefix for the link anchor text.
+
+Before you move on, however, add an entry in the "Reproduction Log" at the bottom of this page:
+
++ Follow the same format as the existing entries: make sure you use a commit id that's on the main trunk of Pyserini. Use its 7-hexadecimal prefix for the link anchor text (but the URL should contain the full commit hash).
++ Provide some details about your setup in the description of your pull request (e.g., operating system, environment and configuration, etc.).
++ Provide some indication of success (e.g., everything worked) or document issues you encountered.
++ Confirm that your new entry is chronologically sorted.
++ Include additional edits in the pull request if you think this exercise can be improved (e.g., you caught a typo or think a clarification is warranted).
+
+Do not send a separate pull request for each exercise in the onboarding path; instead, send a single pull request for all edits to the Pyserini repository.
+If you have any questions, look at previous pull requests for examples.
 
 ## Reproduction Log[*](reproducibility.md)
 


### PR DESCRIPTION
## Summary

- Clarify reproduction-log expectations across onboarding documentation pages.
- Ask contributors to include setup details, success/issues, chronological ordering, and combined onboarding edits in a single PR.
- Mark plain output blocks as `text` and clean up minor markdown whitespace.

## Validation

- `git diff --check HEAD~1 HEAD`
