### PR TITLE
Added Reproduction Log Entry to Pyserini

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -530,3 +530,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-17 (commit [`c16016f`](https://github.com/castorini/pyserini/commit/c16016f315feb83b0c4279cc69c8586dab33f424))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
++ Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -786,3 +786,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-17 (commit [`c16016f`](https://github.com/castorini/pyserini/commit/c16016f315feb83b0c4279cc69c8586dab33f424))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
++ Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -282,3 +282,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-17 (commit [`c16016f`](https://github.com/castorini/pyserini/commit/c16016f315feb83b0c4279cc69c8586dab33f424))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
++ Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -554,3 +554,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`c16016f`](https://github.com/castorini/pyserini/commit/c16016f315feb83b0c4279cc69c8586dab33f424))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
++ Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -575,3 +575,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-17 (commit [`c16016f`](https://github.com/castorini/pyserini/commit/c16016f315feb83b0c4279cc69c8586dab33f424))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
++ Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))


### PR DESCRIPTION
Completed Pyserini onboarding reproduction exercises. 

Environments used:
- macOS 25.6.1
- Java 21 (Homebrew)
- Python 3.14

Results
- Pyserini BM25 on MS-MARCO:  MRR@10 = 0.1874, MAP = 0.1957, R@1000 = 0.8573, matches the guide.
- Bi-encoder framework for retrieval: Sparse dot product = 17.9494787686157227, LuceneSearcher = 17.9495, matches the guide. Used `--threads 4` instead of `--threads 8`.
- NFCorpus Baseline: BGE-base nDCG@10 = 0.308, Contriever-MSMARCO nDCG@10 = 0.3306, matches the guide.
- Manual Dense + Sparse Representations on NFCorpus: Dense manual MED-4555 at 0.791379 matching `FaissSearcher`, Sparse manual BM25 weight = 11.9305, matching `LuceneSearcher` correctly, which matches the guide.
- NFCorpus SPLADE-v3: HuggingFace Splade login is successful, nDCG @ 10 matches guide.

Everything worked smoothly for the onboarding. 

One issue that I had to optimize for my environment while encoding the corpus into sparse vector representations
- Added `--batch-size 8` to process fewer documents at a time; my environment ran out of memory multiple times during the process.

Updated all five reproduction logs.