### PR TITLE
fix: swap argument order for getTopicsWithStringIdsFromFileWithTopicReaderClass

### DIFF
--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -171,7 +171,7 @@ def get_topics(collection_name):
     target_path = _download_and_cache(f'{TOPICS_BASE_URL}{topics_file}', topics_file, _get_topics_cache_path())
 
     # Yes, this is an insanely ridiculous method name.
-    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(topic['reader_class'], str(target_path))
+    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(str(target_path), topic['reader_class'])
     if topics is None:
         raise ValueError(f'Unable to load topic {collection_name} from {target_path}!')
 
@@ -180,7 +180,7 @@ def get_topics(collection_name):
 
 def load_topics_from_file(file_path, reader_class):
     # Yes, this is an insanely ridiculous method name.
-    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(reader_class, file_path)
+    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(file_path, reader_class)
     if topics is None:
         raise ValueError(f'Unable to initialize TopicReader {reader_class} with file {file_path}!')
 


### PR DESCRIPTION
Closes #2642

## Root cause
anserini#3381 (commit `fe3a07e4`) reordered `TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass`'s Java signature from `(className, file)` to `(file, className)`. Since both parameters are `String`, nothing at the compiled-bytecode/PyJNIus level can catch the mismatch — it fails silently at runtime instead of erroring at load time.

Pyserini's two call sites in `pyserini/search/_base.py` (`get_topics` and `load_topics_from_file`) still pass the old argument order, so topic loading breaks against any Anserini fatjar built from current master.

## Fix
Swap the argument order at both call sites to match the new upstream signature.

## Scope
This only affects the **development install path** (building Anserini from source per `docs/installation.md`) — the released fatjar predates the upstream change and is unaffected.

## Validation
Verified by reading the current source at both call sites and cross-referencing against the exact diff described in #2642 (which already did the hard diagnostic work — bisected to the single Anserini commit and confirmed via `javap` that the compiled signature can't distinguish the two argument orders). I don't have a built-from-source Anserini fatjar handy to run this end-to-end, so this is a code-reading verification, not a runtime test — flagging that explicitly.