### PR TITLE
Fix argument order bug in TopicReader calls

### DIFF
--- a/pyserini/search/_base.py
+++ b/pyserini/search/_base.py
@@ -176,7 +176,7 @@ def get_topics(collection_name):
     target_path = _download_and_cache(f'{TOPICS_BASE_URL}{topics_file}', topics_file, _get_topics_cache_path())
 
     # Yes, this is an insanely ridiculous method name.
-    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(str(target_path), topic['reader_class'])
+    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(topic['reader_class'], str(target_path))
     if topics is None:
         raise ValueError(f'Unable to load topic {collection_name} from {target_path}!')
 
@@ -185,7 +185,7 @@ def get_topics(collection_name):
 
 def load_topics_from_file(file_path, reader_class):
     # Yes, this is an insanely ridiculous method name.
-    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(file_path, reader_class)
+    topics = JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(reader_class, file_path)
     if topics is None:
         raise ValueError(f'Unable to initialize TopicReader {reader_class} with file {file_path}!')
 


### PR DESCRIPTION
## Summary

`get_topics()` and `load_topics_from_file()` in `pyserini/search/_base.py` call `JTopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass` with `(file, className)` instead of `(className, file)`. That's backwards: the Java method has always taken `(className, file)`, and Anserini's own `EncodeQuery.java` calls it that way too. #2644 introduced the swap.

With the wrong order, `Class.forName(className)` gets a filesystem path instead of a class name, throws `ClassNotFoundException`, and the Java wrapper silently returns `null` instead of raising. On the Python side that just looks like `Unable to load topic ...` with no clue what's actually wrong — it looked like a corrupted/missing topics cache file until we checked the Java side.

Confirmed by calling the JVM method directly via pyjnius with both orders on the same file: `(file, className)` returns `None`, `(className, file)` returns the topics. Swapping the args back fixes topic loading.

## Test plan

- `python -m unittest tests.base.encoder.test_encoder_model_dpr tests.base.encoder.test_encoder_model_bpr -v` — passes all 7 tests after this fix (previously failing with the "Unable to load topic" error).

Found this while working through Anserini's onboarding docs, see castorini/anserini#3402.