### PR TITLE
[codex] Consolidate subprocess command execution

### DIFF
--- a/integrations/core/papers/test_ecir2023.py
+++ b/integrations/core/papers/test_ecir2023.py
@@ -17,7 +17,6 @@
 """Integration tests for commands in Pradeep et al. resource paper at ECIR 2023."""
 
 import multiprocessing
-import os
 import unittest
 
 from integrations.utils import clean_files, run_command, parse_score_qa
@@ -54,8 +53,8 @@ class TestECIR2023(unittest.TestCase):
                       --output {output_file} --query-prefix question: \
                       --threads {self.threads} --batch-size {self.batch_size} \
                       --hits 100'
-        status = os.system(run_cmd)
-        self.assertEqual(status, 0)
+        result = run_command(run_cmd)
+        self.assertEqual(result.returncode, 0)
 
         # conversion
         convert_cmd = f'python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run \
@@ -63,8 +62,8 @@ class TestECIR2023(unittest.TestCase):
                         --index wikipedia-dpr \
                         --input {output_file} \
                         --output {json_file}'
-        status = os.system(convert_cmd)
-        self.assertEqual(status, 0)
+        result = run_command(convert_cmd)
+        self.assertEqual(result.returncode, 0)
 
         # evaluation
         eval_cmd = f'python -m pyserini.eval.evaluate_dpr_retrieval \
@@ -100,4 +99,3 @@ class TestECIR2023(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/integrations/core/papers/test_sigir2021.py
+++ b/integrations/core/papers/test_sigir2021.py
@@ -16,7 +16,6 @@
 
 """Integration tests for commands in Lin et al. (SIGIR 2021) paper, but with class names updated."""
 
-import os
 import unittest
 
 from integrations.utils import clean_files, run_command, parse_score_msmarco
@@ -161,8 +160,8 @@ class TestSIGIR2021(unittest.TestCase):
         run_cmd = f'python -m pyserini.search.lucene --topics msmarco-passage-dev-subset \
                       --index msmarco-passage --output {output_file} \
                       --bm25 --output-format msmarco'
-        status = os.system(run_cmd)
-        self.assertEqual(status, 0)
+        result = run_command(run_cmd)
+        self.assertEqual(result.returncode, 0)
 
         eval_cmd = f'python -m pyserini.eval.msmarco_passage_eval \
                        msmarco-passage-dev-subset {output_file}'

--- a/integrations/core/papers/test_sigir2022.py
+++ b/integrations/core/papers/test_sigir2022.py
@@ -17,7 +17,6 @@
 """Integration tests for commands in Ma et al. resource paper and Trotman et al. demo paper at SIGIR 2022."""
 
 import multiprocessing
-import os
 import unittest
 
 from integrations.utils import clean_files, run_command, parse_score, parse_score_msmarco
@@ -47,8 +46,8 @@ class TestSIGIR2022(unittest.TestCase):
                       --output {output_file} \
                       --output-format msmarco \
                       --bm25'
-        status = os.system(run_cmd)
-        self.assertEqual(status, 0)
+        result = run_command(run_cmd)
+        self.assertEqual(result.returncode, 0)
 
         eval_cmd = f'python -m pyserini.eval.msmarco_passage_eval \
                        msmarco-passage-dev-subset {output_file}'
@@ -71,8 +70,8 @@ class TestSIGIR2022(unittest.TestCase):
                       --batch {self.batch_size} --threads {self.threads} \
                       --hits 1000 \
                       --impact'
-        status = os.system(run_cmd)
-        self.assertEqual(status, 0)
+        result = run_command(run_cmd)
+        self.assertEqual(result.returncode, 0)
 
         eval_cmd = f'python -m pyserini.eval.trec_eval -c -M 100 -m map -m recip_rank msmarco-v2-passage-dev {output_file}'
         result = run_command(eval_cmd)
@@ -93,8 +92,8 @@ class TestSIGIR2022(unittest.TestCase):
                       --batch {self.batch_size} --threads {self.threads} \
                       --hits 1000 \
                       --impact'
