### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -532,3 +532,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -788,3 +788,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -284,3 +284,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -556,3 +556,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -577,3 +577,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))


### PR DESCRIPTION
Reproduced `experiments-msmarco-passage.md`, `conceptual-framework.md`, `experiments-nfcorpus.md`, `conceptual-framework2.md` and `conceptual-framework3.md` at commit `9a5330a`, on a UWaterloo student teaching host.

Ubuntu 24.04 (64 vCPU / 982 GB RAM)
Python 3.12.3
Java openJDK 21.0.12
Maven 3.8.7
Pyserini 2.4.0, development install (`pip install -e .` in a venv, no conda), with an `anserini-2.3.1-SNAPSHOT` fatjar built from anserini master

Everything matched the documented values: MS MARCO passage MRR@10 0.18741227770955546 and recall@1000 0.8573; the BM25 dot product 17.949487686157227 for docid 7187158; NFCorpus nDCG@10 0.3808 for BGE-base, 0.3218 for BM25 and 0.3624 for SPLADE-v3. Re-encoding MED-4555 reproduced the vector stored in Faiss with an L2 difference of exactly 0.0, and brute-force scoring over all document vectors returned the same top 10 as both `FaissSearcher` and `LuceneSearcher`.

Two things worth mentioning.

**1. MAP came out to 0.1958 rather than the documented 0.1957.** The guide generates the TREC run directly, without `--output-format msmarco`, and that run scores 0.1958. Converting the msmarco-format run from earlier in the guide with `convert_msmarco_to_trec_run.py` gives 0.1957 from the same retrieval. Both runs have identical recall@1000 and MRR@10, consistent with a tie-breaking difference: the conversion is lossy, and MAP reads all 1,000 ranks while MRR@10 reads only the top 10. So the documented value appears to correspond to the converted run rather than the one the guide asks you to produce. Updating it to 0.1958, or noting the dependence on run format, would avoid confusion.

**2. Neural encoding is killed by the default CPU time limit on the UWaterloo teaching hosts.** `pyserini.encode` died at 61% with `CPU time limit exceeded (core dumped)` after ~75 seconds of wall-clock. The soft limit is 3600 CPU-seconds, and PyTorch spreads inference across many cores, so the budget goes far faster than wall-clock suggests. The hard limit is unlimited, so `ulimit -t unlimited` fixes it. Since the onboarding guide points students at these hosts when they can't run locally, a note might save some time.
