### PR TITLE
Add reproduction log entries for conceptual framework and NFCorpus exercises

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -533,5 +533,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -789,5 +789,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -285,5 +285,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -553,6 +553,7 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Rex-fortune](https://github.com/Rex-fortune) on 2026-08-12 (commit [`583bbda`](https://github.com/castorini/pyserini/commit/583bbda9413bf81a57f043c7a2c9b3009dfc34ec))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`c16016f`](https://github.com/castorini/pyserini/commit/c16016f315feb83b0c4279cc69c8586dab33f424))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-16 (commit [`f8af512`](https://github.com/castorini/pyserini/commit/f8af512b484848924d462a67dd0d1cdcd419eb64))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`e863f8e`](https://github.com/castorini/pyserini/commit/e863f8e301990cab979f327f5b292ddfcc94a1f7))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -578,5 +578,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))


### PR DESCRIPTION
## Summary

Reproduction log entries for the conceptual framework series (`docs/conceptual-framework.md`, `conceptual-framework2.md`, `conceptual-framework3.md`), the NFCorpus BGE-base baseline (`docs/experiments-nfcorpus.md`), and the MS MARCO passage BM25 baseline (`docs/experiments-msmarco-passage.md`).

**`conceptual-framework.md`** — this one uses the MS MARCO passage example, not NFCorpus. Reconstructed the BM25 vector for `docid` 7187158 by hand, took the dot product against the multi-hot query vector for "what is paula deen's brother": `17.949487686157227`. `LuceneSearcher` returns `17.94950` for the same query/doc — matches (modulo rounding).

**`experiments-nfcorpus.md`** — BGE-base dense baseline only, no BM25 here. Indexed all 3,633 NFCorpus docs, ndcg@10 came out to 0.3808, matching the guide. Interactive `FaissSearcher` top-10 for "How to Help Prevent Abdominal Aortic Aneurysms" matches the batch run exactly (`MED-4555` at 0.791378, down through `MED-2939` at 0.674646).

**`conceptual-framework2.md`** — the "verify it by hand" lesson, both halves:
- Dense: pulled `MED-4555`'s vector straight out of the Faiss index and compared it to freshly encoding the same document text with `AutoDocumentEncoder` — they match to ~3e-7. Dot product against the query vector gives `0.79137844`, same as `FaissSearcher`. Ran the full manual top-10 (iterate every doc vector, dot product, sort) and it matches `FaissSearcher`'s ranking exactly.
- Sparse: rebuilt NFCorpus as a Lucene BM25 index (`indexes/lucene.nfcorpus`), ndcg@10 0.3217 against the guide's expected 0.3218 — negligible float noise. `LuceneSearcher`'s top-10 matches the guide's listed values exactly (`MED-4555` at 11.9305 down through `MED-1512` at 5.2068). Reconstructed the BM25 document vector for `MED-4555`, built the multi-hot query vector, and got `11.9305` by hand — matches. Ran the full manual retrieval loop and it reproduces `LuceneSearcher`'s ranking exactly.

**`conceptual-framework3.md`** — SPLADE-v3 (learned sparse). `naver/splade-v3` is gated, needed `hf auth login` first. Encoded the corpus, indexed with `--impact --pretokenized`, ndcg@10 came out to 0.3624, matching the guide exactly. Interactive `LuceneImpactSearcher` top-10 also matches exactly (`MED-4555` at 51131.0 down through `MED-1194` at 27588.0).

**`experiments-msmarco-passage.md`** — BM25 baseline on the full MS MARCO passage collection (8,841,823 docs, indexed with `pyserini.index.lucene` in under 2 minutes with 9 threads). Ran the tuned-BM25 search (`k1=0.82, b=0.68`) and scored it with `msmarco_passage_eval.py`: MRR@10 came out to `0.18746668485923484` over 6,980 queries, matching the guide's expected value.
