### PR TITLE
[codex] Consolidate shared 2CR helpers and simplify runners

### DIFF
--- a/pyserini/2cr/_base.py
+++ b/pyserini/2cr/_base.py
@@ -14,11 +14,23 @@
 # limitations under the License.
 #
 
+import importlib.resources
+
 from pyserini.util import run_command
 
 fail_str = '\033[91m[FAIL]\033[0m'
 ok_str = '[OK]'
 okish_str = '\033[94m[OKish]\033[0m'
+
+
+def read_file(filename):
+    with importlib.resources.files('pyserini.2cr').joinpath(filename).open('r') as f:
+        return f.read()
+
+
+def format_eval_command(raw):
+    return raw.replace('-c ', '\\\n  -c ') \
+        .replace(raw.split()[-1], f'\\\n  {raw.split()[-1]}')
 
 
 def run_eval_and_return_metric(metric, eval_key, defs, runfile, display_command=False):

--- a/pyserini/2cr/atomic.py
+++ b/pyserini/2cr/atomic.py
@@ -21,14 +21,21 @@ import os
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    okish_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 atomic_models = [
     'ViT-L-14.laion2b_s32b_b82k',
@@ -58,19 +65,6 @@ def format_run_command(raw):
         .replace('--hits ', '\\\n  --hits ')
 
 
-def format_eval_command(raw):
-    return raw.replace('-c ', '\\\n  -c ')\
-        .replace('run.', '\\\n  run.')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files('pyserini.2cr')/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
-
-
 def list_models():
     for model in atomic_models:
         print(model)
@@ -93,16 +87,20 @@ def list_conditions():
 def print_results(table, metric):
     print(f'Metric = {metric}')
     print(' ' * 35, end='')
+
     conditions = get_conditions()
     for condition in conditions:
         print(f'{condition}' + ' ' * 5, end='')
-    print('')
+
+    print()
+
     for model in atomic_models:
         print(f'{model:35}', end='')
         for condition in conditions:
             print(f'{table[model][condition][metric]:.3f}' + ' ' * len(condition), end='')
-        print('')
-    print('')
+        print()
+
+    print()
 
 
 def generate_report(args):
@@ -129,8 +127,7 @@ def generate_report(args):
 
                 for expected in models['scores']:
                     for metric in expected:
-                        eval_cmd = f'python -m pyserini.eval.trec_eval ' + \
-                                   f'{trec_eval_metric_definitions[metric]} atomic.validation.{retrieval_type} {runfile}'
+                        eval_cmd = f'python -m pyserini.eval.trec_eval {trec_eval_metric_definitions[metric]} atomic.validation.{retrieval_type} {runfile}'
                         eval_commands[model][name] += format_eval_command(eval_cmd) + '\n\n'
 
                         table[model][name][metric] = expected[metric]
@@ -204,9 +201,7 @@ def run_conditions(args):
                 
                 if args.all:
                     pass
-                elif args.condition != name:
-                    continue
-                elif args.model and args.model != model:
+                elif args.condition != name or args.model and args.model != model:
                     continue
 
                 print(f'  - Model: {model}')
@@ -217,9 +212,8 @@ def run_conditions(args):
                 if args.display_commands:
                     print(f'\n```bash\n{format_run_command(cmd)}\n```\n')
 
-                if not os.path.exists(runfile):
-                    if not args.dry_run:
-                        run_command(cmd, capture_output=False)
+                if not os.path.exists(runfile) and not args.dry_run:
+                    run_command(cmd, capture_output=False)
 
                 for expected in models['scores']:
                     for metric in expected:
@@ -243,14 +237,14 @@ def run_conditions(args):
                         else:
                             table[model][name][metric] = expected[metric]
 
-            print('')
+            print()
 
     for metric in trec_eval_metric_definitions:
         print_results(table, metric)
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print('\n')
     print(f'Start time: {start_str}')
@@ -286,14 +280,14 @@ if __name__ == '__main__':
     
     if args.generate_report:
         if not args.output:
-            print(f'Must specify report filename with --output.')
+            print('Must specify report filename with --output.')
             sys.exit()
 
         generate_report(args)
         sys.exit()
     
     if not args.all and not args.condition:
-        print(f'Must specify a specific condition using --condition or use --all to run all conditions.')
+        print('Must specify a specific condition using --condition or use --all to run all conditions.')
         sys.exit()
         
     if args.all and (args.condition or args.model):

--- a/pyserini/2cr/beir.py
+++ b/pyserini/2cr/beir.py
@@ -21,14 +21,21 @@ import os
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    okish_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 dense_threads = 16
 dense_batch_size = 512
@@ -95,19 +102,6 @@ def format_run_command(raw):
         .replace('--query-prefix', '\\\n  --query-prefix')
 
 
-def format_eval_command(raw):
-    return raw.replace('-c ', '\\\n  -c ') \
-        .replace('run.', '\\\n  run.')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr")/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
-
-
 def list_conditions():
     with importlib.resources.files('pyserini.2cr').joinpath('beir.yaml').open('r') as f:
         yaml_data = yaml.safe_load(f)
@@ -152,8 +146,7 @@ def generate_report(args):
 
                 for expected in datasets['scores']:
                     for metric in expected:
-                        eval_cmd = f'python -m pyserini.eval.trec_eval ' + \
-                                   f'{trec_eval_metric_definitions[metric]} beir-v1.0.0-{dataset}-test {runfile}'
+                        eval_cmd = f'python -m pyserini.eval.trec_eval {trec_eval_metric_definitions[metric]} beir-v1.0.0-{dataset}-test {runfile}'
                         eval_commands[dataset][name] += format_eval_command(eval_cmd) + '\n\n'
                         
                         if dataset.startswith('cqadupstack-'):
@@ -259,9 +252,7 @@ def run_conditions(args):
                     query_prefix = '"Represent this sentence for searching relevant passages:"'
                 if args.all:
                     pass
-                elif args.condition != name:
-                    continue
-                elif args.dataset and args.dataset != dataset:
+                elif args.condition != name or args.dataset and args.dataset != dataset:
                     continue
 
                 print(f'  - dataset: {dataset}')
@@ -274,9 +265,8 @@ def run_conditions(args):
                 if args.display_commands:
                     print(f'\n```bash\n{format_run_command(cmd)}\n```\n')
 
-                if not os.path.exists(runfile):
-                    if not args.dry_run:
-                        run_command(cmd, capture_output=False)
+                if not os.path.exists(runfile) and not args.dry_run:
+                    run_command(cmd, capture_output=False)
 
                 for expected in datasets['scores']:
                     for metric in expected:
@@ -299,9 +289,9 @@ def run_conditions(args):
                             table[dataset][name][metric] = score
                         else:
                             table[dataset][name][metric] = expected[metric]
-                    print('')
+                    print()
 
-            print('')
+            print()
 
     top_level_sums = defaultdict(lambda: defaultdict(float))
     cqadupstack_sums = defaultdict(lambda: defaultdict(float))
@@ -392,8 +382,8 @@ def run_conditions(args):
           f'{cqa_scores["bge-base-en-v1.5.lucene-flat"]["nDCG@10"]:8.3f}{cqa_scores["bge-base-en-v1.5.lucene-flat"]["R@100"]:8.3f}')
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print('\n')
     print(f'Start time: {start_str}')
