### PR TITLE
Add Foundations of Retrieval reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -523,3 +523,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-03 (commit [`9dcc206`](https://github.com/castorini/pyserini/commit/9dcc2063187b0d9770af2580a964091f1a08252b))
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-09 (commit [`0a0be29`](https://github.com/castorini/pyserini/commit/0a0be2960d33a578a883f10ec962ef1eff0ce1b7))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -779,3 +779,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-03 (commit [`9dcc206`](https://github.com/castorini/pyserini/commit/9dcc2063187b0d9770af2580a964091f1a08252b))
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-09 (commit [`0a0be29`](https://github.com/castorini/pyserini/commit/0a0be2960d33a578a883f10ec962ef1eff0ce1b7))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -271,3 +271,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-03 (commit [`9dcc206`](https://github.com/castorini/pyserini/commit/9dcc2063187b0d9770af2580a964091f1a08252b))
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-11 (commit [`0a0be29`](https://github.com/castorini/pyserini/commit/0a0be2960d33a578a883f10ec962ef1eff0ce1b7))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -559,3 +559,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-03 (commit [`9dcc206`](https://github.com/castorini/pyserini/commit/9dcc2063187b0d9770af2580a964091f1a08252b))
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-09 (commit [`0a0be29`](https://github.com/castorini/pyserini/commit/0a0be2960d33a578a883f10ec962ef1eff0ce1b7))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -568,3 +568,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-03 (commit [`9dcc206`](https://github.com/castorini/pyserini/commit/9dcc2063187b0d9770af2580a964091f1a08252b))
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-09 (commit [`0a0be29`](https://github.com/castorini/pyserini/commit/0a0be2960d33a578a883f10ec962ef1eff0ce1b7))


### PR DESCRIPTION
## Summary

Adds my reproduction-log entries for the Pyserini portion of the Foundations of Retrieval onboarding path (lessons 4-8).

## Setup

- OS: Windows 11 x86_64
- CPU: AMD Ryzen 7 5800H; 15.9 GB RAM; neural inference on CPU
- Storage: repositories, indexes, models, caches, and temporary files on a separate E: drive
- Python: 3.12.13; editable Pyserini 2.3.0
- Java: Oracle JDK 21.0.12
- PyTorch: 2.13.0 CPU; FAISS: 1.15
- Reproduced commit: `0a0be29`

## Results

- `docs/experiments-msmarco-passage.md`: indexed 8,841,823 documents with 0 errors. BM25 produced MRR@10 `0.18741227770955546`, MAP@1000 `0.195686651429`, and Recall@1000 `0.857342406877`.
- `docs/conceptual-framework.md`: manually reconstructed the MS MARCO BM25 vectors and verified the dot product for document `7187158` as `17.949487686`.
- `docs/experiments-nfcorpus.md`: BGE-base encoded all 3,633 NFCorpus documents; full retrieval over 3,237 queries produced nDCG@10 `0.3807599221` (`0.3808`).
- `docs/conceptual-framework2.md`: verified the dense score for `MED-4555` as `0.7913785`, the sparse BM25 score as `11.9305`, and NFCorpus BM25 nDCG@10 as `0.3216739345`.
- `docs/conceptual-framework3.md`: SPLADE-v3 encoded 3,633 documents, indexed all documents with 0 errors, and searched all 3,237 queries. nDCG@10 was `0.3624281377` (`0.3624`). The interactive top-10 matched the guide exactly, including `MED-4555` at `51131.000000`.

## Notes

- SPLADE-v3 used `--batch-size 8` with the documented max length of 512 to stay within 15.9 GB RAM; corpus encoding took about 36 minutes.
- The Windows/Python JNI MS MARCO search loop was pathologically slow, so I cross-checked the completed run with the equivalent Anserini Java retrieval path.
- The bundled `trec_eval` wrapper does not provide a Windows amd64 executable. I cross-checked SPLADE nDCG@10 with `ir_measures`/`pytrec_eval-terrier`, which produced the documented `0.3624`.

`git diff --check` passes; this PR only updates the five reproduction logs.