### PR TITLE
Add reproduction log entries for Foundations of Retrieval lessons 4-8

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -515,3 +515,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -771,3 +771,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -263,3 +263,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -551,3 +551,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -560,3 +560,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`a5a5b33`](https://github.com/castorini/pyserini/commit/a5a5b33d7b648cba2597230deefed73ed85f7eff))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`50e5dc8`](https://github.com/castorini/pyserini/commit/50e5dc8737538eb82dbe3592e53f736e175daac7))
 + Results reproduced by [@ayesha12321](https://github.com/ayesha12321) on 2026-07-25 (commit [`8f6964c`](https://github.com/ayesha12321/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`8f6964c`](https://github.com/castorini/pyserini/commit/8f6964c95d01980b1700381998c2448d9e6232de))


### PR DESCRIPTION
Add reproduction log entries for the "Foundations of Retrieval" onboarding path (lessons 4-8): BM25 baseline, conceptual framework, NFCorpus dense retrieval (BGE-base), deeper dive into dense/sparse representations, and learned sparse retrieval (SPLADE-v3).

## Setup

- OS: macOS 26.5.2 (Darwin 25.5.0), Apple M4, 16 GB RAM
- Java: OpenJDK 21.0.12 (Homebrew); Python 3.13.7 in a checkout-local `.venv`
- Dev install: `pip install -e .`, Anserini fatjar copied into `pyserini/resources/jars/`, `tools/eval` submodule built (trec_eval 9.0.4, ndeval)

## Results

All five lessons reproduced against documented expected values:

- **experiments-msmarco-passage.md**: indexed 8,841,823 docs (0 errors). MRR@10 = `0.18741227770955546` (exact match, official eval script). `trec_eval` gave `map=0.1958` vs documented `0.1957` — traced this down: the retrieved rankings are byte-identical to Anserini's Java-side run (0 diffs across all 6,974,598 qid/docid/rank triples), so it's a `trec_eval` tie-break artifact from real (tied) BM25 float scores vs the synthetic strictly-decreasing scores produced by the msmarco→trec run converter, not a reproduction error. `recall_1000=0.8573` and per-query MRR@10 for qid 1048585 (`1.0000`) both matched exactly. Interactive `LuceneSearcher` also matched exactly.
- **conceptual-framework.md**: BM25 document vector for docid 7187158, query tokens, and dot product (`17.949487686157227`) all matched exactly; Lucene score matched (`17.94950`).
- **experiments-nfcorpus.md**: BGE-base encoding + Faiss flat index, retrieval and `ndcg_cut_10=0.3808` (exact match). Interactive `FaissSearcher` matched the batch run exactly.
- **conceptual-framework2.md**: Faiss vector count (3633), L2 norm check (0.0), query-doc dot product (`0.7913785`), and brute-force top-10 all matched exactly for dense; BM25 index (3633 docs, 0 errors), `ndcg_cut_10=0.3218`, and hand-computed BM25 retrieval matched exactly for sparse.
- **conceptual-framework3.md**: SPLADE-v3 encoding + impact index (3633 docs, 0 errors), `ndcg_cut_10=0.3624` (exact match), and interactive `LuceneImpactSearcher` scores matched exactly (`51131.0` for top hit).

## Issues encountered

- `faiss` isn't a listed dependency (per the install guide, intentionally — needs manual variant selection); had to `pip install faiss-cpu` before the NFCorpus lesson would run.
- Faiss batch retrieval (`--threads 8`) crashed the JVM with a SIGSEGV in `libomp` — a known macOS ARM conflict between the JVM's and PyTorch/Faiss's OpenMP runtimes. Fixed with `--threads 1` plus `KMP_DUPLICATE_LIB_OK=TRUE` and `OMP_NUM_THREADS=1`.
- SPLADE-v3 is a gated HF model; needed to accept its terms and `hf auth login` before encoding.
- Hit the GitHub API's unauthenticated rate limit (60/hr) twice on prebuilt-index/metadata fetches; both times resolved after the hourly reset.