@@ -429,7 +419,7 @@ if __name__ == '__main__':
 
     if args.generate_report:
         if not args.output:
-            print(f'Must specify report filename with --output.')
+            print('Must specify report filename with --output.')
             sys.exit()
 
         generate_report(args)
@@ -440,7 +430,7 @@ if __name__ == '__main__':
         sys.exit()
 
     if not args.all and not args.condition:
-        print(f'Must specify a specific condition using --condition or use --all to run all conditions.')
+        print('Must specify a specific condition using --condition or use --all to run all conditions.')
         sys.exit()
         
     if args.all and (args.condition or args.dataset):

--- a/pyserini/2cr/bright.py
+++ b/pyserini/2cr/bright.py
@@ -21,12 +21,19 @@ import os
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    okish_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 metrics = ['nDCG@10', 'R@100', 'R@1000']
 
@@ -70,19 +77,6 @@ def format_run_command(raw):
         .replace('--hits ', '\\\n  --hits ') \
 
 
-def format_eval_command(raw):
-    return raw.replace('-c ', '\\\n  -c ') \
-        .replace('run.', '\\\n  run.')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr")/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
-
-
 def list_conditions():
     with importlib.resources.files('pyserini.2cr').joinpath('bright.yaml').open('r') as f:
         yaml_data = yaml.safe_load(f)
@@ -118,8 +112,7 @@ def generate_report(args):
 
                 for expected in datasets['scores']:
                     for metric in expected:
-                        eval_cmd = f'python -m pyserini.eval.trec_eval ' + \
-                                   f'{trec_eval_metric_definitions[metric]} bright-{dataset} {runfile}'
+                        eval_cmd = f'python -m pyserini.eval.trec_eval {trec_eval_metric_definitions[metric]} bright-{dataset} {runfile}'
                         eval_commands[dataset][name] += format_eval_command(eval_cmd) + '\n\n'
                         
                         table[dataset][name][metric] = expected[metric]
@@ -183,9 +176,7 @@ def run_conditions(args):
                 dataset = datasets['dataset']
                 if args.all:
                     pass
-                elif args.condition != name:
-                    continue
-                elif args.dataset and args.dataset != dataset:
+                elif args.condition != name or args.dataset and args.dataset != dataset:
                     continue
 
                 print(f'  - dataset: {dataset}')
@@ -197,9 +188,8 @@ def run_conditions(args):
                 if args.display_commands:
                     print(f'\n```bash\n{format_run_command(cmd)}\n```\n')
 
-                if not os.path.exists(runfile):
-                    if not args.dry_run:
-                        os.system(cmd)
+                if not os.path.exists(runfile) and not args.dry_run:
+                    os.system(cmd)
 
                 for expected in datasets['scores']:
                     for metric in expected:
@@ -222,9 +212,9 @@ def run_conditions(args):
                             table[dataset][name][metric] = score
                         else:
                             table[dataset][name][metric] = expected[metric]
-                    print('')
+                    print()
 
-            print('')
+            print()
 
     top_level_sums = defaultdict(lambda: defaultdict(float))
     final_scores = defaultdict(lambda: defaultdict(float))
