### PR TITLE
Add reproduction log entries for onboarding lessons 4-8

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -539,3 +539,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -795,3 +795,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-31 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -291,3 +291,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-09-01 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -563,3 +563,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-30 (commit [`45b6ca2`](https://github.com/castorini/pyserini/commit/45b6ca2cbf14f61a38b6391b641e232fecba15a3))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -584,3 +584,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`3664a5d`](https://github.com/castorini/pyserini/commit/3664a5dc840696471cd94ae5e3a51d4635c77edc))
 + Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-31 (commit [`9a5330a`](https://github.com/castorini/pyserini/commit/9a5330a2dcbabda99ccf70c6237a7caa92d5cef4))
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))


### PR DESCRIPTION
Working through the [Foundations of Retrieval](https://github.com/castorini/onboarding/blob/master/ura.md) onboarding path. This PR adds reproduction log entries for the five Pyserini lessons (4-8), consolidated into a single pull request as the guide asks.

### Environment

| | |
| --- | --- |
| Host | Windows, 64 GB RAM, 16 logical CPUs (AMD EPYC 7763), no CUDA GPU |
| OS | Ubuntu 24.04.4 LTS on WSL2 (WSL sees 31 GB of host RAM) |
| JDK | OpenJDK 21.0.12 |
| Python | 3.12.3 |
| Pyserini | 2.4.0, development (editable) install at `b791648` |
| Anserini fatjar | built from source, copied into `pyserini/resources/jars/` |
| PyTorch / Faiss | 2.14.0+cpu / faiss-cpu 1.15.0 |

All neural inference was done on CPU.

### Results

**Lesson 4 — `experiments-msmarco-passage.md`**

| Metric | Expected | Actual |
| --- | --- | --- |
| Documents indexed | 8,841,823 | 8,841,823 |
| MRR@10 | 0.18741227770955546 | 0.18741227770955546 |
| MAP | 0.1957 | **0.1958** |
| recall@1000 | 0.8573 | 0.8573 |
| `recip_rank` for qid 1048585 | 1.0000 | 1.0000 |
| Interactive top-10 | as documented | identical |

**Lesson 5 — `conceptual-framework.md`**

The BM25 document vector for docid 7187158 came out byte-identical to the JSON in the guide; query tokens `['what', 'paula', 'deen', 'brother']`; inner product `17.949487686157227` by both the numpy and dict-comprehension routes; `LuceneSearcher` hit 1 scored `17.94950`.

**Lesson 6 — `experiments-nfcorpus.md`** — nDCG@10 **0.3808** as documented; interactive and batch runs agree.

**Lesson 7 — `conceptual-framework2.md`**

| Check | Expected | Actual |
| --- | --- | --- |
| Vectors in Faiss index | 3,633 | 3,633 |
| ‖re-encoded MED-4555 − stored vector‖₂ | ≈ 0 | 0.0 |
| `np.dot(q_vec, v1)` | 0.7913785 | 0.7913785 |
| Brute-force scan vs. Faiss top-10 | same | same |
| BM25 on NFCorpus, nDCG@10 | 0.3218 | 0.3218 |
| BM25 hand-computed dot product | 11.9305 | 11.9305 |

**Lesson 8 — `conceptual-framework3.md`** — nDCG@10 **0.3624** as documented; the interactive SPLADE-v3 top-10 matched the guide exactly, scores included.

### Issues encountered

**1. MAP is 0.1958, not the documented 0.1957 (lesson 4).**

MRR@10 and recall@1000 match to the last digit, so this looks like the tie-breaking effect that `experiments-msmarco-passage2.md` in Anserini describes: the Anserini lesson arrives at 0.1957 by writing an MS MARCO-format run and converting it to TREC (lossy), whereas this lesson re-runs retrieval and writes TREC directly, so tied documents land in a different order. MRR@10 is unaffected because it only looks at rank ≤ 10. Flagging it rather than quietly logging an exact match — happy to be told this is expected drift, or to dig further if it isn't.

**2. `naver/splade-v3` is now a gated model (lesson 8).**

Every download fails without an accepted licence and an auth token:

```
huggingface_hub.errors.GatedRepoError: 401 Client Error.
Cannot access gated repo for url https://huggingface.co/naver/splade-v3/resolve/main/config.json.
```

The guide already covers `hf auth login`, so this is only a small framing issue: the login step currently reads as setup advice, but it is now strictly required, and the failure surfaces as a `GatedRepoError` partway through rather than as an obvious "log in first" message. One extra trap worth a sentence: `hf auth login` writes the token to the *host* home directory, so running it in Windows PowerShell while doing the work in WSL leaves the token invisible to Python — it has to exist at `~/.cache/huggingface/token` inside the distro.

**3. Default SPLADE batch size destabilised WSL (lesson 8).**

With the default `--batch-size 64`, the whole WSL VM died with `Wsl/Service/E_UNEXPECTED` and needed `wsl --shutdown` to recover — not the kernel OOM killer the guide anticipates, so the existing "if the process exits with nothing but `Killed`" hint doesn't quite cover it. `--batch-size 8` completed in 27 minutes and produced exactly the documented 0.3624, as the guide promises.

I'm happy to fold points 2 and 3 into `conceptual-framework3.md` as doc edits in this PR if you'd like — I left them as PR commentary rather than presuming the right wording.

### Overall

Everything reproduced. The one number that differs does so by 0.0001 and has a plausible tie-breaking explanation. The lessons hang together well: seeing the brute-force scan return the same ranking as Faiss, and the hand-computed BM25 dot product match Lucene's own score, made the bi-encoder framing concrete rather than abstract. Worth noting that on NFCorpus the three approaches land at BM25 0.3218 < SPLADE-v3 0.3624 < BGE-base 0.3808, which is a useful reminder that "learned" and "dense" are independent axes.
