### PR TITLE
Add to onboarding reproduction logs, plus doc fixes for the tools/ submodule removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 pyserini/resources/jars/*.jar
 collections/*
 indexes/*
+encode/*
 .vscode/
 venv/
 

--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -524,3 +524,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`583bbda`](https://github.com/castorini/pyserini/commit/583bbda9413bf81a57f043c7a2c9b3009dfc34ec))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -780,3 +780,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`583bbda`](https://github.com/castorini/pyserini/commit/583bbda9413bf81a57f043c7a2c9b3009dfc34ec))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -94,6 +94,10 @@ python -m pyserini.encode \
 
 Use `--device cuda` for faster encoding if you have a CUDA-enabled GPU.
 
+This command uses the default batch size of 64, which needs roughly 10 GB of RAM.
+If the process exits with nothing but `Killed`, that was the kernel's out-of-memory killer: add `--batch-size 8` to the `encoder` arguments.
+Encoding then takes about 27 minutes on a 12-core CPU, and the nDCG@10 score below is unchanged.
+
 Next, we will index the encoded corpus using inverted index into a retrieval system.
 
 ```bash

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -272,3 +272,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`583bbda`](https://github.com/castorini/pyserini/commit/583bbda9413bf81a57f043c7a2c9b3009dfc34ec))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -100,7 +100,7 @@ Next, we will index the encoded corpus using inverted index into a retrieval sys
 python -m pyserini.index.lucene \
   --collection JsonVectorCollection \
   --input encode/nfcorpus.splade-v3 \
-  --index index/nfcorpus.splade-v3 \
+  --index indexes/nfcorpus.splade-v3 \
   --generator DefaultLuceneDocumentGenerator \
   --threads 4 \
   --impact \
@@ -112,7 +112,7 @@ Perform retrieval:
 
 ```bash
 python -m pyserini.search.lucene \
-  --index index/nfcorpus.splade-v3 \
+  --index indexes/nfcorpus.splade-v3 \
   --topics collections/nfcorpus/queries.tsv \
   --output runs/run.splade.txt \
   --hits 1000 \
@@ -147,7 +147,7 @@ from pyserini.search.lucene import LuceneImpactSearcher
 from pyserini.encode import SpladeQueryEncoder
 
 encoder = SpladeQueryEncoder(model_name_or_path="naver/splade-v3", device='cuda' if torch.cuda.is_available() else 'cpu')
-searcher = LuceneImpactSearcher('index/nfcorpus.splade-v3', query_encoder=encoder)
+searcher = LuceneImpactSearcher('indexes/nfcorpus.splade-v3', query_encoder=encoder)
 hits = searcher.search('How to Help Prevent Abdominal Aortic Aneurysms')
 
 for i in range(0, 10):

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -548,3 +548,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`583bbda`](https://github.com/castorini/pyserini/commit/583bbda9413bf81a57f043c7a2c9b3009dfc34ec))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -49,10 +49,14 @@ tar xvfz collections/msmarco-passage/collectionandqueries.tar.gz -C collections/
 
 To confirm, `collectionandqueries.tar.gz` should have MD5 checksum of `31644046b18952c1386cd4564ba2ae69`.
 
-Next, we need to convert the MS MARCO tsv collection into Pyserini's jsonl files (which have one json object per line):
+Next, we need to convert the MS MARCO tsv collection into Pyserini's jsonl files (which have one json object per line).
+The conversion script lives in [`castorini/eval`](https://github.com/castorini/eval), so fetch it first:
 
 ```bash
-python tools/scripts/msmarco/convert_collection_to_jsonl.py \
+wget https://raw.githubusercontent.com/castorini/eval/master/scripts/msmarco/convert_collection_to_jsonl.py \
+ -P collections/msmarco-passage/
+
+python collections/msmarco-passage/convert_collection_to_jsonl.py \
  --collection-path collections/msmarco-passage/collection.tsv \
  --output-folder collections/msmarco-passage/collection_jsonl
 ```
@@ -81,27 +85,19 @@ The indexing speed may vary; on a modern desktop with an SSD, indexing takes a c
 
 ## Retrieval
 
-The 6980 queries in the development set are already stored in the repo.
+The 6980 queries in the development set are downloaded and cached automatically the first time they are referenced by name.
 Let's take a peek:
 
-```bash
-$ head tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt
-1048585	what is paula deen's brother
-2	 Androgen receptor define
-524332	treating tension headaches without medication
-1048642	what is paranoid sc
-524447	treatment of varicose veins in legs
-786674	what is prime rate in canada
-1048876	who plays young dr mallard on ncis
-1048917	what is operating system misconfiguration
-786786	what is priority pass
-524699	tricare service number
-
-$ wc tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt
-    6980   48335  290193 tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt
+```python
+>>> from pyserini.search import get_topics
+>>> topics = get_topics('msmarco-passage-dev-subset')
+>>> len(topics)
+6980
+>>> list(topics.items())[:2]
+[(1102330, {'title': 'why do people grind teeth in sleep'}), (160885, {'title': 'do you need immunizations for belize'})]
 ```
 
-Each line contains a tab-delimited (query id, query) pair.
+Each entry pairs a query id with the query text, which sits under the `title` key.
 Conveniently, Pyserini already knows how to load and iterate through these pairs.
 We can now perform retrieval using these queries:
 
@@ -134,7 +130,7 @@ After the run finishes, we can evaluate the results using the official MS MARCO 
 
 ```bash
 $ python -m pyserini.eval.msmarco_passage_eval \
-   tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt \
+   msmarco-passage-dev-subset \
    runs/run.msmarco-passage.bm25tuned.txt
 
 #####################
@@ -159,19 +155,11 @@ python -m pyserini.search.lucene \
 
 The only difference here is that we've removed `--output-format msmarco`.
 
-Then, convert qrels files to the TREC format:
-
-```bash
-python tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \
-  --input collections/msmarco-passage/qrels.dev.small.tsv \
-  --output collections/msmarco-passage/qrels.dev.small.trec
-```
-
 Finally, run the `trec_eval` tool, which has been incorporated into Pyserini:
 
 ```bash
 $ python -m pyserini.eval.trec_eval -c -mrecall.1000 -mmap \
-   collections/msmarco-passage/qrels.dev.small.trec \
+   msmarco-passage-dev-subset \
    runs/run.msmarco-passage.bm25tuned.trec
 
 map                   	all	0.1957
@@ -182,7 +170,7 @@ If you want to examine the MRR@10 for `qid` 1048585:
 
 ```bash
 $ python -m pyserini.eval.trec_eval -q -c -M 10 -m recip_rank \
-    collections/msmarco-passage/qrels.dev.small.trec \
+    msmarco-passage-dev-subset \
     runs/run.msmarco-passage.bm25tuned.trec | grep 1048585
 
 recip_rank            	1048585	1.0000

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -569,3 +569,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-04 (commit [`7b13d9b`](https://github.com/castorini/pyserini/commit/7b13d9ba2dbb07bd6ceee269564f972a394f26ac))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`b81d99c`](https://github.com/castorini/pyserini/commit/b81d99c868e39cdbc9e420425e9b123dfa55bb95))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`583bbda`](https://github.com/castorini/pyserini/commit/583bbda9413bf81a57f043c7a2c9b3009dfc34ec))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -173,19 +173,15 @@ However, if you're planning on contributing to the codebase or want to work with
 
 Start the same way as the install above, but **don't** install `pip install pyserini`.
 
-Instead, clone the Pyserini repo with the `--recurse-submodules` option to make sure the `tools/` submodule also gets cloned:
+Instead, clone the Pyserini repo:
 
 ```bash
-git clone git@github.com:castorini/pyserini.git --recurse-submodules
+git clone git@github.com:castorini/pyserini.git
 ```
 
-The `tools/` directory, which contains evaluation tools and scripts, is actually [this repo](https://github.com/castorini/anserini-tools), integrated as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) (so that it can be shared across related projects).
-Change into the `pyserini` subdirectory and build as follows (you might get warnings, but okay to ignore):
-
-```bash
-cd tools/eval && tar xvfz trec_eval.9.0.4.tar.gz && cd trec_eval.9.0.4 && make && cd ../../..
-cd tools/eval/ndeval && make && cd ../../..
-```
+Topics and qrels live in a [centralized repo containing evaluation data](https://github.com/castorini/eval), shared across Anserini and Pyserini.
+Pyserini fetches what it needs on demand and caches it under `$PYSERINI_CACHE` (`~/.cache/pyserini` by default), so there is nothing to build here.
+The `trec_eval` implementation used by `pyserini.eval.trec_eval` comes from the Anserini fatjar, which is added below.
 
 Then, in the `pyserini` clone, use `pip` to add an ["editable" installation](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), as follows:
 


### PR DESCRIPTION
This covers the Pyserini half of the onboarding path: `experiments-msmarco-passage.md`,
`conceptual-framework.md`, `experiments-nfcorpus.md`, `conceptual-framework2.md` and
`conceptual-framework3.md`. All five reproduced.

It is larger than a typical onboarding PR. The extra size comes from documentation that still
referenced the `tools/` submodule after #2632 removed it: two of the five guides pointed at paths
inside it, so those commands no longer run. If you only want the reproduction log entries, they are
`d59b816` on its own, which touches the usual five files and nothing else.

### Environment

| | |
|---|---|
| OS | Ubuntu 24.04.2 LTS, kernel 6.8.0-45-generic, x86_64 |
| CPU | Intel Core i7-10750H @ 2.60GHz, 6 cores / 12 threads |
| RAM | 15 GiB |
| GPU | none, everything ran on CPU |
| Java | OpenJDK 21.0.7 |
| Python | 3.12.3, venv |
| Pyserini | editable install at `f8af512` |
| Anserini jar | `anserini-2.2.0-fatjar.jar`, md5 `1b0a84bbdfc1674749fa9cf577b30e8b` |
| torch / transformers / faiss-cpu | 2.13.0 / 5.15.0 / 1.15.0 |
| numpy / scipy / onnxruntime / pyjnius | 2.5.2 / 1.18.0 / 1.28.0 / 1.7.0 |

Two deviations from the documented setup:

- A plain venv on system Python 3.12 rather than conda.
- The released 2.2.0 fatjar rather than one built from Anserini master. This one is forced: building
  master currently produces a jar that cannot load any topic. I traced that to a single commit,
  anserini#3381, since a jar built from its parent `6caeb33a` loads topics normally, and filed it as
  #2642.

### Results

| Guide | Result |
|---|---|
| `experiments-msmarco-passage.md` | MRR@10 `0.18741227770955546`, recall@1000 `0.8573`, map `0.1958` where the guide says `0.1957` |
| `conceptual-framework.md` | BM25 vector for docid 7187158 identical term for term; hand-computed inner product `17.949487686157227` against `LuceneSearcher`'s `17.94950` |
| `experiments-nfcorpus.md` | nDCG@10 `0.3808` |
| `conceptual-framework2.md` | nDCG@10 `0.3218`; re-encoding a document reproduced its stored vector to `3.59e-07`; by-hand dot product `11.930485963821411` matching `LuceneSearcher` |
| `conceptual-framework3.md` | nDCG@10 `0.3624`, interactive top 10 exact |

The MS MARCO passage index was built from scratch: 8,841,823 documents, 352,316,036 terms.
Everything matched except `map`, which is covered under findings.

### What changed

| Commit | Change |
|---|---|
| `488f773` | `installation.md`, the clone flag and the `tools/eval` build steps |
| `447de19` | `experiments-msmarco-passage.md`, six stale `tools/` paths |
| `d59b816` | reproduction log entries, all five guides |
| `332d790` | `conceptual-framework3.md`, `index/` to `indexes/`, plus `.gitignore` |
| `db66c19` | `conceptual-framework3.md`, encoder batch-size note |

Each commit message explains its own reasoning, so the log is probably more useful than a summary
here. Each deletion removes a command that no longer runs, rather than one that works.

**The `.gitignore` line in `332d790` is the only non-documentation change in this PR.**

One point worth stating outside the log, since it covers the largest deletion:
`java -cp <fatjar> trec_eval --version` reports **9.0.4**, the same version the removed step
compiled from `trec_eval.9.0.4.tar.gz`. The jar carries prebuilt binaries for linux-amd64,
linux-i386, macosx-aarch64, macosx-x86_64 and win-x86. `castorini/eval` does still host that
tarball, so repointing the step there was an option; I removed it because the jar the install
already requires provides the same binary. I could not find any reference to `ndeval` in the
Pyserini codebase.

### Verification

I re-ran the fixed guides end to end in a clean Ubuntu 24.04 container, with the `topics/`, `qrels/`
and `eval/` cache directories emptied, no `tools/` directory, and no `trec_eval` binary installed
anywhere in the image.


### Findings

**Fixed here:** the stale `tools/` paths, the `.gitignore` entry, and the batch-size note.

**Noticed but not fixed:**

- `map` is given as `0.1957`; I measured `0.1958` twice, and
  `integrations/core/sparse/test_prebuilt_msmarco_v1_passage.py` asserts `0.1958` for this exact
  configuration. The guide and the test suite disagree.
- `experiments-nfcorpus.md` says 32 is the default batch size; `pyserini/encode/__main__.py`
  declares `--batch-size` with `default=64`.
- 13 further docs still reference `tools/`, plus `scripts/rest_concurrency_benchmark.py` and
  `scripts/trec-covid-ranker.py`, which carry dead paths as argument defaults.

### Follow-up

Happy to send a separate PR for the remaining 13 docs and 2 scripts, if useful. I left them out
because they cover experiments I did not run, so I cannot verify a fix the way I could for the two
guides on the onboarding path.