@@ -263,8 +253,8 @@ def run_conditions(args):
     print('\n')
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print(f'Start time: {start_str}')
     print(f'End time: {end_str}')
@@ -299,7 +289,7 @@ if __name__ == '__main__':
 
     if args.generate_report:
         if not args.output:
-            print(f'Must specify report filename with --output.')
+            print('Must specify report filename with --output.')
             sys.exit()
 
         generate_report(args)
@@ -310,7 +300,7 @@ if __name__ == '__main__':
         sys.exit()
 
     if not args.all and not args.condition:
-        print(f'Must specify a specific condition using --condition or use --all to run all conditions.')
+        print('Must specify a specific condition using --condition or use --all to run all conditions.')
         sys.exit()
         
     if args.all and (args.condition or args.dataset):

--- a/pyserini/2cr/ciral.py
+++ b/pyserini/2cr/ciral.py
@@ -20,21 +20,27 @@ import math
 import os
 import sys
 import time
-from collections import defaultdict, OrderedDict
-from datetime import datetime, timezone
+from collections import OrderedDict, defaultdict
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, fail_str
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 dense_threads = 16
 dense_batch_size = 512
 sparse_threads = 16
 sparse_batch_size = 128
-fusion_tag="rrf-afridpr-bmdt"
+fusion_tag='rrf-afridpr-bmdt'
 
 languages = [
     ['ha', 'hausa'],
@@ -77,22 +83,9 @@ def format_run_command(raw):
         .replace('--threads 12', '--threads 12 \\\n ')
 
 
-def format_eval_command(raw):
-    return raw.replace('-c ', '\\\n  -c ') \
-        .replace(raw.split()[-1], f'\\\n  {raw.split()[-1]}')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr")/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
-
-
 def list_conditions():
     print('Conditions:\n-----------')
-    for condition, _ in html_display.items():
+    for condition in html_display:
         print(condition)
     print('\nLanguages\n---------')
     for language in languages:
@@ -104,14 +97,17 @@ def print_results(table, metric, split):
     print(' ' * 32, end='')
     for lang in languages:
         print(f' {lang[1]:4}   ', end='')
-    print('')
+
+    print()
+
     for model in models:
         print(f'{model:32}', end='')
         for lang in languages:
             key = f'{model}.{lang[0]}'
             print(f'{table[key][split][metric]:7.4f}', end='   ')
-        print('')
-    print('')
+        print()
+
+    print()
 
 
 def generate_table_rows(table, row_template, commands, eval_commands, table_id, split, metric):
@@ -186,16 +182,23 @@ def generate_report(args):
 
             runfile = os.path.join(args.directory, f'run.ciral.{name}.{display_split}.txt')
             if is_fusion:
-                bm25_dt_output = os.path.join(args.directory,
-                                            f'run.ciral.bm25-dt.{lang}.{display_split}.txt')
-                afriberta_dpr_output = os.path.join(args.directory,
-                                            f'run.ciral.afriberta-pft-msmarco-ft-mrtydi.{lang}.{display_split}.txt')
-                expected_args = dict(output=runfile, bm25_dt_output=bm25_dt_output, 
-                                     afriberta_dpr_output=afriberta_dpr_output, fusion_tag=fusion_tag)
+                bm25_dt_output = os.path.join(args.directory, f'run.ciral.bm25-dt.{lang}.{display_split}.txt')
+                afriberta_dpr_output = os.path.join(args.directory, f'run.ciral.afriberta-pft-msmarco-ft-mrtydi.{lang}.{display_split}.txt')
+                expected_args = {
+                    'output': runfile,
+                    'bm25_dt_output': bm25_dt_output,
+                    'afriberta_dpr_output': afriberta_dpr_output,
+                    'fusion_tag': fusion_tag
+                    }
             else:
-                expected_args = dict(split=display_split, output=runfile,
-                                     sparse_threads=sparse_threads, sparse_batch_size=sparse_batch_size,
-                                     dense_threads=dense_threads, dense_batch_size=dense_batch_size)
+                expected_args = {
+                    'split': display_split,
+                    'output': runfile,
+                    'sparse_threads': sparse_threads,
+                    'sparse_batch_size': sparse_batch_size,
+                    'dense_threads': dense_threads,
+                    'dense_batch_size': dense_batch_size
+                    }
 
             cmd = Template(cmd_template).substitute(**expected_args)
             commands[name] = format_run_command(cmd)
@@ -207,8 +210,7 @@ def generate_report(args):
                         for metric in scores:
                             table[name][display_split][metric] = scores[metric]
 
-                            eval_cmd = f'python -m pyserini.eval.trec_eval ' + \
-                                    f'{trec_eval_metric_definitions[metric]} {eval_key}-{display_split} {runfile}'
+                            eval_cmd = f'python -m pyserini.eval.trec_eval {trec_eval_metric_definitions[metric]} {eval_key}-{display_split} {runfile}'
                             eval_commands[name][metric] = format_eval_command(eval_cmd)
 
         tables_html = []
@@ -216,14 +218,12 @@ def generate_report(args):
         # Build the table for nDCG@20, dev queries
         html_rows = generate_table_rows(table, row_template, commands, eval_commands, 1, display_split, 'nDCG@20')
         all_rows = '\n'.join(html_rows)
-        tables_html.append(Template(table_template).substitute(desc=f'nDCG@20, {all_splits[display_split]}', 
-                                                               rows=all_rows))
+        tables_html.append(Template(table_template).substitute(desc=f'nDCG@20, {all_splits[display_split]}', rows=all_rows))
 
         # Build the table for R@100, dev queries
         html_rows = generate_table_rows(table, row_template, commands, eval_commands, 3, display_split, 'R@100')
         all_rows = '\n'.join(html_rows)
-        tables_html.append(Template(table_template).substitute(desc=f'Recall@100, {all_splits[display_split]}', 
-                                                               rows=all_rows))
+        tables_html.append(Template(table_template).substitute(desc=f'Recall@100, {all_splits[display_split]}', rows=all_rows))
 
     with open(args.output, 'w') as out:
         out.write(Template(html_template).substitute(title='CIRAL', tables=' '.join(tables_html)))
@@ -241,14 +241,12 @@ def run_conditions(args):
             encoder = name.split('.')[0]
             lang = name.split('.')[-1]
 
-            lang_name = [item[1] for item in languages 
-                         if item[0] == lang][0]
+            lang_name = next(item[1] for item in languages if item[0] == lang)
             if args.all:
                 pass
-            elif args.condition != encoder:
+            elif args.condition != encoder or args.language and args.language != lang_name:
                 continue
-            elif args.language and args.language != lang_name:
-                continue
+
             eval_key = condition['eval_key']
             cmd_template = condition['command']
 
@@ -270,8 +268,8 @@ def run_conditions(args):
                                                 f'run.ciral.bm25-dt.{lang}.{split}.txt')
                     afriberta_dpr_output = os.path.join(args.directory,
                                                 f'run.ciral.afriberta-pft-msmarco-ft-mrtydi.{lang}.{split}.txt')
