### PR TITLE
Clarify query encoder model path names

### DIFF
--- a/pyserini/demo/miracl.py
+++ b/pyserini/demo/miracl.py
@@ -110,7 +110,7 @@ def _load_sparse_searcher(language: str, k1: Optional[float]=None, b: Optional[f
 
 
 def _load_faiss_searcher(language: str, device:  str) -> (Searcher, str):
-    query_encoder = AutoQueryEncoder(encoder_dir='castorini/mdpr-tied-pft-msmarco', device=device)
+    query_encoder = AutoQueryEncoder(encoder_name_or_path='castorini/mdpr-tied-pft-msmarco', device=device)
     searcher = FaissSearcher.from_prebuilt_index(
         f'miracl-v{VERSION}-{language}-mdpr-tied-pft-msmarco', query_encoder
     )

--- a/pyserini/encode/_aggretriever.py
+++ b/pyserini/encode/_aggretriever.py
@@ -26,7 +26,7 @@ if torch.cuda.is_available():
 from transformers import DistilBertConfig, BertConfig
 from transformers import AutoModelForMaskedLM, AutoTokenizer, PreTrainedModel
 from pyserini.encode import DocumentEncoder, QueryEncoder
-from pyserini.encode._base import load_head_weights
+from pyserini.encode._base import load_head_weights, resolve_encoder_name_or_path
 from packaging.version import Version
 from transformers import __version__ as transformers_version
 
@@ -181,16 +181,18 @@ class AggretrieverDocumentEncoder(DocumentEncoder):
 
 
 class AggretrieverQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, tokenizer_name: str = None,
-                 encoded_queries_dir: str = None, device: str = 'cpu', **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, tokenizer_name: str = None,
+                 encoded_queries_dir: str = None, device: str = 'cpu',
+                 encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             self.device = device
-            if 'distilbert' in encoder_dir.lower():
-                self.model = DistlBertAggretrieverEncoder.load_pretrained_encoder(encoder_dir, device)
+            if 'distilbert' in encoder_name_or_path.lower():
+                self.model = DistlBertAggretrieverEncoder.load_pretrained_encoder(encoder_name_or_path, device)
             else:
-                self.model = BertAggretrieverEncoder.load_pretrained_encoder(encoder_dir, device)
-            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or encoder_dir,
+                self.model = BertAggretrieverEncoder.load_pretrained_encoder(encoder_name_or_path, device)
+            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or encoder_name_or_path,
                                                            clean_up_tokenization_spaces=True)
             self.has_model = True
         if (not self.has_model) and (not self.has_encoded_queries):

--- a/pyserini/encode/_ance.py
+++ b/pyserini/encode/_ance.py
@@ -27,7 +27,7 @@ from transformers import (
 from transformers import __version__ as transformers_version
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
-from pyserini.encode._base import load_head_weights, load_roberta_tokenizer
+from pyserini.encode._base import load_head_weights, load_roberta_tokenizer, resolve_encoder_name_or_path
 from pyserini.util import temporary_env
 
 
@@ -117,13 +117,16 @@ class AnceDocumentEncoder(DocumentEncoder):
 
 
 class AnceQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, tokenizer_name: str = None,
-                 encoded_queries_dir: str = None, device: str = 'cpu', **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, tokenizer_name: str = None,
+                 encoded_queries_dir: str = None, device: str = 'cpu',
+                 encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             self.device = device
-            self.model = AnceEncoder.load_pretrained_encoder(encoder_dir, device)
-            self.tokenizer = load_roberta_tokenizer(tokenizer_name or encoder_dir, clean_up_tokenization_spaces=True)
+            self.model = AnceEncoder.load_pretrained_encoder(encoder_name_or_path, device)
+            self.tokenizer = load_roberta_tokenizer(tokenizer_name or encoder_name_or_path,
+                                                    clean_up_tokenization_spaces=True)
             self.has_model = True
             self.tokenizer.do_lower_case = True
         if (not self.has_model) and (not self.has_encoded_queries):

--- a/pyserini/encode/_arctic.py
+++ b/pyserini/encode/_arctic.py
@@ -19,6 +19,7 @@ from torch.nn.functional import normalize
 from transformers import AutoModel, AutoTokenizer
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 
 
 class ArcticDocumentEncoder(DocumentEncoder):
@@ -50,15 +51,18 @@ class ArcticDocumentEncoder(DocumentEncoder):
 
 
 class ArcticQueryEncoder(QueryEncoder):  
-    def __init__(self, encoder_dir: str, query_prefix: str = 'Represent this sentence for searching relevant passages: ', 
-                 tokenizer_name: str = None, encoded_queries_dir: str = None, device: str = 'cpu', normalize: bool = True, **kwargs):
+    def __init__(self, encoder_name_or_path: str = None,
+                 query_prefix: str = 'Represent this sentence for searching relevant passages: ',
+                 tokenizer_name: str = None, encoded_queries_dir: str = None, device: str = 'cpu',
+                 normalize: bool = True, encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
         
-        if encoder_dir:
+        if encoder_name_or_path:
             self.device = device 
             self.query_prefix = query_prefix
-            self.model = AutoModel.from_pretrained(encoder_dir, add_pooling_layer=False).to(self.device)
-            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or encoder_dir,
+            self.model = AutoModel.from_pretrained(encoder_name_or_path, add_pooling_layer=False).to(self.device)
+            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or encoder_name_or_path,
                                                            clean_up_tokenization_spaces=True)
             self.has_model = True
             self.normalize = normalize

--- a/pyserini/encode/_auto.py
+++ b/pyserini/encode/_auto.py
@@ -18,7 +18,7 @@ import numpy as np
 from sklearn.preprocessing import normalize
 from transformers import AutoModel
 
-from pyserini.encode._base import DocumentEncoder, QueryEncoder, load_auto_tokenizer
+from pyserini.encode._base import DocumentEncoder, QueryEncoder, load_auto_tokenizer, resolve_encoder_name_or_path
 
 
 class AutoDocumentEncoder(DocumentEncoder):
@@ -67,14 +67,17 @@ class AutoDocumentEncoder(DocumentEncoder):
 
 
 class AutoQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, tokenizer_name: str = None, encoded_queries_dir: str = None,
-                 device: str = 'cpu', pooling: str = 'cls', l2_norm: bool = False, prefix=None, **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, tokenizer_name: str = None, encoded_queries_dir: str = None,
+                 device: str = 'cpu', pooling: str = 'cls', l2_norm: bool = False, prefix=None,
+                 encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             self.device = device
-            self.model = AutoModel.from_pretrained(encoder_dir)
+            self.model = AutoModel.from_pretrained(encoder_name_or_path)
             self.model.to(self.device)
-            self.tokenizer = load_auto_tokenizer(tokenizer_name or encoder_dir, clean_up_tokenization_spaces=True)
+            self.tokenizer = load_auto_tokenizer(tokenizer_name or encoder_name_or_path,
+                                                 clean_up_tokenization_spaces=True)
             self.has_model = True
             self.pooling = pooling
             self.l2_norm = l2_norm

--- a/pyserini/encode/_base.py
+++ b/pyserini/encode/_base.py
@@ -28,6 +28,12 @@ from transformers.utils import cached_file
 from pyserini.util import download_encoded_queries
 
 
+def resolve_encoder_name_or_path(encoder_name_or_path: str = None, encoder_dir: str = None) -> str:
+    if encoder_name_or_path is not None and encoder_dir is not None and encoder_name_or_path != encoder_dir:
+        raise ValueError('encoder_name_or_path and encoder_dir refer to different models.')
+    return encoder_name_or_path if encoder_name_or_path is not None else encoder_dir
+
+
 def load_bert_tokenizer(tokenizer_name, **kwargs):
     # The upstream tokenizers WordPiece implementation emits this warning while
     # constructing BERT WordPiece tokenizers; tokenization behavior is unchanged.

--- a/pyserini/encode/_bpr.py
+++ b/pyserini/encode/_bpr.py
@@ -21,11 +21,13 @@ import torch
 from transformers import DPRQuestionEncoder, DPRQuestionEncoderTokenizer
 
 from pyserini.encode import QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 
 
 class BprQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, tokenizer_name: str = None,
-                 encoded_queries_dir: str = None, device: str = 'cpu', **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, tokenizer_name: str = None,
+                 encoded_queries_dir: str = None, device: str = 'cpu',
+                 encoder_dir: str = None, **kwargs):
         self.has_model = False
         self.has_encoded_queries = False
 
@@ -33,11 +35,12 @@ class BprQueryEncoder(QueryEncoder):
             self.embeddings = self._load_embeddings(encoded_queries_dir)
             self.has_encoded_queries = True
 
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             self.device = device
-            self.model = DPRQuestionEncoder.from_pretrained(encoder_dir)
+            self.model = DPRQuestionEncoder.from_pretrained(encoder_name_or_path)
             self.model.to(self.device)
-            self.tokenizer = DPRQuestionEncoderTokenizer.from_pretrained(tokenizer_name or encoder_dir,
+            self.tokenizer = DPRQuestionEncoderTokenizer.from_pretrained(tokenizer_name or encoder_name_or_path,
                                                                          clean_up_tokenization_spaces=True)
             self.has_model = True
 

--- a/pyserini/encode/_clip.py
+++ b/pyserini/encode/_clip.py
@@ -24,6 +24,7 @@ from sklearn.preprocessing import normalize
 from transformers import CLIPProcessor, CLIPModel
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 
 os.environ['OPENBLAS_NUM_THREADS'] = '1'
 
@@ -142,12 +143,14 @@ class ClipEncoder(QueryEncoder):
 class ClipQueryEncoder(QueryEncoder):
     """Encodes queries using a CLIP model, supporting both images and texts."""
 
-    def __init__(self, encoder_dir: str = None, encoded_queries_dir: str = None, device: str = 'cuda:0',
-                 l2_norm: bool = False, prefix: str = None, multimodal: bool = False, **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, encoded_queries_dir: str = None,
+                 device: str = 'cuda:0', l2_norm: bool = False, prefix: str = None,
+                 multimodal: bool = False, encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             self.device = device
-            self.encoder = ClipEncoder(encoder_dir, device, l2_norm, prefix, multimodal)
+            self.encoder = ClipEncoder(encoder_name_or_path, device, l2_norm, prefix, multimodal)
             self.has_model = True
 
         if not self.has_model and not self.has_encoded_queries:

--- a/pyserini/encode/_cosdpr.py
+++ b/pyserini/encode/_cosdpr.py
@@ -22,6 +22,7 @@ from transformers import PreTrainedModel, BertConfig, BertModel, BertTokenizer
 from transformers import __version__ as transformers_version
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 from pyserini.encode._base import load_head_weights
 from pyserini.util import temporary_env
 
@@ -115,10 +116,12 @@ class CosDprDocumentEncoder(DocumentEncoder):
 
 class CosDprQueryEncoder(QueryEncoder):
 
-    def __init__(self, encoder_dir: str, tokenizer_name: str = None, device: str = 'cpu', **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, tokenizer_name: str = None,
+                 device: str = 'cpu', encoder_dir: str = None, **kwargs):
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
         self.device = device
-        self.model = CosDprEncoder.load_pretrained_encoder(encoder_dir, self.device)
-        self.tokenizer = BertTokenizer.from_pretrained(encoder_dir or tokenizer_name,
+        self.model = CosDprEncoder.load_pretrained_encoder(encoder_name_or_path, self.device)
+        self.tokenizer = BertTokenizer.from_pretrained(tokenizer_name or encoder_name_or_path,
                                                        clean_up_tokenization_spaces=True)
 
     def encode(self, query: str, max_length: int = None, **kwargs):

--- a/pyserini/encode/_dkrr.py
+++ b/pyserini/encode/_dkrr.py
@@ -16,14 +16,16 @@
 import torch
 from transformers import BertModel
 
-from pyserini.encode._base import QueryEncoder, load_bert_tokenizer
+from pyserini.encode._base import QueryEncoder, load_bert_tokenizer, resolve_encoder_name_or_path
 
 
 class DkrrDprQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, encoded_queries_dir: str = None, device: str = 'cpu', prefix: str = 'question:', **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, encoded_queries_dir: str = None,
+                 device: str = 'cpu', prefix: str = 'question:', encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
         self.device = device
-        self.model = BertModel.from_pretrained(encoder_dir)
+        self.model = BertModel.from_pretrained(encoder_name_or_path)
         self.model.to(self.device)
         self.tokenizer = load_bert_tokenizer('bert-base-uncased', clean_up_tokenization_spaces=True)
         self.has_model = True

--- a/pyserini/encode/_dpr.py
+++ b/pyserini/encode/_dpr.py
@@ -29,6 +29,7 @@ from transformers import __version__ as transformers_version
 from transformers.utils import logging
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 
 
 class _LegacyDprTokenizer:
@@ -282,15 +283,17 @@ class DprDocumentEncoder(DocumentEncoder):
 
 
 class DprQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, tokenizer_name: str = None,
-                 encoded_queries_dir: str = None, device: str = 'cpu', **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, tokenizer_name: str = None,
+                 encoded_queries_dir: str = None, device: str = 'cpu',
+                 encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             self.device = device
             with log_level(logging.ERROR):
-                self.model = DPRQuestionEncoder.from_pretrained(encoder_dir)
+                self.model = DPRQuestionEncoder.from_pretrained(encoder_name_or_path)
             self.model.to(self.device)
-            self.tokenizer = _load_dpr_tokenizer(DPRQuestionEncoderTokenizer, tokenizer_name or encoder_dir,
+            self.tokenizer = _load_dpr_tokenizer(DPRQuestionEncoderTokenizer, tokenizer_name or encoder_name_or_path,
                                                  clean_up_tokenization_spaces=True)
             self.has_model = True
         if (not self.has_model) and (not self.has_encoded_queries):

--- a/pyserini/encode/_dse.py
+++ b/pyserini/encode/_dse.py
@@ -29,6 +29,7 @@ from sklearn.preprocessing import normalize
 from transformers import AutoProcessor, AutoModelForCausalLM
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 
 logger = logging.getLogger(__name__)
 
@@ -327,19 +328,21 @@ class DseQueryEncoder(QueryEncoder):
     
     def __init__(
         self, 
-        encoder_dir: str = None, 
+        encoder_name_or_path: str = None,
         encoded_queries_dir: str = None,
         device: str = 'cpu',
         l2_norm: bool = False,
         pooling: str = 'last',
         cache_dir: Optional[str] = None,
         fp16: bool = False,
+        encoder_dir: str = None,
         **kwargs
     ):
         super().__init__(encoded_queries_dir)
         self.has_model = False
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
         
-        if encoder_dir:
+        if encoder_name_or_path:
             self.device = device
             self.l2_norm = l2_norm
             self.pooling = pooling
@@ -347,7 +350,7 @@ class DseQueryEncoder(QueryEncoder):
             
             # Load processor
             self.processor = AutoProcessor.from_pretrained(
-                encoder_dir,
+                encoder_name_or_path,
                 cache_dir=cache_dir,
                 trust_remote_code=True
             )
@@ -358,7 +361,7 @@ class DseQueryEncoder(QueryEncoder):
             
             # Load model (pre-merged checkpoint, no LoRA needed)
             self.model = DSEModel.load(
-                encoder_dir,
+                encoder_name_or_path,
                 pooling=pooling,
                 normalize=l2_norm,
                 cache_dir=cache_dir

--- a/pyserini/encode/_openai.py
+++ b/pyserini/encode/_openai.py
@@ -23,6 +23,7 @@ import openai
 import tiktoken
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 
 OPENAI_API_RETRY_DELAY = 5
 
@@ -62,14 +63,16 @@ class OpenAiDocumentEncoder(DocumentEncoder):
 
 
 class OpenAiQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, encoded_queries_dir: str = None,
-                 tokenizer_name: str = None, max_length: int = 512, **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, encoded_queries_dir: str = None,
+                 tokenizer_name: str = None, max_length: int = 512,
+                 encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             api_key = '' if os.getenv("OPENAI_API_KEY") is None else os.getenv("OPENAI_API_KEY")
             org_key = '' if os.getenv("OPENAI_ORG_KEY") is None else os.getenv("OPENAI_ORG_KEY")
             self.client = openai.OpenAI(api_key=api_key, organization=org_key)
-            self.model = encoder_dir
+            self.model = encoder_name_or_path
             self.tokenizer = tiktoken.get_encoding(tokenizer_name)
             self.max_length = max_length
             self.has_model = True

--- a/pyserini/encode/_qwen3.py
+++ b/pyserini/encode/_qwen3.py
@@ -20,6 +20,7 @@ from torch import Tensor
 from transformers import AutoModel, AutoTokenizer
 
 from pyserini.encode import DocumentEncoder, QueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
 
 
 def last_token_pool(last_hidden_states: Tensor, attention_mask: Tensor) -> Tensor:
@@ -82,7 +83,8 @@ class Qwen3DocumentEncoder(DocumentEncoder):
 
 
 class Qwen3QueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir, device='cpu', **kwargs):
+    def __init__(self, encoder_name_or_path=None, device='cpu', encoder_dir=None, **kwargs):
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
         self.explicit_truncate = kwargs.get('explicit_truncate', False)
         self.prefix = kwargs.get('prefix', '')
         self.device = device
@@ -91,10 +93,10 @@ class Qwen3QueryEncoder(QueryEncoder):
         self.dtype = torch.bfloat16 if kwargs.get('fp16', False) else torch.float32
         self.max_length = kwargs.get('max_length', 8192)
         self.tokenizer = AutoTokenizer.from_pretrained(
-            encoder_dir, padding_side='left', trust_remote_code=True
+            encoder_name_or_path, padding_side='left', trust_remote_code=True
         )
         self.model = AutoModel.from_pretrained(
-            encoder_dir, trust_remote_code=True, torch_dtype=self.dtype
+            encoder_name_or_path, trust_remote_code=True, torch_dtype=self.dtype
         )
         self.model.to(device=self.device, dtype=self.dtype).eval()
 

--- a/pyserini/encode/_tct_colbert.py
+++ b/pyserini/encode/_tct_colbert.py
@@ -20,7 +20,7 @@ import torch
 from transformers import BertModel
 from transformers.utils import logging as transformers_logging
 
-from pyserini.encode._base import DocumentEncoder, QueryEncoder, load_bert_tokenizer
+from pyserini.encode._base import DocumentEncoder, QueryEncoder, load_bert_tokenizer, resolve_encoder_name_or_path
 
 
 def _load_bert_backbone(model_name):
@@ -105,15 +105,17 @@ class TctColBertDocumentEncoder(DocumentEncoder):
 
 
 class TctColBertQueryEncoder(QueryEncoder):
-    def __init__(self, encoder_dir: str = None, tokenizer_name: str = None,
-                 encoded_queries_dir: str = None, device: str = 'cpu', **kwargs):
+    def __init__(self, encoder_name_or_path: str = None, tokenizer_name: str = None,
+                 encoded_queries_dir: str = None, device: str = 'cpu',
+                 encoder_dir: str = None, **kwargs):
         super().__init__(encoded_queries_dir)
-        if encoder_dir:
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
+        if encoder_name_or_path:
             self.device = device
-            self.model = _load_bert_backbone(encoder_dir)
+            self.model = _load_bert_backbone(encoder_name_or_path)
             self.model.to(self.device)
             self.tokenizer = load_bert_tokenizer(
-                tokenizer_name or encoder_dir,
+                tokenizer_name or encoder_name_or_path,
                 clean_up_tokenization_spaces=True
             )
             self.has_model = True

--- a/pyserini/encode/optional/_mmeb.py
+++ b/pyserini/encode/optional/_mmeb.py
@@ -20,6 +20,8 @@ import faiss
 from vlm2vec_for_pyserini.pyserini_integration.mmeb_corpus_encoder import CorpusEncoder
 from vlm2vec_for_pyserini.pyserini_integration.mmeb_query_encoder import QueryEncoder
 
+from pyserini.encode._base import resolve_encoder_name_or_path
+
 
 def get_model_type(model_name: str) -> str:
     if "gme" in model_name.lower():
@@ -73,17 +75,19 @@ class MMEBCorpusEncoder:
 class MMEBQueryEncoder:
     def __init__(
         self,
-        encoder_dir: str,
+        encoder_name_or_path: str = None,
         device="cpu",
+        encoder_dir: str = None,
         **kwargs: Any,
     ):
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
         pooling = kwargs.get("pooling", "eos")
         self.l2_norm = kwargs.get("l2_norm", True)
         # Unlike the corpus encoder, here fp16 is only passed during the initialization.
         self.fp16 = kwargs.get("fp16", False)
         self.query_encoder = QueryEncoder(
-            model_name=encoder_dir,
-            model_type=get_model_type(encoder_dir),
+            model_name=encoder_name_or_path,
+            model_type=get_model_type(encoder_name_or_path),
             device=device,
             pooling=pooling,
             l2_norm=False,

--- a/pyserini/encode/optional/_uniir.py
+++ b/pyserini/encode/optional/_uniir.py
@@ -20,6 +20,8 @@ import faiss
 from uniir_for_pyserini.pyserini_integration.uniir_corpus_encoder import CorpusEncoder
 from uniir_for_pyserini.pyserini_integration.uniir_query_encoder import QueryEncoder
 
+from pyserini.encode._base import resolve_encoder_name_or_path
+
 
 def _ensure_transformers_additional_special_token_ids():
     """Restore tokenizer accessors used by uniir-for-pyserini with transformers 5."""
@@ -115,18 +117,20 @@ class UniIRCorpusEncoder:
 class UniIRQueryEncoder:
     def __init__(
         self,
-        encoder_dir: str,
+        encoder_name_or_path: str = None,
         device="cpu",
         l2_norm=False,
         instruction_config=None,
+        encoder_dir: str = None,
         **kwargs: Any,
     ):
+        encoder_name_or_path = resolve_encoder_name_or_path(encoder_name_or_path, encoder_dir)
         # Unlike the corpus encoder, fp16 is passed at init time for the query encoder.
         _ensure_transformers_compatibility()
         self.fp16 = kwargs.get("fp16", False)
         self.l2_norm = l2_norm
         self.instruction_config = instruction_config
-        self.query_encoder = QueryEncoder(model_name=encoder_dir, device=device)
+        self.query_encoder = QueryEncoder(model_name=encoder_name_or_path, device=device)
 
     def _get_instruction_config(self, instr_file: str = None):
         """This functions downloads all the instruction config files if not already present."""

--- a/pyserini/encode/query.py
+++ b/pyserini/encode/query.py
@@ -66,11 +66,11 @@ def init_encoder(encoder, device, pooling, l2_norm, prefix, bpr):
     elif 'arctic' in encoder.lower():
         return ArcticQueryEncoder(encoder, device=device)
     elif 'dse' in encoder.lower():
-        return DseQueryEncoder(encoder_dir=encoder, device=device, pooling=pooling, l2_norm=l2_norm)
+        return DseQueryEncoder(encoder_name_or_path=encoder, device=device, pooling=pooling, l2_norm=l2_norm)
     elif 'mmeb' in encoder.lower():
         if MMEBQueryEncoder is None:
             raise ValueError(f"MMEB's query encoder class is not available. Have you installed the vlm2vec-for-pyserini package? Detailed stack trace:\n {MMEB_IMPORT_ERROR}")
-        return MMEBQueryEncoder(encoder_dir=encoder, device=device, pooling=pooling, l2_norm=l2_norm)
+        return MMEBQueryEncoder(encoder_name_or_path=encoder, device=device, pooling=pooling, l2_norm=l2_norm)
     else:
         return AutoQueryEncoder(encoder, device=device, pooling=pooling, l2_norm=l2_norm, prefix=prefix)
 

--- a/pyserini/search/faiss/__main__.py
+++ b/pyserini/search/faiss/__main__.py
@@ -285,7 +285,7 @@ def init_query_encoder(
 
         # prepare arguments to encoder class
         kwargs = dict(
-            encoder_dir=encoder,
+            encoder_name_or_path=encoder,
             tokenizer_name=tokenizer_name,
             device=device,
             prefix=prefix,
@@ -501,7 +501,7 @@ if __name__ == "__main__":
             else:
                 sparse_searcher = LuceneSearcher.from_prebuilt_index(args.sparse_index)
             prf_query_encoder = AnceQueryEncoder(
-                encoder_dir=args.ance_prf_encoder,
+                encoder_name_or_path=args.ance_prf_encoder,
                 tokenizer_name=args.tokenizer,
                 device=args.device,
             )

--- a/pyserini/search/faiss/_searcher.py
+++ b/pyserini/search/faiss/_searcher.py
@@ -353,15 +353,15 @@ class FaissSearcher:
     def _init_encoder_from_str(encoder):
         encoder_lower = encoder.lower()
         if 'dpr' in encoder_lower:
-            return DprQueryEncoder(encoder_dir=encoder)
+            return DprQueryEncoder(encoder_name_or_path=encoder)
         elif 'tct_colbert' in encoder_lower:
-            return TctColBertQueryEncoder(encoder_dir=encoder)
+            return TctColBertQueryEncoder(encoder_name_or_path=encoder)
         elif 'ance' in encoder_lower:
-            return AnceQueryEncoder(encoder_dir=encoder)
+            return AnceQueryEncoder(encoder_name_or_path=encoder)
         elif 'sentence' in encoder_lower:
-            return AutoQueryEncoder(encoder_dir=encoder, pooling='mean', l2_norm=True)
+            return AutoQueryEncoder(encoder_name_or_path=encoder, pooling='mean', l2_norm=True)
         else:
-            return AutoQueryEncoder(encoder_dir=encoder)
+            return AutoQueryEncoder(encoder_name_or_path=encoder)
 
     @staticmethod
     def load_docids(docid_path: str) -> List[str]:
@@ -539,6 +539,6 @@ class BinaryDenseFaissSearcher(FaissSearcher):
     def _init_encoder_from_str(encoder):
         encoder = encoder.lower()
         if 'bpr' in encoder:
-            return BprQueryEncoder(encoder_dir=encoder)
+            return BprQueryEncoder(encoder_name_or_path=encoder)
         else:
             raise NotImplementedError

--- a/pyserini/server/backend.py
+++ b/pyserini/server/backend.py
@@ -291,7 +291,7 @@ class SharedSearchBackend:
                 return FaissSearcher.from_prebuilt_index(
                     config.name,
                     query_encoder=uniir_query_encoder(
-                        encoder_dir=config.encoder,
+                        encoder_name_or_path=config.encoder,
                         instruction_config=self._resolve_mbeir_instruction_config(config.name),
                     ),
                 )

--- a/tests/base/encoder/test_query_encoder_name_or_path.py
+++ b/tests/base/encoder/test_query_encoder_name_or_path.py
@@ -1,0 +1,76 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pyserini.encode import AutoQueryEncoder
+from pyserini.encode._base import resolve_encoder_name_or_path
+
+
+class TestQueryEncoderNameOrPath(unittest.TestCase):
+    def test_resolve_encoder_name_or_path_prefers_new_name(self):
+        self.assertEqual(
+            resolve_encoder_name_or_path('castorini/model', None),
+            'castorini/model',
+        )
+
+    def test_resolve_encoder_name_or_path_accepts_legacy_alias(self):
+        self.assertEqual(
+            resolve_encoder_name_or_path(None, 'castorini/model'),
+            'castorini/model',
+        )
+
+    def test_resolve_encoder_name_or_path_rejects_conflicting_values(self):
+        with self.assertRaisesRegex(ValueError, 'refer to different models'):
+            resolve_encoder_name_or_path('castorini/model-a', 'castorini/model-b')
+
+    @patch('pyserini.encode._auto.load_auto_tokenizer')
+    @patch('pyserini.encode._auto.AutoModel.from_pretrained')
+    def test_auto_query_encoder_accepts_new_name(self, from_pretrained, load_tokenizer):
+        model = MagicMock()
+        from_pretrained.return_value = model
+
+        encoder = AutoQueryEncoder(encoder_name_or_path='castorini/model', device='cpu')
+
+        self.assertTrue(encoder.has_model)
+        from_pretrained.assert_called_once_with('castorini/model')
+        model.to.assert_called_once_with('cpu')
+        load_tokenizer.assert_called_once_with('castorini/model', clean_up_tokenization_spaces=True)
+
+    @patch('pyserini.encode._auto.load_auto_tokenizer')
+    @patch('pyserini.encode._auto.AutoModel.from_pretrained')
+    def test_auto_query_encoder_accepts_legacy_alias(self, from_pretrained, load_tokenizer):
+        model = MagicMock()
+        from_pretrained.return_value = model
+
+        encoder = AutoQueryEncoder(encoder_dir='castorini/model', device='cpu')
+
+        self.assertTrue(encoder.has_model)
+        from_pretrained.assert_called_once_with('castorini/model')
+        model.to.assert_called_once_with('cpu')
+        load_tokenizer.assert_called_once_with('castorini/model', clean_up_tokenization_spaces=True)
+
+    def test_auto_query_encoder_rejects_conflicting_names(self):
+        with self.assertRaisesRegex(ValueError, 'refer to different models'):
+            AutoQueryEncoder(
+                encoder_name_or_path='castorini/model-a',
+                encoder_dir='castorini/model-b',
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/optional/test_encoder_uniir.py
+++ b/tests/optional/test_encoder_uniir.py
@@ -30,7 +30,7 @@ class TestUniIREncoderInstantiation(unittest.TestCase):
         from pyserini.encode.optional._uniir import UniIRQueryEncoder
         from uniir_for_pyserini.pyserini_integration.uniir_query_encoder import QueryEncoder
 
-        encoder = UniIRQueryEncoder(encoder_dir="clip_sf_large", device="cpu")
+        encoder = UniIRQueryEncoder(encoder_name_or_path="clip_sf_large", device="cpu")
 
         assert encoder.query_encoder is not None
         assert isinstance(encoder.query_encoder, QueryEncoder)

--- a/tests/optional/test_mcp_uniir.py
+++ b/tests/optional/test_mcp_uniir.py
@@ -84,8 +84,8 @@ class TestMCPyseriniServerUniIR(unittest.TestCase):
         from pyserini.server.backend import SharedSearchBackend
 
         class FakeUniIRQueryEncoder:
-            def __init__(self, encoder_dir, instruction_config=None, **kwargs):
-                self.encoder_dir = encoder_dir
+            def __init__(self, encoder_name_or_path, instruction_config=None, **kwargs):
+                self.encoder_name_or_path = encoder_name_or_path
                 self.instruction_config = instruction_config
 
         class FakeFaissSearcher:


### PR DESCRIPTION
## Why

Query encoder constructors currently use `encoder_dir`, but most of these values can be either a local path or a model name such as a Hugging Face identifier. That makes the public API less clear than the behavior.

## What changed

- Add a shared `resolve_encoder_name_or_path` helper that prefers `encoder_name_or_path` while keeping `encoder_dir` as a compatibility alias.
- Update query encoder constructors and internal search/demo/server call sites to use `encoder_name_or_path` for new code.
- Cover the new name, the legacy alias, and conflicting values with a lightweight unit test.

Closes #2671

## Validation

- `python -m compileall pyserini\encode pyserini\search\faiss pyserini\server\backend.py tests\base\encoder\test_query_encoder_name_or_path.py`
- `git diff --check`
- Attempted `python -m unittest tests.base.encoder.test_query_encoder_name_or_path -v`; local import stopped before test execution because the current Python environment is missing project dependencies such as `pandas`.
- Attempted `python -m pytest tests\base\encoder\test_query_encoder_name_or_path.py -q`; local Python environment does not have `pytest`.

## Risk / follow-up

The change keeps existing `encoder_dir=` callers working as a compatibility alias. The main risk is a missed direct call site, but the remaining `encoder_dir` references are constructor aliases, the shared resolver, or compatibility tests.