-        status = os.system(run_cmd)
-        self.assertEqual(status, 0)
+        result = run_command(run_cmd)
+        self.assertEqual(result.returncode, 0)
 
         eval_cmd = f'python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset {output_file}'
         result = run_command(eval_cmd)

--- a/integrations/core/sparse/test_prebuilt_unicoil.py
+++ b/integrations/core/sparse/test_prebuilt_unicoil.py
@@ -16,7 +16,6 @@
 
 """Integration tests for uniCOIL models using on-the-fly query encoding."""
 
-import os
 import unittest
 
 from integrations.utils import clean_files, parse_score, run_command
@@ -39,8 +38,8 @@ class TestSearchIntegration(unittest.TestCase):
                    --output {output_file} \
                    --output-format msmarco \
                    --impact --hits 1000'
-        status = os.system(cmd)
-        self.assertEqual(status, 0)
+        result = run_command(cmd)
+        self.assertEqual(result.returncode, 0)
 
         # Match score in https://github.com/castorini/pyserini/blob/master/docs/experiments-unicoil-tilde-expansion.md
         result = run_command(f'python -m pyserini.eval.msmarco_passage_eval msmarco-passage-dev-subset {output_file}')

--- a/integrations/utils.py
+++ b/integrations/utils.py
@@ -15,10 +15,9 @@
 #
 
 import os
-import shlex
 import shutil
-import subprocess
-from collections.abc import Sequence
+
+from pyserini.util import run_command
 
 
 def clean_files(files):
@@ -28,16 +27,6 @@ def clean_files(files):
                 shutil.rmtree(file)
             else:
                 os.remove(file)
-
-
-def run_command(cmd: str | Sequence[str], echo: bool = False) -> subprocess.CompletedProcess[str]:
-    args = shlex.split(cmd) if isinstance(cmd, str) else list(cmd)
-    result = subprocess.run(args, capture_output=True, text=True, check=False)
-    if result.stderr and echo:
-        print(result.stderr)
-    if echo:
-        print(result.stdout)
-    return result
 
 
 def parse_score(output, metric, digits=4):