-                    cmd = Template(cmd_template).substitute(split=test_split, output=runfile, 
-                                                            bm25_dt_output=bm25_dt_output, afriberta_dpr_output=afriberta_dpr_output, fusion_tag=fusion_tag)
+                    cmd = Template(cmd_template).substitute(split=test_split, output=runfile, bm25_dt_output=bm25_dt_output,
+                                                            afriberta_dpr_output=afriberta_dpr_output, fusion_tag=fusion_tag)
                 else:
                     cmd = Template(cmd_template).substitute(split=test_split, output=runfile,
                                         sparse_threads=sparse_threads, sparse_batch_size=sparse_batch_size,
@@ -280,9 +278,8 @@ def run_conditions(args):
                 if args.display_commands:
                         print(f'\n```bash\n{format_run_command(cmd)}\n```\n')
 
-                if not os.path.exists(runfile):
-                    if not args.dry_run:
-                        run_command(cmd, capture_output=False)
+                if not os.path.exists(runfile) and not args.dry_run:
+                    run_command(cmd, capture_output=False)
 
                 for expected in splits['scores']:
                     for metric in expected:
@@ -302,15 +299,15 @@ def run_conditions(args):
                         else:
                             table[name][split][metric] = expected[metric]
 
-                print('')
+                print()
 
     for metric in ['nDCG@20', 'R@100']:
         for split in ['test-a', 'test-b']: # To add test later 
             print_results(table, metric, split)
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print('\n')
     print(f'Start time: {start_str}')
@@ -342,7 +339,7 @@ if __name__ == '__main__':
 
     if args.generate_report:
         if not args.output:
-            print(f'Must specify report filename with --output.')
+            print('Must specify report filename with --output.')
             sys.exit()
 
         generate_report(args)

--- a/pyserini/2cr/dse.py
+++ b/pyserini/2cr/dse.py
@@ -28,7 +28,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import read_file, run_eval_and_return_metric, ok_str, okish_str, fail_str
 
 def format_run_command(raw):
     return raw.replace('--topics', '\\\n  --topics') \
@@ -149,13 +149,6 @@ def run_conditions(args):
     print(f'End time: {end_str}')
     print(f'Total elapsed time: {end - start:.0f}s ~{(end - start)/3600:.1f}hr')
 
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr")/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
 
 def generate_report(args):
     

--- a/pyserini/2cr/m_beir.py
+++ b/pyserini/2cr/m_beir.py
@@ -28,7 +28,14 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import fail_str, ok_str, okish_str, run_eval_and_return_metric
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    okish_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 dense_threads = 16
 dense_batch_size = 512
@@ -51,15 +58,6 @@ def format_run_command(raw):
         .replace("--hits", "\\\n  --hits")
     )
 
-def format_eval_command(raw):
-    return raw.replace("-c ", "\\\n  -c ").replace("run.", "\\\n  run.")
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr") / f, "r")
-    text = fin.read()
-    fin.close()
-    return text
-
 def list_conditions():  
     with importlib.resources.files('pyserini.2cr').joinpath('m_beir.yaml').open('r') as f:  
         yaml_data = yaml.safe_load(f)  
@@ -72,9 +70,9 @@ def print_results_by_metric_position(table, position, metric_name):
     conditions = ['clip-sf-large', 'blip-ff-large']
     for condition in conditions:
         print(f'{condition:15}', end='')
-    print('')
+    print()
 
-    for dataset in table.keys():
+    for dataset in table:
         print(f'{dataset:30}', end='')
         metric_list = list(trec_eval_metric_definitions.keys())
 
