### PR TITLE
Add Onboard Production Log Entry

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -514,3 +514,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@JonHolman](https://github.com/JonHolman) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
++ Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -770,3 +770,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@JonHolman](https://github.com/JonHolman) on 2026-06-29 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
++ Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -262,3 +262,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@JonHolman](https://github.com/JonHolman) on 2026-06-29 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
++ Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -550,3 +550,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@JonHolman](https://github.com/JonHolman) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
++ Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -559,3 +559,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@JonHolman](https://github.com/JonHolman) on 2026-06-28 (commit [`6d03d1e`](https://github.com/castorini/pyserini/commit/6d03d1e43e5d6bc424f4bd46ac978891661fcb55))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
++ Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))


### PR DESCRIPTION
Operating System: Ubuntu Linux (Google Colab runtime)
Environment: Google Colab
Java: OpenJDK 21
Build tool: Maven

Configuration:

Built Pyserini in the Colab environment.
Modified bin/run.sh to reduce the JVM maximum heap size from -Xmx192G to a smaller value -Xmx4G to better fit the available Colab memory.
Reduced indexing threads from 9 to 1 to lower memory usage during indexing.
Results:

Successfully completed the onboarding steps and added my reproduction log entry.