### PR TITLE
docs: Foundations of Retrieval onboarding reproductions

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -516,4 +516,5 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-21 (commit [`282c69d`](https://github.com/castorini/pyserini/commit/282c69d77b230e52eba5cff681bc80af51492bbc))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -772,4 +772,5 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-26 (commit [`282c69d`](https://github.com/castorini/pyserini/commit/282c69d77b230e52eba5cff681bc80af51492bbc))
++ Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -264,4 +264,5 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-26 (commit [`282c69d`](https://github.com/castorini/pyserini/commit/282c69d77b230e52eba5cff681bc80af51492bbc))
++ Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-27 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -552,4 +552,5 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-19 (commit [`282c69d`](https://github.com/castorini/pyserini/commit/282c69d77b230e52eba5cff681bc80af51492bbc))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -561,4 +561,5 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-23 (commit [`282c69d`](https://github.com/castorini/pyserini/commit/282c69d77b230e52eba5cff681bc80af51492bbc))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))


### PR DESCRIPTION
## Summary

This pull request records my completion of the Pyserini portion of the Foundations of Retrieval onboarding path:

- MS MARCO passage BM25 indexing, retrieval, evaluation, and interactive retrieval
- reconstruction of BM25 document and query vectors and manual score verification
- NFCorpus dense retrieval with BGE-base and the optional Contriever baseline
- manual dense and sparse vector reconstruction and top-k retrieval
- NFCorpus learned sparse retrieval with SPLADE-v3

It also updates the current `trec_eval` argument syntax in the MS MARCO guide from the concatenated form to `-m recall.1000 -m map`.

## Reproduced results

- MS MARCO passage BM25: MRR@10 `0.18741227770955546`
- MS MARCO passage BM25: recall@1000 `0.8573`
- NFCorpus BGE-base: nDCG@10 `0.3808`
- NFCorpus Contriever-MS MARCO: nDCG@10 `0.3306`
- NFCorpus BM25: nDCG@10 `0.3218`
- NFCorpus SPLADE-v3: nDCG@10 `0.3624`

The interactive rankings matched the corresponding batch runs. Manual dot-product retrieval matched Faiss for both BGE-base and Contriever, and manual BM25 retrieval matched Lucene.

## Environment

- Windows 11 with Ubuntu 22.04 under WSL2
- CPU execution with 12 GB allocated to WSL2
- Python 3.12 in a Conda environment
- Java supplied by the Conda environment

For SPLADE-v3 document encoding, I reduced the batch size to 4 because the guide's implicit default exceeded the available WSL memory. This changes throughput only; the expected `0.3624` nDCG@10 score and documented interactive ranking were reproduced exactly.