@@ -86,8 +84,8 @@ def print_results_by_metric_position(table, position, metric_name):
             else:
                 score = 0.0
             print(f'{score:8.4f}' + ' ' * 7, end='')
-        print('')
-    print('')
+        print()
+    print()
 
 def run_conditions(args):  
     start = time.time()  
@@ -127,8 +125,8 @@ def run_conditions(args):
                         if args.display_commands:  
                             print(f'\n```bash\n{format_run_command(cmd)}\n```\n')  
                           
-                        if not os.path.exists(runfile):  
-                            if not args.dry_run:  
+                        if not os.path.exists(runfile):
+                            if not args.dry_run:
                                 run_command(cmd, capture_output=False)
                           
                         for expected in sub['scores']:  
@@ -157,8 +155,8 @@ def run_conditions(args):
                     if args.display_commands:  
                         print(f'\n```bash\n{format_run_command(cmd)}\n```\n')  
                           
-                    if not os.path.exists(runfile):  
-                        if not args.dry_run:  
+                    if not os.path.exists(runfile):
+                        if not args.dry_run:
                             run_command(cmd, capture_output=False)
                               
                     for expected in datasets['scores']:  
@@ -180,9 +178,9 @@ def run_conditions(args):
                                 table[dataset][name][metric] = score  
                             else:  
                                 table[dataset][name][metric] = expected[metric]  
-                print('')  
+                print()
                               
-            print('')  
+            print()
     
     print_results_by_metric_position(table, 0, 'R@5')
     print_results_by_metric_position(table, 1, 'R@10')
@@ -248,7 +246,7 @@ def generate_report(args):
     html_rows = []    
     row_cnt = 1    
         
-    for dataset in table.keys():  
+    for dataset in table:
         # Get dataset-specific metrics to determine the order  
         metric_names = list(trec_eval_metric_definitions.keys())  
           
@@ -281,27 +279,18 @@ def generate_report(args):
 
 
 if __name__ == '__main__':  
-    parser = argparse.ArgumentParser(description='Generate regression matrix for UniIR datasets.')  
+    parser = argparse.ArgumentParser(description='Generate regression matrix for UniIR datasets.')
       
-    parser.add_argument('--list-conditions', action='store_true', default=False,   
-                        help='List available conditions.')  
-      
-    parser.add_argument('--generate-report', action='store_true', default=False,   
-                        help='Generate report.')  
-    parser.add_argument('--output', type=str, help='File to store report.', required=False)  
-      
-    parser.add_argument('--all', action='store_true', default=False,   
-                        help='Run all conditions.')  
-    parser.add_argument('--condition', type=str, help='Condition to run.', required=False)  
-    parser.add_argument('--dataset', type=str, help='Dataset to run.', required=False)  
-    parser.add_argument('--directory', type=str, help='Base directory.', default='', required=False)  
-      
-    parser.add_argument('--dry-run', action='store_true', default=False,   
-                        help='Print out commands but do not execute.')  
-    parser.add_argument('--skip-eval', action='store_true', default=False,   
-                        help='Skip running trec_eval.')  
-    parser.add_argument('--display-commands', action='store_true', default=False,   
-                        help='Display command.')  
+    parser.add_argument('--list-conditions', action='store_true', default=False, help='List available conditions.')
+    parser.add_argument('--generate-report', action='store_true', default=False, help='Generate report.')
+    parser.add_argument('--output', type=str, help='File to store report.', required=False)
+    parser.add_argument('--all', action='store_true', default=False, help='Run all conditions.')
+    parser.add_argument('--condition', type=str, help='Condition to run.', required=False)
+    parser.add_argument('--dataset', type=str, help='Dataset to run.', required=False)
+    parser.add_argument('--directory', type=str, help='Base directory.', default='', required=False)
+    parser.add_argument('--dry-run', action='store_true', default=False, help='Print out commands but do not execute.')
+    parser.add_argument('--skip-eval', action='store_true', default=False, help='Skip running trec_eval.')
+    parser.add_argument('--display-commands', action='store_true', default=False, help='Display command.')
       
     args = parser.parse_args()  
   

--- a/pyserini/2cr/miracl.py
+++ b/pyserini/2cr/miracl.py
@@ -20,15 +20,22 @@ import math
 import os
 import sys
 import time
-from collections import defaultdict, OrderedDict
-from datetime import datetime, timezone
+from collections import OrderedDict, defaultdict
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    okish_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 dense_threads = 16
 dense_batch_size = 512
@@ -83,22 +90,9 @@ def format_run_command(raw):
         .replace('--bm25 ', '\\\n  --bm25 ')
 
 
-def format_eval_command(raw):
-    return raw.replace('-c ', '\\\n  -c ') \
-        .replace(raw.split()[-1], f'\\\n  {raw.split()[-1]}')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr")/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
-
-
 def list_conditions():
     print('Conditions:\n-----------')
-    for condition, _ in html_display.items():
+    for condition in html_display:
         print(condition)
     print('\nLanguages\n---------')
     for language in languages:
@@ -209,14 +203,17 @@ def print_results(table, metric, split):
     print(' ' * 35, end='')
     for lang in languages:
         print(f'{lang[0]:3}    ', end='')
