### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/conceptual-framework.md
+++ b/docs/conceptual-framework.md
@@ -542,3 +542,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`139adc8`](https://github.com/castorini/pyserini/commit/139adc808413158c09510a7341cd6dcd3f122acc))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`b0ad282`](https://github.com/castorini/pyserini/commit/b0ad28270848f9b34ca822827bf5f71717255e84))

--- a/docs/conceptual-framework2.md
+++ b/docs/conceptual-framework2.md
@@ -798,3 +798,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`139adc8`](https://github.com/castorini/pyserini/commit/139adc808413158c09510a7341cd6dcd3f122acc))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`b0ad282`](https://github.com/castorini/pyserini/commit/b0ad28270848f9b34ca822827bf5f71717255e84))

--- a/docs/conceptual-framework3.md
+++ b/docs/conceptual-framework3.md
@@ -294,3 +294,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`139adc8`](https://github.com/castorini/pyserini/commit/139adc808413158c09510a7341cd6dcd3f122acc))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`b0ad282`](https://github.com/castorini/pyserini/commit/b0ad28270848f9b34ca822827bf5f71717255e84))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -566,3 +566,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`139adc8`](https://github.com/castorini/pyserini/commit/139adc808413158c09510a7341cd6dcd3f122acc))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`b0ad282`](https://github.com/castorini/pyserini/commit/b0ad28270848f9b34ca822827bf5f71717255e84))

--- a/docs/experiments-nfcorpus.md
+++ b/docs/experiments-nfcorpus.md
@@ -587,3 +587,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`b791648`](https://github.com/castorini/pyserini/commit/b791648ea88f301cc48d1e53943cae441ba068d8))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`139adc8`](https://github.com/castorini/pyserini/commit/139adc808413158c09510a7341cd6dcd3f122acc))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`b0ad282`](https://github.com/castorini/pyserini/commit/b0ad28270848f9b34ca822827bf5f71717255e84))


### PR DESCRIPTION
Completed the Pyserini exercises in the Foundations of Retrieval onboarding path on an Apple Silicon Mac and Python 3.12.

Successfully reproduced the following items:
- MS MARCO BM25 baseline
     ->  MRR@10: 0.1874
- BGE-base baseline on NFCorpus
     ->  nDCG@10: 0.3808
- BM25 baseline on NFCorpus
     ->  nDCG@10: 0.3218
- SPLADE-v3 learned sparse baseline on NFCorpus
     ->  nDCG@10: 0.3624
- Dense and sparse representation exercises, including manually reproducing ranking scores from vector representations

Some interesting notes:
- Comparing BM25, BGE, and SPLADE made the tradeoff between sparse and dense retrieval much more concrete. SPLADE was unique because it learns sparse term weights with a neural model while still retaining an inverted-index retrieval architecture.
- Manually computing retrieval scores helped connect the abstractions to the underlying ranking operation: both dense and sparse retrieval can ultimately be viewed as constructing query and document representations and scoring their similarity, despite using very different representations for it.
- I encountered a `libomp` crash during multithreaded Faiss retrieval on Apple Silicon. I used Codex to help troubleshoot the issue and ultimately resolved it by restricting OpenMP/vecLib and running with a single retrieval thread. This may be worth noting in case someone encounters a similar issue in the future.

```
OMP_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 \
python -m pyserini.search.faiss \
--encoder-class auto \
--encoder BAAI/bge-base-en-v1.5 \
--l2-norm \
--pooling mean \
--index indexes/nfcorpus.bge-base-en-v1.5 \
--topics collections/nfcorpus/queries.tsv \
--output runs/run.beir.bge-base-en-v1.5.nfcorpus.txt \
--batch 32 \
--threads 1 \
--hits 1000
```