@@ -84,7 +73,7 @@ def run_retrieval_and_return_scores(output_file, retrieval_cmd, qrels, eval_type
     temp_files = [output_file]
 
     # Take the base retrieval command and append the output file name to it.
-    os.system(retrieval_cmd + f' --output {output_file}')
+    run_command(retrieval_cmd + f' --output {output_file}')
 
     scores = {}
     # How we compute eval metrics depends on the `eval_type`.

--- a/pyserini/2cr/_base.py
+++ b/pyserini/2cr/_base.py
@@ -15,20 +15,12 @@
 #
 
 import os
-import subprocess
+
+from pyserini.util import run_command
 
 fail_str = '\033[91m[FAIL]\033[0m'
 ok_str = '[OK]'
 okish_str = '\033[94m[OKish]\033[0m'
-
-
-def run_command(cmd):
-    process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    stdout = stdout.decode('utf-8')
-    stderr = stderr.decode('utf-8')
-
-    return stdout, stderr
 
 
 def run_eval_and_return_metric(metric, eval_key, defs, runfile, display_command=False):
@@ -37,7 +29,8 @@ def run_eval_and_return_metric(metric, eval_key, defs, runfile, display_command=
     if display_command:
         print(f'\n```bash\n{eval_cmd}\n```\n')
 
-    eval_stdout, eval_stderr = run_command(eval_cmd)
+    result = run_command(eval_cmd)
+    eval_stdout = result.stdout
 
     for line in eval_stdout.split('\n'):
         parts = line.split('\t')
@@ -58,7 +51,8 @@ def run_dpr_retrieval_eval_and_return_metric(defs, json_file):
         topk: a dictionary of topk scores (e.g., {"Top5": <score>})
     """
     eval_cmd = f'python -m pyserini.eval.evaluate_dpr_retrieval --retrieval {json_file} {defs} '
-    eval_stdout, eval_stderr = run_command(eval_cmd)
+    result = run_command(eval_cmd)
+    eval_stdout = result.stdout
     topk = {}
     for line in eval_stdout.split('\n'):
         parts = line.split('\t')

--- a/pyserini/2cr/_base.py
+++ b/pyserini/2cr/_base.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-import os
-
 from pyserini.util import run_command
 
 fail_str = '\033[91m[FAIL]\033[0m'
@@ -74,7 +72,7 @@ def convert_trec_run_to_dpr_retrieval_json(topics,index,runfile,output):
         exit status: exit status
     """
     cmd = f'python -m pyserini.eval.convert_trec_run_to_dpr_retrieval_run --topics {topics} --index {index} --input {runfile} --output {output}'
-    return os.system(cmd)
+    return run_command(cmd, capture_output=False).returncode
 
 
 def run_fusion(run_ls, output, k):
@@ -90,4 +88,4 @@ def run_fusion(run_ls, output, k):
     """
     run_files = ' '.join(run_ls)
     cmd = f'python -m pyserini.fusion --runs {run_files} --output {output} --k {k}'
-    return os.system(cmd)
+    return run_command(cmd, capture_output=False).returncode

--- a/pyserini/2cr/atomic.py
+++ b/pyserini/2cr/atomic.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 atomic_models = [
@@ -217,7 +219,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        os.system(cmd)
+                        run_command(cmd, capture_output=False)
 
                 for expected in models['scores']:
                     for metric in expected:

--- a/pyserini/2cr/beir.py
+++ b/pyserini/2cr/beir.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 dense_threads = 16
@@ -274,7 +276,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        os.system(cmd)
+                        run_command(cmd, capture_output=False)
 
                 for expected in datasets['scores']:
                     for metric in expected:

--- a/pyserini/2cr/bright.py
+++ b/pyserini/2cr/bright.py
@@ -26,8 +26,6 @@ from string import Template
 
 import yaml
 
-from pyserini.util import run_command
-
 from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 metrics = ['nDCG@10', 'R@100', 'R@1000']
@@ -201,7 +199,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        run_command(cmd, capture_output=False)
+                        os.system(cmd)
 
                 for expected in datasets['scores']:
                     for metric in expected:

--- a/pyserini/2cr/bright.py
+++ b/pyserini/2cr/bright.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 metrics = ['nDCG@10', 'R@100', 'R@1000']
@@ -199,7 +201,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        os.system(cmd)
+                        run_command(cmd, capture_output=False)
 
                 for expected in datasets['scores']:
                     for metric in expected:

--- a/pyserini/2cr/ciral.py
+++ b/pyserini/2cr/ciral.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import run_eval_and_return_metric, ok_str, fail_str
 
 dense_threads = 16
@@ -280,7 +282,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        os.system(cmd)
+                        run_command(cmd, capture_output=False)
 
                 for expected in splits['scores']:
                     for metric in expected:

--- a/pyserini/2cr/dse.py
+++ b/pyserini/2cr/dse.py
@@ -104,7 +104,7 @@ def run_conditions(args):
                                 # Custom evaluation for Wiki-SS
                                 k = int(metric.split('-')[1])
                                 eval_cmd = f'python scripts/dse/evaluate_wiki_ss_run.py --run_file {runfile} --k {k}'
-                                out, err = run_command(eval_cmd)
+                                out = run_command(eval_cmd).stdout
                                 # Parse "Top-k Accuracy: 0.43"
                                 for line in out.split('\n'):
                                     if "Top-k Accuracy:" in line:

--- a/pyserini/2cr/dse.py
+++ b/pyserini/2cr/dse.py
@@ -26,7 +26,9 @@ from string import Template
 
 import yaml
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str, run_command
+from pyserini.util import run_command
+
+from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 def format_run_command(raw):
     return raw.replace('--topics', '\\\n  --topics') \
@@ -91,7 +93,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        os.system(cmd)
+                        run_command(cmd, capture_output=False)
 
                 for expected in datasets['scores']:
                     for metric in expected:

--- a/pyserini/2cr/m_beir.py
+++ b/pyserini/2cr/m_beir.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
@@ -127,7 +129,7 @@ def run_conditions(args):
                           
                         if not os.path.exists(runfile):  
                             if not args.dry_run:  
-                                os.system(cmd)  
+                                run_command(cmd, capture_output=False)
                           
                         for expected in sub['scores']:  
                             for metric in expected:  
@@ -157,7 +159,7 @@ def run_conditions(args):
                           
                     if not os.path.exists(runfile):  
                         if not args.dry_run:  
-                            os.system(cmd)  
+                            run_command(cmd, capture_output=False)
                               
                     for expected in datasets['scores']:  
                         for metric in expected:  

--- a/pyserini/2cr/miracl.py
+++ b/pyserini/2cr/miracl.py
@@ -18,7 +18,6 @@ import argparse
 import importlib.resources
 import math
 import os
-import subprocess
 import sys
 import time
 from collections import defaultdict, OrderedDict
@@ -26,6 +25,8 @@ from datetime import datetime, timezone
 from string import Template
 
 import yaml
+
+from pyserini.util import run_command
 
 from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
@@ -357,8 +358,8 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        rtn = subprocess.run(cmd.split(), capture_output=True)
-                        stderr = rtn.stderr.decode()
+                        result = run_command(cmd)
+                        stderr = result.stderr
                         if '--topics' in cmd:
                             topic_fn = extract_topic_fn_from_cmd(cmd)
                             if f'ValueError: Topic {topic_fn} Not Found' in stderr:

--- a/pyserini/2cr/mmeb.py
+++ b/pyserini/2cr/mmeb.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
@@ -136,7 +138,7 @@ def run_conditions(args):
                       
                 if not os.path.exists(runfile):  
                     if not args.dry_run:  
-                        os.system(cmd)  
+                        run_command(cmd, capture_output=False)
                           
                 for expected in datasets['scores']:  
                     for metric in expected:  
@@ -288,4 +290,3 @@ if __name__ == '__main__':
         sys.exit()  
   
     run_conditions(args)
-

--- a/pyserini/2cr/mrtydi.py
+++ b/pyserini/2cr/mrtydi.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 dense_threads = 16
@@ -263,7 +265,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        os.system(cmd)
+                        run_command(cmd, capture_output=False)
 
                 for expected in splits['scores']:
                     for metric in expected:

--- a/pyserini/2cr/msmarco.py
+++ b/pyserini/2cr/msmarco.py
@@ -27,6 +27,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 dense_threads = 16
@@ -560,7 +562,7 @@ def run_conditions(args):
 
                 if not os.path.exists(runfile):
                     if not args.dry_run:
-                        os.system(cmd)
+                        run_command(cmd, capture_output=False)
 
                 for expected in topic_set['scores']:
                     for metric in expected:

--- a/pyserini/2cr/odqa.py
+++ b/pyserini/2cr/odqa.py
@@ -26,6 +26,8 @@ from string import Template
 
 import yaml
 
+from pyserini.util import run_command
+
 from ._base import (
     convert_trec_run_to_dpr_retrieval_json,
     fail_str,
@@ -392,7 +394,7 @@ def run_topic_conditions(args, topic_arg, default_topics, yaml_path):
                         print(f'\n```bash\n{formatted_command}\n```\n')
                     if not os.path.exists(runfile[i]):
                         if not args.dry_run:
-                            os.system(cmd[i])
+                            run_command(cmd[i], capture_output=False)
 
             # fusion
             if 'RRF' in name:

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -52,21 +52,22 @@ def run_command(
     cwd: str | os.PathLike | None = None,
     env: Mapping[str, str] | None = None,
     timeout: float | None = None,
+    capture_output: bool = True,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a command and capture its output as text."""
+    """Run a command, optionally capturing its output as text."""
     args = shlex.split(cmd) if isinstance(cmd, str) else list(cmd)
     result = subprocess.run(
         args,
-        capture_output=True,
+        capture_output=capture_output,
         text=True,
         check=check,
         cwd=cwd,
         env=env,
         timeout=timeout,
     )
-    if result.stderr and echo:
+    if capture_output and result.stderr and echo:
         print(result.stderr)
-    if echo:
+    if capture_output and echo:
         print(result.stdout)
     return result
 

--- a/pyserini/util.py
+++ b/pyserini/util.py
@@ -19,10 +19,12 @@ import importlib
 import logging
 import os
 import re
+import shlex
 import shutil
+import subprocess
 import tarfile
 import urllib.request
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from urllib.error import HTTPError, URLError
 
@@ -40,6 +42,33 @@ from pyserini.prebuilt_index_info import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def run_command(
+    cmd: str | Sequence[str],
+    *,
+    echo: bool = False,
+    check: bool = False,
+    cwd: str | os.PathLike | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command and capture its output as text."""
+    args = shlex.split(cmd) if isinstance(cmd, str) else list(cmd)
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=check,
+        cwd=cwd,
+        env=env,
+        timeout=timeout,
+    )
+    if result.stderr and echo:
+        print(result.stderr)
+    if echo:
+        print(result.stdout)
+    return result
 
 
 @contextmanager

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -16,6 +16,8 @@
 
 import os
 import shutil
+import subprocess
+import sys
 import tarfile
 import tempfile
 import unittest
@@ -31,8 +33,27 @@ from pyserini.util import (
     download_url,
     get_cache_home,
     get_mbeir_instruction_config,
+    run_command,
     temporary_env,
 )
+
+
+class TestRunCommand(unittest.TestCase):
+    def test_run_command_accepts_argument_sequence(self):
+        result = run_command([sys.executable, '-c', 'print("hello")'])
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, 'hello\n')
+        self.assertEqual(result.stderr, '')
+
+    def test_run_command_parses_quoted_string(self):
+        result = run_command(f'{sys.executable} -c "print(\'hello world\')"')
+
+        self.assertEqual(result.stdout, 'hello world\n')
+
+    def test_run_command_check_raises_for_nonzero_exit(self):
+        with self.assertRaises(subprocess.CalledProcessError):
+            run_command([sys.executable, '-c', 'raise SystemExit(2)'], check=True)
 
 
 class TestIterateCollection(unittest.TestCase):

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -55,6 +55,22 @@ class TestRunCommand(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             run_command([sys.executable, '-c', 'raise SystemExit(2)'], check=True)
 
+    @patch('pyserini.util.subprocess.run')
+    def test_run_command_can_stream_output(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess([], 0)
+
+        run_command(['example'], capture_output=False)
+
+        mock_run.assert_called_once_with(
+            ['example'],
+            capture_output=False,
+            text=True,
+            check=False,
+            cwd=None,
+            env=None,
+            timeout=None,
+        )
+
 
 class TestIterateCollection(unittest.TestCase):
     def test_cacm_prebuilt_index_download(self):


### PR DESCRIPTION
## Summary

- add a shared `run_command` utility with configurable execution options
- migrate integration tests and `2cr` command execution to the shared helper
- add unit tests for sequence arguments, quoted strings, and checked failures

## Validation

- `mamba run -n pyserini-dev3 python -m unittest tests.base.test_utils.TestRunCommand`
- `mamba run -n pyserini-dev3 python -m py_compile pyserini/util.py pyserini/2cr/_base.py pyserini/2cr/dse.py pyserini/2cr/miracl.py integrations/utils.py integrations/core/sparse/test_prebuilt_unicoil.py integrations/core/papers/test_ecir2023.py integrations/core/papers/test_sigir2021.py integrations/core/papers/test_sigir2022.py tests/base/test_utils.py`
- `git diff --check`