-    print('')
+
+    print()
+
     for model in models:
         print(f'{model:33}', end='')
         for lang in languages:
             key = f'{model}.{lang[0]}'
             print(f'{table[key][split][metric]:7.3f}', end='')
-        print('')
-    print('')
+        print()
+
+    print()
 
 
 def extract_topic_fn_from_cmd(cmd):
@@ -275,8 +272,7 @@ def generate_report(args):
                             expected[metric] += 1e-5
                         table[name][split][metric] = expected[metric]
 
-                        eval_cmd = f'python -m pyserini.eval.trec_eval ' + \
-                                   f'{trec_eval_metric_definitions[metric]} {eval_key}-{split} {runfile}'
+                        eval_cmd = f'python -m pyserini.eval.trec_eval {trec_eval_metric_definitions[metric]} {eval_key}-{split} {runfile}'
                         eval_commands[name][metric] = format_eval_command(eval_cmd)
 
         tables_html = []
@@ -314,9 +310,7 @@ def run_conditions(args):
             lang = name.split('.')[-1]
             if args.all:
                 pass
-            elif args.condition != encoder:
-                continue
-            elif args.language and args.language != lang:
+            elif args.condition != encoder or args.language and args.language != lang:
                 continue
             eval_key = condition['eval_key']
             cmd_template = condition['command']
@@ -336,10 +330,8 @@ def run_conditions(args):
 
                 runfile = os.path.join(args.directory, f'run.miracl.{name}.{split}.top{hits}.txt')
                 if is_hybrid_run:
-                    bm25_output = os.path.join(args.directory,
-                                               f'run.miracl.bm25.{lang}.{split}.top{hits}.txt')
-                    mdpr_output = os.path.join(args.directory,
-                                               f'run.miracl.mdpr-tied-pft-msmarco.{lang}.{split}.top{hits}.txt')
+                    bm25_output = os.path.join(args.directory, f'run.miracl.bm25.{lang}.{split}.top{hits}.txt')
+                    mdpr_output = os.path.join(args.directory, f'run.miracl.mdpr-tied-pft-msmarco.{lang}.{split}.top{hits}.txt')
                     if not os.path.exists(bm25_output):
                         print(f'Missing BM25 file: {bm25_output}')
                         continue
@@ -356,15 +348,14 @@ def run_conditions(args):
                 if args.display_commands:
                     print(f'\n```bash\n{format_run_command(cmd)}\n```\n')
 
-                if not os.path.exists(runfile):
-                    if not args.dry_run:
-                        result = run_command(cmd)
-                        stderr = result.stderr
-                        if '--topics' in cmd:
-                            topic_fn = extract_topic_fn_from_cmd(cmd)
-                            if f'ValueError: Topic {topic_fn} Not Found' in stderr:
-                                print(f'Skipping {topic_fn}: file not found.')
-                                continue
+                if not os.path.exists(runfile) and not args.dry_run:
+                    result = run_command(cmd)
+                    stderr = result.stderr
+                    if '--topics' in cmd:
+                        topic_fn = extract_topic_fn_from_cmd(cmd)
+                        if f'ValueError: Topic {topic_fn} Not Found' in stderr:
+                            print(f'Skipping {topic_fn}: file not found.')
+                            continue
 
                 for expected in splits['scores']:
                     for metric in expected:
@@ -388,15 +379,15 @@ def run_conditions(args):
                         else:
                             table[name][split][metric] = expected[metric]
 
-            print('')
+            print()
 
     for metric in ['nDCG@10', 'R@100']:
         for split in ['dev', 'train']:
             print_results(table, metric, split)
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print('\n')
     print(f'Start time: {start_str}')
@@ -427,7 +418,7 @@ if __name__ == '__main__':
 
     if args.generate_report:
         if not args.output:
-            print(f'Must specify report filename with --output.')
+            print('Must specify report filename with --output.')
             sys.exit()
 
         generate_report(args)

--- a/pyserini/2cr/mmeb.py
+++ b/pyserini/2cr/mmeb.py
@@ -28,7 +28,14 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import fail_str, ok_str, okish_str, run_eval_and_return_metric
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    okish_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 dense_threads = 16
 dense_batch_size = 512
@@ -52,21 +59,11 @@ def format_run_command(raw):
         .replace("--hits", "\\\n  --hits")
     )
 
-def format_eval_command(raw):
-    return raw.replace("-c ", "\\\n  -c ").replace("run.", "\\\n  run.")
-
-
 def print_command_block(cmd):
     print('```bash')
     print(format_run_command(cmd))
     print('```')
     print()
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr") / f, "r")
-    text = fin.read()
-    fin.close()
-    return text
 
 def list_conditions():  
     with importlib.resources.files('pyserini.2cr').joinpath('mmeb.yaml').open('r') as f:  

--- a/pyserini/2cr/mrtydi.py
+++ b/pyserini/2cr/mrtydi.py
@@ -21,14 +21,21 @@ import os
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import (
+    fail_str,
+    format_eval_command,
+    ok_str,
+    okish_str,
+    read_file,
+    run_eval_and_return_metric,
+)
 
 dense_threads = 16
 dense_batch_size = 512
@@ -74,19 +81,6 @@ def format_run_command(raw):
         .replace('--threads ', '\\\n  --threads ')
 
 
