### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -538,3 +538,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
++ Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -794,3 +794,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-31 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -290,3 +290,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-09-01 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -562,3 +562,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-29 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
++ Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -583,3 +583,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-31 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
++ Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))


### PR DESCRIPTION
Adds reproduction-log entries for the Foundations of Retrieval onboarding path,
Pyserini lessons 4–8:

- `docs/experiments-msmarco-passage.md`
- `docs/conceptual-framework.md`
- `docs/experiments-nfcorpus.md`
- `docs/conceptual-framework2.md`
- `docs/conceptual-framework3.md`

## Environment
- Windows 11 + WSL2 (Ubuntu 24.04)
- Python 3.12, venv install (`pip install torch --index-url .../cpu`, `faiss-cpu`, `pyserini`)
- OpenJDK 21, `JAVA_HOME` set
- CPU only, no GPU

## Results — all matched the guides

| Lesson | Metric | Value |
|---|---|---|
| 4 — BM25 MS MARCO passage | MRR@10 / MAP / Recall@1000 | 0.18741227770955546 / 0.1957 / 0.8573 |
| 4 — per-query check (qid 1048585) | recip_rank | 1.0000 |
| 5 — conceptual-framework | BM25 as sparse dot product | 17.949487686157227 (LuceneSearcher: 17.94950) |
| 6 — NFCorpus BGE-base | nDCG@10 | 0.3808 |
| 6 — NFCorpus Contriever | nDCG@10 | 0.3306 |
| 7 — conceptual-framework2 (dense) | query·doc dot, FaissSearcher, brute force | 0.7913785 / 0.791379, all consistent |
| 7 — conceptual-framework2 (sparse BM25) | manual dot / LuceneSearcher / brute force | 11.9305, all consistent; nDCG@10 0.3218 |
| 8 — conceptual-framework3 SPLADE-v3 | nDCG@10 | 0.3624 |
| 8 — LuceneImpactSearcher top-10 | scores | identical to guide (MED-4555 51131.0 …) |

## Issues 

1. **Python 3.12.** Ubuntu 24.04 ships 3.12 (docs target 3.10/3.11). Everything
   worked without changes; just needed `apt install python3.12-venv python3-pip`.

2. **Lesson 8 - SPLADE-v3 CPU encoding OOM-killed in WSL** at the default batch
   size (`Killed` mid-progress-bar). Passing `--batch-size 8` fixed it, at the
   cost of speed (~59 min to encode NFCorpus's 3.6K docs on CPU). BGE and
   Contriever encodes were ~25 min each.

## Notes
- Reused the `collection_jsonl` built during the Anserini onboarding rather than
  re-downloading/re-converting.