### PR TITLE
fix: resolve M-BEIR instructions from cache home

### DIFF
--- a/pyserini/encode/optional/_uniir.py
+++ b/pyserini/encode/optional/_uniir.py
@@ -131,30 +131,9 @@ class UniIRQueryEncoder:
     def _get_instruction_config(self, instr_file: str = None):
         """This functions downloads all the instruction config files if not already present."""
 
-        import os
-        import tarfile
-        from pyserini.util import download_url, get_cache_home
+        from pyserini.util import get_mbeir_instruction_config
 
-        cache_dir = get_cache_home()
-        instructions_dir = os.path.join(cache_dir, 'query_instructions')
-
-        if not os.path.exists(instructions_dir):
-            query_images_and_instructions_url = "https://huggingface.co/datasets/castorini/prebuilt-indexes-m-beir/resolve/main/mbeir_query_images_and_instructions.tar.gz"
-            tar_path = os.path.join(
-                cache_dir, 'mbeir_query_images_and_instructions.tar.gz'
-            )
-
-            try:
-                download_url(query_images_and_instructions_url, cache_dir, force=False)
-                with tarfile.open(tar_path, 'r:gz') as tar:
-                    tar.extractall(cache_dir, filter='data')
-            except Exception as e:
-                raise Exception(f"Could not download query images: {e}")
-
-        if instr_file:
-            return os.path.join(instructions_dir, instr_file)
-        else:
-            return None
+        return get_mbeir_instruction_config(instr_file)
 
     def encode_batch(
         self,

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -36,7 +36,7 @@ from pyserini.server.config import load_server_config
 from pyserini.server.utils import INDEX_TYPE, SHARDS, Bm25Config, Bm25SearcherCacheEntry, IndexConfig, create_searcher, lookup_index_type
 from pyserini.server.document_format import format_lucene_document, truncate_document_payload
 from pyserini.server.errors import BadSearchRequestError, DocumentNotFoundError, IndexNotAvailableError
-from pyserini.util import check_downloaded, download_prebuilt_index, download_url, get_cache_home
+from pyserini.util import check_downloaded, download_prebuilt_index, get_cache_home, get_mbeir_instruction_config
 
 logger = logging.getLogger(__name__)
 
@@ -466,21 +466,7 @@ class SharedSearchBackend:
 
     def _resolve_mbeir_instruction_config(self, index_name: str) -> str | None:
         instr_file = next((v for k, v in _MBEIR_NAME_TO_INSTR_FILE.items() if k in index_name), None)
-        if not instr_file:
-            return None
-
-        cache_dir = get_cache_home()
-        instr_dir = os.path.join(cache_dir, 'query_instructions')
-        if not os.path.exists(instr_dir):
-            query_images_and_instructions_url = (
-                'https://huggingface.co/datasets/castorini/prebuilt-indexes-m-beir/resolve/main/mbeir_query_images_and_instructions.tar.gz'
-            )
-            download_url(query_images_and_instructions_url, cache_dir, force=False)
-            import tarfile
-
-            with tarfile.open(os.path.join(cache_dir, 'mbeir_query_images_and_instructions.tar.gz'), 'r:gz') as tar:
-                tar.extractall(cache_dir, filter='data')
-        return str(os.path.join(instr_dir, instr_file))
+        return get_mbeir_instruction_config(instr_file)
 
     def _prepare_query(self, query: str | dict[str, Any], index_name: str) -> str | dict[str, Any]:
         if isinstance(query, str):

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -300,6 +300,65 @@ def get_cache_home():
     return os.path.expanduser(os.path.join(f'~{os.path.sep}.cache', 'pyserini'))
 
 
+def _rewrite_mbeir_instruction_config(instruction_config_path, instructions_dir):
+    import yaml
+
+    with open(instruction_config_path, 'r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+
+    if not isinstance(config, dict):
+        return
+
+    instruction_file = config.get('instruction_file')
+    if not isinstance(instruction_file, str) or not instruction_file:
+        return
+
+    if os.path.basename(os.path.normpath(instruction_file)) != 'query_instructions.tsv':
+        return
+
+    resolved_instruction_file = os.path.abspath(
+        os.path.join(instructions_dir, 'query_instructions.tsv')
+    )
+    if os.path.normpath(os.path.expanduser(instruction_file)) == os.path.normpath(resolved_instruction_file):
+        return
+
+    config['instruction_file'] = resolved_instruction_file
+    with open(instruction_config_path, 'w', encoding='utf-8') as f:
+        yaml.safe_dump(config, f, default_flow_style=False, sort_keys=False)
+
+
+def get_mbeir_instruction_config(instr_file=None):
+    """Return an M-BEIR instruction config path resolved against the Pyserini cache."""
+    if instr_file is None:
+        return None
+
+    cache_dir = get_cache_home()
+    instructions_dir = os.path.join(cache_dir, 'query_instructions')
+
+    if not os.path.exists(instructions_dir):
+        os.makedirs(cache_dir, exist_ok=True)
+        query_images_and_instructions_url = (
+            "https://huggingface.co/datasets/castorini/prebuilt-indexes-m-beir/resolve/main/"
+            "mbeir_query_images_and_instructions.tar.gz"
+        )
+        tar_path = os.path.join(
+            cache_dir, 'mbeir_query_images_and_instructions.tar.gz'
+        )
+
+        try:
+            download_url(query_images_and_instructions_url, cache_dir, force=False)
+            with tarfile.open(tar_path, 'r:gz') as tar:
+                tar.extractall(cache_dir, filter='data')
+        except Exception as e:
+            raise Exception(f"Could not download default M-BEIR instructions: {e}")
+
+    instruction_config_path = os.path.join(instructions_dir, instr_file)
+    if os.path.exists(instruction_config_path):
+        _rewrite_mbeir_instruction_config(instruction_config_path, instructions_dir)
+
+    return instruction_config_path
+
+
 def download_and_unpack_archive(url, output_dir='indexes', local_filename=False, md5=None,
                                 force=False, verbose=True, append_md5_to_dir_name=False, expected_size=None):
     archive_name = _download_archive_name(url, local_filename)

--- a/tests/base/test_query_iterator.py
+++ b/tests/base/test_query_iterator.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import tempfile
+from unittest.mock import patch
 from pyserini.query_iterator import MBEIRQueryIterator, DefaultQueryIterator, KiltQueryIterator, MultimodalQueryIterator
 
 class TestQueryIterators(unittest.TestCase):
@@ -105,6 +106,34 @@ class TestQueryIterators(unittest.TestCase):
             result = iterator.get_query("missing_text_field")
             self.assertEqual(result['query_txt'], '')
             self.assertEqual(result['query_modality'], 'image')
+
+    def test_mbeir_predefined_topics_use_configured_cache_home(self):
+        topics = {
+            "text_only": {
+                "qid": "text_only",
+                "query_txt": "This is a text-only query",
+                "query_img_path": None,
+                "query_modality": "text",
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as cache_dir:
+            os.makedirs(os.path.join(cache_dir, "mbeir_images"))
+
+            with (
+                patch.dict(os.environ, {"PYSERINI_CACHE": cache_dir}),
+                patch("pyserini.query_iterator.get_topics", return_value=topics),
+                patch(
+                    "pyserini.query_iterator.download_url",
+                    side_effect=AssertionError("download_url should not be called"),
+                ),
+            ):
+                iterator = MBEIRQueryIterator.from_topics("m-beir-cirr_task7-test")
+                result = iterator.get_query("text_only")
+
+        self.assertEqual(iterator.topic_dir, cache_dir)
+        self.assertEqual(result["instr_file"], "cirr_task7_instr.yaml")
+        self.assertEqual(result["query_modality"], "text")
 
     def test_default_query_iterator(self):
         topics = {

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -21,6 +21,8 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import yaml
+
 from pyserini.prebuilt_index_info import TF_INDEX_INFO
 from pyserini.util import (
     compare_trec_files_with_tolerance,
@@ -28,6 +30,7 @@ from pyserini.util import (
     download_and_unpack_archive,
     download_url,
     get_cache_home,
+    get_mbeir_instruction_config,
     temporary_env,
 )
 
@@ -132,7 +135,77 @@ class TestCacheHome(unittest.TestCase):
     def test_cache_home_uses_default_when_no_override_or_local_cache_exists(self):
         with tempfile.TemporaryDirectory(prefix="cache-home-") as directory:
             with patch.dict(os.environ, {}, clear=True), patch('os.getcwd', return_value=directory):
-                self.assertEqual(get_cache_home(), os.path.expanduser('~/.cache/pyserini'))
+                self.assertEqual(
+                    get_cache_home(),
+                    os.path.expanduser(os.path.join('~', '.cache', 'pyserini'))
+                )
+
+
+class TestMbeirInstructionConfig(unittest.TestCase):
+    def test_mbeir_instruction_config_rewrites_instruction_file_to_cache_home(self):
+        with tempfile.TemporaryDirectory(prefix='mbeir-source-') as source_dir, \
+                tempfile.TemporaryDirectory(prefix='mbeir-cache-parent-') as cache_parent_dir:
+            cache_dir = os.path.join(cache_parent_dir, 'pyserini-cache')
+            source_instr_dir = os.path.join(source_dir, 'query_instructions')
+            os.makedirs(source_instr_dir)
+            config_path = os.path.join(source_instr_dir, 'cirr_task7_instr.yaml')
+            with open(config_path, 'w', encoding='utf-8') as f:
+                yaml.safe_dump({
+                    'instruction_file': '~/.cache/pyserini/query_instructions/query_instructions.tsv',
+                    'candidate_modality': 'image',
+                    'dataset_id': 0,
+                }, f)
+            with open(os.path.join(source_instr_dir, 'query_instructions.tsv'), 'w', encoding='utf-8') as f:
+                f.write('dataset_id\tquery_modality\tcand_modality\tprompt_1\n')
+
+            source_tar = os.path.join(source_dir, 'mbeir_query_images_and_instructions.tar.gz')
+            with tarfile.open(source_tar, 'w:gz') as tar:
+                tar.add(source_instr_dir, arcname='query_instructions')
+
+            def fake_download_url(url, save_dir, force=False):
+                self.assertIn('mbeir_query_images_and_instructions.tar.gz', url)
+                destination_path = os.path.join(save_dir, 'mbeir_query_images_and_instructions.tar.gz')
+                shutil.copyfile(source_tar, destination_path)
+                return destination_path
+
+            with patch.dict(os.environ, {'PYSERINI_CACHE': cache_dir}), \
+                    patch('pyserini.util.download_url', side_effect=fake_download_url):
+                instruction_config = get_mbeir_instruction_config('cirr_task7_instr.yaml')
+
+            expected_config = os.path.join(cache_dir, 'query_instructions', 'cirr_task7_instr.yaml')
+            expected_instruction_file = os.path.abspath(
+                os.path.join(cache_dir, 'query_instructions', 'query_instructions.tsv')
+            )
+            self.assertEqual(instruction_config, expected_config)
+            with open(expected_config, 'r', encoding='utf-8') as f:
+                config = yaml.safe_load(f)
+            self.assertEqual(config['instruction_file'], expected_instruction_file)
+            self.assertEqual(config['candidate_modality'], 'image')
+            self.assertEqual(config['dataset_id'], 0)
+
+    def test_mbeir_instruction_config_preserves_custom_instruction_file(self):
+        with tempfile.TemporaryDirectory(prefix='mbeir-cache-') as cache_dir:
+            instr_dir = os.path.join(cache_dir, 'query_instructions')
+            os.makedirs(instr_dir)
+            config_path = os.path.join(instr_dir, 'cirr_task7_instr.yaml')
+            with open(config_path, 'w', encoding='utf-8') as f:
+                yaml.safe_dump({
+                    'instruction_file': 'custom_instructions.tsv',
+                    'candidate_modality': 'image',
+                    'dataset_id': 0,
+                }, f)
+
+            with patch.dict(os.environ, {'PYSERINI_CACHE': cache_dir}), \
+                    patch(
+                        'pyserini.util.download_url',
+                        side_effect=AssertionError('download_url should not be called'),
+                    ):
+                instruction_config = get_mbeir_instruction_config('cirr_task7_instr.yaml')
+
+            self.assertEqual(instruction_config, config_path)
+            with open(config_path, 'r', encoding='utf-8') as f:
+                config = yaml.safe_load(f)
+            self.assertEqual(config['instruction_file'], 'custom_instructions.tsv')
 
 
 class TestTemporaryEnv(unittest.TestCase):


### PR DESCRIPTION
## Why

M-BEIR/UniIR instruction configs are resolved through the Pyserini cache, but downloaded configs may still point `instruction_file` at the default `~/.cache/pyserini` location. That breaks custom `PYSERINI_CACHE` setups.

Fixes #2475.

## What changed

- Added a shared helper that downloads/extracts M-BEIR instruction configs from `get_cache_home()` and rewrites `query_instructions.tsv` references to the active cache path.
- Reused the helper from both the UniIR query encoder and the server backend so CLI and MCP behavior stay aligned.
- Added regression coverage for custom cache resolution, predefined M-BEIR topics, and the default cache-home test expectation on Windows.

## Validation

- `python -m unittest tests.base.test_utils.TestCacheHome tests.base.test_utils.TestMbeirInstructionConfig tests.base.test_query_iterator -v`
- `python -m py_compile pyserini\util.py pyserini\encode\optional\_uniir.py pyserini\server\backend.py tests\base\test_utils.py tests\base\test_query_iterator.py`
- `git diff --check`

## Risk / follow-up

Low. The rewrite only applies to M-BEIR configs whose `instruction_file` basename is `query_instructions.tsv`; custom instruction files are preserved by regression coverage.