### PR TITLE
Fix BRIGHT end timestamp

### DIFF
--- a/pyserini/2cr/bright.py
+++ b/pyserini/2cr/bright.py
@@ -264,7 +264,7 @@ def run_conditions(args):
 
     end = time.time()
     start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
 
     print(f'Start time: {start_str}')
     print(f'End time: {end_str}')


### PR DESCRIPTION
Fixes #2673.

The BRIGHT runner now formats End time from the captured end timestamp. The elapsed duration calculation is unchanged.

Verification:

- python -m py_compile pyserini/2cr/bright.py
- Mocked start and end times and confirmed that the printed timestamps differ as expected