-def format_eval_command(raw):
-    return raw.replace('-c ', '\\\n  -c ') \
-        .replace(raw.split()[-1], f'\\\n  {raw.split()[-1]}')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr")/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
-
-
 def list_conditions():
     print('Conditions:\n-----------')
     for condition in models:
@@ -101,14 +95,17 @@ def print_results(table, metric, split):
     print(' ' * 32, end='')
     for lang in languages:
         print(f'{lang[0]:3}    ', end='')
-    print('')
+
+    print()
+
     for model in models:
         print(f'{model:30}', end='')
         for lang in languages:
             key = f'{model}.{lang[0]}'
             print(f'{table[key][split][metric]:7.3f}', end='')
-        print('')
-    print('')
+        print()
+
+    print()
 
 
 def generate_table_rows(table, row_template, commands, eval_commands, table_id, split, metric):
@@ -208,8 +205,7 @@ def generate_report(args):
                     for metric in expected:
                         table[name][split][metric] = expected[metric]
 
-                        eval_cmd = f'python -m pyserini.eval.trec_eval ' + \
-                                   f'{trec_eval_metric_definitions[metric]} {eval_key}-{split} {runfile}'
+                        eval_cmd = f'python -m pyserini.eval.trec_eval {trec_eval_metric_definitions[metric]} {eval_key}-{split} {runfile}'
                         eval_commands[name][metric] = format_eval_command(eval_cmd)
 
         tables_html = []
@@ -241,9 +237,7 @@ def run_conditions(args):
             lang = name.split('.')[-1]
             if args.all:
                 pass
-            elif args.condition != encoder:
-                continue
-            elif args.language and args.language != lang:
+            elif args.condition != encoder or args.language and args.language != lang:
                 continue
             eval_key = condition['eval_key']
             cmd_template = condition['command']
@@ -263,9 +257,8 @@ def run_conditions(args):
                 if args.display_commands:
                     print(f'\n```bash\n{format_run_command(cmd)}\n```\n')
 
-                if not os.path.exists(runfile):
-                    if not args.dry_run:
-                        run_command(cmd, capture_output=False)
+                if not os.path.exists(runfile) and not args.dry_run:
+                    run_command(cmd, capture_output=False)
 
                 for expected in splits['scores']:
                     for metric in expected:
@@ -288,15 +281,15 @@ def run_conditions(args):
                         else:
                             table[name][split][metric] = expected[metric]
 
-            print('')
+            print()
 
     for metric in ['MRR@100', 'R@100']:
         for split in ['test', 'dev', 'train']:
             print_results(table, metric, split)
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print('\n')
     print(f'Start time: {start_str}')
@@ -306,8 +299,7 @@ def run_conditions(args):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate regression matrix for MIRACL.')
-    parser.add_argument('--condition', type=str,
-                        help='Condition to run', required=False)
+    parser.add_argument('--condition', type=str, help='Condition to run', required=False)
     # To list all conditions
     parser.add_argument('--list-conditions', action='store_true', default=False, help='List available conditions.')
     # For generating reports
@@ -328,7 +320,7 @@ if __name__ == '__main__':
 
     if args.generate_report:
         if not args.output:
-            print(f'Must specify report filename with --output.')
+            print('Must specify report filename with --output.')
             sys.exit()
 
         generate_report(args)

--- a/pyserini/2cr/msmarco.py
+++ b/pyserini/2cr/msmarco.py
@@ -22,14 +22,14 @@ import re
 import sys
 import time
 from collections import defaultdict, namedtuple
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import fail_str, ok_str, okish_str, read_file, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -276,9 +276,9 @@ def find_msmarco_table_topic_set_key_v1(topic_key):
 
 def find_msmarco_table_topic_set_key_v2(topic_key):
     key = ''
-    if topic_key.endswith('dev') or topic_key.endswith('dev-unicoil') or topic_key.endswith('dev-unicoil-noexp'):
+    if topic_key.endswith(('dev', 'dev-unicoil', 'dev-unicoil-noexp')):
         key = 'dev'
-    elif topic_key.endswith('dev2') or topic_key.endswith('dev2-unicoil') or topic_key.endswith('dev2-unicoil-noexp'):
+    elif topic_key.endswith(('dev2', 'dev2-unicoil', 'dev2-unicoil-noexp')):
         key = 'dev2'
     elif topic_key.startswith('dl21'):
         key = 'dl21'
@@ -317,14 +317,6 @@ def format_command(raw):
         .replace('--encoded-corpus', '\\\n  --encoded-corpus') \
         .replace('--encoded-queries', '\\\n  --encoded-queries') \
         .replace('.txt ', '.txt \\\n  ')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files("pyserini.2cr")/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
 
 
 def list_conditions(args):
@@ -388,7 +380,7 @@ def generate_report(args):
         for condition in yaml_data['conditions']:
             name = condition['name']
             display = condition['display-html']
-            row_id = condition['display-row'] if 'display-row' in condition else ''
+            row_id = condition.get('display-row', '')
             cmd_template = condition['command']
 
             row_ids[name] = row_id
@@ -411,8 +403,7 @@ def generate_report(args):
 
                 for expected in topic_set['scores']:
                     for metric in expected:
