### PR TITLE
Add onboarding reproduction log entries

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -533,6 +533,7 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
 + Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -792,3 +792,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-31 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -288,3 +288,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-09-01 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -558,5 +558,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`71072b4`](https://github.com/castorini/pyserini/commit/71072b4c94a1a6ba3d627f8b602b28fa2d9b9400))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d476ebc`](https://github.com/castorini/pyserini/commit/d476ebc4fe1af2f3dee149bc2caec700a69e811f))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -581,3 +581,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-31 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))


### PR DESCRIPTION
I completed the five Pyserini exercises in the Foundations of Retrieval onboarding path and added a Reproduction Log entry to each page. The experiments were run at commit `9a5330a2dcbabda99ccf70c6237a7caa92d5cef4`.

Environment:
- Windows 11, WSL2 Ubuntu 24.04
- Python 3.12.14 in a conda environment
- OpenJDK 21.0.12
- Editable Pyserini 2.4.0 installation with an Anserini 2.3.1-SNAPSHOT fatjar
- NVIDIA RTX 3070 Laptop GPU, PyTorch 2.13.0+cu130, CUDA 13.0

The main results matched the expected values:
- MS MARCO Passage BM25: MRR@10 0.1874, MAP 0.1957, Recall@1000 0.8573
- NFCorpus BGE-base-en-v1.5: nDCG@10 0.3808
- NFCorpus SPLADE-v3: nDCG@10 0.3624

The manual BM25, dense, and sparse retrieval checks also matched the corresponding Lucene and Faiss results.

I ran into a few setup issues. `--device gpu` fell back to CPU, so I changed it to `--device cuda`. GitHub metadata requests sometimes timed out from WSL and worked after enabling LAN access in the Windows proxy and refreshing the WSL proxy settings. The evaluation script also failed until I moved the Anserini fatjar directly into `resources/jars/`. For the SPLADE exercise, I tried a batch size of 8 and used 16 for the final run.

This PR contains only the five Reproduction Log entries; generated indexes, run files, caches, and local setup changes are not included.