### PR TITLE
Add batch query encoding to AutoQueryEncoder

### DIFF
--- a/pyserini/encode/_auto.py
+++ b/pyserini/encode/_auto.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+from typing import List
+
 import numpy as np
 from sklearn.preprocessing import normalize
 from transformers import AutoModel
@@ -107,3 +109,39 @@ class AutoQueryEncoder(QueryEncoder):
             return embeddings.flatten()
         else:
             return super().encode(query)
+
+    def encode_batch(self, queries: List[str], max_length: int = None):
+        """Encode a list of queries in a single forward pass.
+
+        Row i of the returned array equals ``encode(queries[i])``, so this is a
+        drop-in speed-up for callers such as ``FaissSearcher.batch_search`` that
+        would otherwise encode queries one at a time.
+        """
+        if not self.has_model:
+            return np.array([QueryEncoder.encode(self, query) for query in queries])
+        if self.prefix:
+            queries = [f'{self.prefix} {query}' for query in queries]
+        tokenizer_kwargs = dict(
+            add_special_tokens=True,
+            return_tensors='pt',
+            padding='longest',
+            return_token_type_ids=False,
+            truncation=True,
+        )
+        if max_length is not None:
+            tokenizer_kwargs['max_length'] = max_length
+        inputs = self.tokenizer(queries, **tokenizer_kwargs)
+        inputs.to(self.device)
+        outputs = self.model(**inputs)[0].detach().cpu().numpy()
+        if self.pooling == "mean":
+            # Mask padding tokens so each row averages only its real tokens,
+            # matching the per-query result (single queries have no padding).
+            mask = inputs['attention_mask'].detach().cpu().numpy()
+            summed = (outputs * mask[:, :, None]).sum(axis=1)
+            counts = np.clip(mask.sum(axis=1)[:, None], a_min=1, a_max=None)
+            embeddings = summed / counts
+        else:
+            embeddings = outputs[:, 0, :]
+        if self.l2_norm:
+            embeddings = normalize(embeddings, norm='l2')
+        return embeddings

--- a/tests/base/encoder/test_encoder_batch_encode.py
+++ b/tests/base/encoder/test_encoder_batch_encode.py
@@ -1,0 +1,55 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+import numpy as np
+
+from pyserini.encode import AutoQueryEncoder
+
+MODEL = 'sentence-transformers/msmarco-distilbert-base-v3'
+# Deliberately different lengths so batching pads the shorter queries; the
+# padding mask is what makes mean pooling match the per-query result.
+QUERIES = [
+    'what is information retrieval',
+    'dense retrieval',
+    'how do transformer models encode text for semantic search',
+]
+
+
+class TestBatchQueryEncode(unittest.TestCase):
+    def _assert_batch_matches_single(self, encoder):
+        batch = encoder.encode_batch(QUERIES)
+        self.assertEqual(batch.shape[0], len(QUERIES))
+        for i, query in enumerate(QUERIES):
+            single = encoder.encode(query)
+            self.assertEqual(batch[i].shape, single.shape)
+            self.assertTrue(
+                np.allclose(batch[i], single, atol=1e-5),
+                f'batch row {i} differs from encode({query!r})',
+            )
+
+    def test_cls_pooling(self):
+        encoder = AutoQueryEncoder(MODEL, device='cpu', pooling='cls')
+        self._assert_batch_matches_single(encoder)
+
+    def test_mean_pooling_l2(self):
+        encoder = AutoQueryEncoder(MODEL, device='cpu', pooling='mean', l2_norm=True)
+        self._assert_batch_matches_single(encoder)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #2270.

`AutoQueryEncoder.encode` only took a single query, so `FaissSearcher.batch_search` encoded queries one at a time in a Python loop even though it already checks for an `encode_batch` method. This adds that method to `AutoQueryEncoder`, so a whole query set is encoded in one forward pass.

Mean pooling masks padding tokens so each row matches the per-query result; cls pooling is padding-invariant. Added a test asserting `encode_batch(queries)[i]` equals `encode(queries[i])` for both poolings, with variable-length queries so padding is exercised.

Opening as a draft. One scope question for maintainers: should this also extend to the other query encoders (TCT, DPR, etc.), or is `AutoQueryEncoder` the right first step?