-                        eval_cmd = f'python -m pyserini.eval.trec_eval ' + \
-                                   f'{trec_eval_metric_definitions[args.collection][eval_key][metric]} {eval_key} {runfile}'
+                        eval_cmd = f'python -m pyserini.eval.trec_eval {trec_eval_metric_definitions[args.collection][eval_key][metric]} {eval_key} {runfile}'
                         eval_commands[name][short_topic_key] += eval_cmd + '\n'
                         table[name][short_topic_key][metric] = expected[metric]
 
@@ -532,9 +523,8 @@ def run_conditions(args):
         yaml_data = yaml.safe_load(f)
         for condition in yaml_data['conditions']:
             # Either we're running all conditions, or running only the condition specified in --condition
-            if not args.all:
-                if not condition['name'] == args.condition:
-                    continue
+            if not args.all and condition['name'] != args.condition:
+                continue
 
             name = condition['name']
             display = condition['display']
@@ -560,9 +550,8 @@ def run_conditions(args):
                 if args.display_commands:
                     print(f'\n```bash\n{format_command(cmd)}\n```\n')
 
-                if not os.path.exists(runfile):
-                    if not args.dry_run:
-                        run_command(cmd, capture_output=False)
+                if not os.path.exists(runfile) and not args.dry_run:
+                    run_command(cmd, capture_output=False)
 
                 for expected in topic_set['scores']:
                     for metric in expected:
@@ -594,7 +583,7 @@ def run_conditions(args):
                             table[name][short_topic_key][metric] = expected[metric]
 
                 if not args.skip_eval:
-                    print('')
+                    print()
 
     if args.collection == 'msmarco-v1-passage' or args.collection == 'msmarco-v1-doc':
         print(' ' * 74 + 'TREC 2019' + ' ' * 16 + 'TREC 2020' + ' ' * 12 + 'MS MARCO dev')
@@ -610,7 +599,7 @@ def run_conditions(args):
 
         for name in names:
             if not name:
-                print('')
+                print()
                 continue
             print(f'{table_keys[name]:65}' +
                   f'{table[name]["dl19"]["MAP"]:8.4f}{table[name]["dl19"]["nDCG@10"]:8.4f}{table[name]["dl19"]["R@1K"]:8.4f}  ' +
@@ -630,7 +619,7 @@ def run_conditions(args):
 
         for name in names:
             if not name:
-                print('')
+                print()
                 continue
             print(f'{table_keys[name]:60}' +
                   f'{table[name]["dl21"]["MAP@100"]:8.4f}{table[name]["dl21"]["nDCG@10"]:8.4f}{table[name]["dl21"]["R@1K"]:8.4f}  ' +
@@ -640,8 +629,8 @@ def run_conditions(args):
                   f'{table[name]["dev2"]["MRR@100"]:8.4f}{table[name]["dev2"]["R@1K"]:8.4f}')
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print('\n')
     print(f'Start time: {start_str}')
@@ -683,14 +672,14 @@ if __name__ == '__main__':
 
     if args.generate_report:
         if not args.output:
-            print(f'Must specify report filename with --output.')
+            print('Must specify report filename with --output.')
             sys.exit()
 
         generate_report(args)
         sys.exit()
 
     if not args.all and not args.condition:
-        print(f'Must specify a specific condition using --condition or use --all to run all conditions.')
+        print('Must specify a specific condition using --condition or use --all to run all conditions.')
         sys.exit()
 
     run_conditions(args)

--- a/pyserini/2cr/odqa.py
+++ b/pyserini/2cr/odqa.py
@@ -21,7 +21,7 @@ import os
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from string import Template
 
 import yaml
@@ -32,8 +32,9 @@ from ._base import (
     convert_trec_run_to_dpr_retrieval_json,
     fail_str,
     ok_str,
+    read_file,
     run_dpr_retrieval_eval_and_return_metric,
-    run_fusion
+    run_fusion,
 )
 
 dense_threads = 16
@@ -114,14 +115,6 @@ def format_convert_command(raw):
 def format_eval_command(raw):
     return raw.replace('--retrieval ', '\\\n  --retrieval ') \
         .replace('--topk', '\\\n  --topk')
-
-
-def read_file(f):
-    fin = open(importlib.resources.files('pyserini.2cr')/f, 'r')
-    text = fin.read()
-    fin.close()
-
-    return text
 
 
 def list_conditions():
@@ -458,8 +451,8 @@ def run_conditions(args):
         run_topic_conditions(args, topic_arg, default_topics, yaml_path)
 
     end = time.time()
-    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
-    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    start_str = datetime.fromtimestamp(start, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end, tz=UTC).strftime('%Y-%m-%d %H:%M:%S')
 
     print('\n')
     print(f'Start time: {start_str}')


### PR DESCRIPTION
## Summary

- Consolidate template reading across 11 runners into a shared helper using a context manager.
- Consolidate eight evaluation-command formatters, preserving complete runfile paths when inserting line continuations.
- Simplify imports, conditionals, dictionary operations, printing, and UTC timestamp usage.

## Validation

- `git diff --check`
- `python -B -c 'import ast, pathlib; [ast.parse(p.read_text(), filename=str(p)) for p in pathlib.Path("pyserini/2cr").glob("*.py")]'`

Targeted checks passed for 32 templates, missing-file errors, four shell-argument cases, and shared imports. Full runner execution was not tested; local imports lack `pandas`.
