### PR TITLE
Unify 2CR score classification

### DIFF
--- a/pyserini/2cr/_base.py
+++ b/pyserini/2cr/_base.py
@@ -14,11 +14,42 @@
 # limitations under the License.
 #
 
+from enum import Enum
+
 from pyserini.util import run_command
 
 fail_str = '\033[91m[FAIL]\033[0m'
 ok_str = '[OK]'
 okish_str = '\033[94m[OKish]\033[0m'
+
+NUMERICAL_TOLERANCE = 1e-9
+OKISH_TOLERANCE = 0.0002
+
+
+class ScoreStatus(Enum):
+    OK = 'OK'
+    OKISH = 'OKish'
+    FAIL = 'FAIL'
+
+
+def classify_score(observed, expected, *, percentage=False):
+    """Classify an observed score against its expected value.
+
+    ``NUMERICAL_TOLERANCE`` absorbs floating-point noise. Larger improvements
+    and differences strictly below ``OKISH_TOLERANCE`` are ``OKISH``; all
+    remaining regressions are ``FAIL``. Percentage-scale inputs are normalized
+    to the same 0-1 scale before comparison.
+    """
+    scale = 100.0 if percentage else 1.0
+    observed = float(observed) / scale
+    expected = float(expected) / scale
+    delta = abs(observed - expected)
+
+    if delta <= NUMERICAL_TOLERANCE:
+        return ScoreStatus.OK
+    if observed > expected or delta < OKISH_TOLERANCE:
+        return ScoreStatus.OKISH
+    return ScoreStatus.FAIL
 
 
 def run_eval_and_return_metric(metric, eval_key, defs, runfile, display_command=False):

--- a/pyserini/2cr/atomic.py
+++ b/pyserini/2cr/atomic.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 atomic_models = [
     'ViT-L-14.laion2b_s32b_b82k',
@@ -230,10 +229,10 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric,f'atomic.validation.{retrieval_type}',
                                 trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                            if math.isclose(score, float(expected[metric])):
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result = ok_str
-                            # If results are within 0.0005, just call it "OKish".
-                            elif abs(score - float(expected[metric])) <= 0.0005:
+                            elif status is ScoreStatus.OKISH:
                                 result = okish_str + f' expected {expected[metric]:.4f}'
                             else:
                                 result = fail_str + f' expected {expected[metric]:.4f}'

--- a/pyserini/2cr/beir.py
+++ b/pyserini/2cr/beir.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -287,10 +286,10 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric, f'beir-v1.0.0-{dataset}-test',
                                 trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                            if math.isclose(score, float(expected[metric])):
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result = ok_str
-                            # If results are within 0.0005, just call it "OKish".
-                            elif abs(score - float(expected[metric])) <= 0.0005:
+                            elif status is ScoreStatus.OKISH:
                                 result = okish_str + f' expected {expected[metric]:.4f}'
                             else:
                                 result = fail_str + f' expected {expected[metric]:.4f}'

--- a/pyserini/2cr/bright.py
+++ b/pyserini/2cr/bright.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -26,7 +25,7 @@ from string import Template
 
 import yaml
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 metrics = ['nDCG@10', 'R@100', 'R@1000']
 
@@ -210,10 +209,10 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric, f'bright-{dataset}',
                                 trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                            if math.isclose(score, float(expected[metric])):
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result = ok_str
-                            # If results are within 0.005, just call it "OKish".
-                            elif abs(score - float(expected[metric])) <= 0.005:
+                            elif status is ScoreStatus.OKISH:
                                 result = okish_str + f' expected {expected[metric]:.4f}'
                             else:
                                 result = fail_str + f' expected {expected[metric]:.4f}'

--- a/pyserini/2cr/ciral.py
+++ b/pyserini/2cr/ciral.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -293,8 +292,11 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric, f'{eval_key}-{split}',
                                 trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                            if math.isclose(score, float(expected[metric])):
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result_str = ok_str
+                            elif status is ScoreStatus.OKISH:
+                                result_str = okish_str + f' expected {expected[metric]:.4f}'
                             else:
                                 result_str = fail_str + f' expected {expected[metric]:.4f}'
                             print(f'      {metric:7}: {score:.4f} {result_str}')

--- a/pyserini/2cr/dse.py
+++ b/pyserini/2cr/dse.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 def format_run_command(raw):
     return raw.replace('--topics', '\\\n  --topics') \
@@ -125,9 +124,10 @@ def run_conditions(args):
                                     trec_eval_metric, runfile, display_command=args.display_commands)) * 100
 
 
-                            if math.isclose(score, float(expected[metric]), abs_tol=0.1): 
+                            status = classify_score(score, expected[metric], percentage=True)
+                            if status is ScoreStatus.OK:
                                 result = ok_str
-                            elif abs(score - float(expected[metric])) <= 0.5:
+                            elif status is ScoreStatus.OKISH:
                                 result = okish_str + f' expected {expected[metric]:.1f}'
                             else:
                                 result = fail_str + f' expected {expected[metric]:.1f}'

--- a/pyserini/2cr/m_beir.py
+++ b/pyserini/2cr/m_beir.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import fail_str, ok_str, okish_str, run_eval_and_return_metric
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -140,9 +139,10 @@ def run_conditions(args):
                                     score = float(run_eval_and_return_metric(metric, 'm-beir-' + sub_dataset.replace('_', '-'),
                                         trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                                    if math.isclose(score, float(expected[metric])):  
+                                    status = classify_score(score, expected[metric])
+                                    if status is ScoreStatus.OK:
                                         result = ok_str  
-                                    elif abs(score - float(expected[metric])) <= 0.0005 or score > float(expected[metric]):  
+                                    elif status is ScoreStatus.OKISH:
                                         result = okish_str + f' expected {expected[metric]:.4f}'  
                                     else:  
                                         result = fail_str + f' expected {expected[metric]:.4f}'  
@@ -170,9 +170,10 @@ def run_conditions(args):
                                 score = float(run_eval_and_return_metric(metric, 'm-beir-' + dataset.replace('_', '-'),
                                     trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                                if math.isclose(score, float(expected[metric])):  
+                                status = classify_score(score, expected[metric])
+                                if status is ScoreStatus.OK:
                                     result = ok_str  
-                                elif abs(score - float(expected[metric])) <= 0.0005 or score > float(expected[metric]):  
+                                elif status is ScoreStatus.OKISH:
                                     result = okish_str + f' expected {expected[metric]:.4f}'  
                                 else:  
                                     result = fail_str + f' expected {expected[metric]:.4f}'  

--- a/pyserini/2cr/miracl.py
+++ b/pyserini/2cr/miracl.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -376,10 +375,10 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric, qrels,
                                 trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                            if math.isclose(score, float(expected[metric])):
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result_str = ok_str
-                            # If results are within 0.0005, just call it "OKish".
-                            elif math.isclose(score, float(expected[metric]), abs_tol=5e-4):
+                            elif status is ScoreStatus.OKISH:
                                 result_str = okish_str + f' expected {expected[metric]:.4f}'
                             else:
                                 result_str = fail_str + f' expected {expected[metric]:.4f}'

--- a/pyserini/2cr/mmeb.py
+++ b/pyserini/2cr/mmeb.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import fail_str, ok_str, okish_str, run_eval_and_return_metric
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -150,9 +149,10 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric, qrels_name,
                                 trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
                                   
-                            if math.isclose(score, float(expected[metric])):  
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result = ok_str  
-                            elif abs(score - float(expected[metric])) <= 0.0005 or score > float(expected[metric]):
+                            elif status is ScoreStatus.OKISH:
                                 result = okish_str + f' expected {expected[metric]:.4f}'  
                             else:  
                                 result = fail_str + f' expected {expected[metric]:.4f}'  

--- a/pyserini/2cr/mrtydi.py
+++ b/pyserini/2cr/mrtydi.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -28,7 +27,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -276,10 +275,10 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric, f'{eval_key}-{split}',
                                 trec_eval_metric_definitions[metric], runfile, display_command=args.display_commands))
 
-                            if math.isclose(score, float(expected[metric])):
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result_str = ok_str
-                            # If results are within 0.0005, just call it "OKish".
-                            elif math.isclose(score, float(expected[metric]), abs_tol=5e-4):
+                            elif status is ScoreStatus.OKISH:
                                 result_str = okish_str + f' expected {expected[metric]:.4f}'
                             else:
                                 result_str = fail_str + f' expected {expected[metric]:.4f}'

--- a/pyserini/2cr/msmarco.py
+++ b/pyserini/2cr/msmarco.py
@@ -16,12 +16,11 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import re
 import sys
 import time
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from datetime import datetime, timezone
 from string import Template
 
@@ -29,7 +28,7 @@ import yaml
 
 from pyserini.util import run_command
 
-from ._base import run_eval_and_return_metric, ok_str, okish_str, fail_str
+from ._base import ScoreStatus, classify_score, fail_str, ok_str, okish_str, run_eval_and_return_metric
 
 dense_threads = 16
 dense_batch_size = 512
@@ -512,16 +511,6 @@ def generate_report(args):
             out.write(Template(html_template).substitute(title=full_name, rows=all_rows))
 
 
-FlakyKey = namedtuple('FlakyKey', ['collection', 'name', 'topic_key', 'metric'])
-flaky_dict = {
-    # Score differences between runs on Ubuntu and (Jimmy's) Mac Studio
-    FlakyKey('msmarco-v1-passage', 'tct_colbert-v2-hnp-avg-prf-pytorch', 'dl20', 'nDCG@10'): 0.0009,
-    FlakyKey('msmarco-v1-passage', 'ance-rocchio-prf-pytorch', 'dl19-passage', 'nDCG@10'): 0.0008,
-    # Score differences between tuna and linux.cs
-    FlakyKey('msmarco-v1-passage', 'ance-rocchio-prf-pytorch', 'dl20', 'R@1K'): 0.0011,
-}
-
-
 def run_conditions(args):
     start = time.time()
 
@@ -576,15 +565,10 @@ def run_conditions(args):
                             score = float(run_eval_and_return_metric(metric, eval_key,
                                     trec_eval_metric_definitions[args.collection][eval_key][metric], runfile, display_command=args.display_commands))
 
-                            if math.isclose(score, float(expected[metric])):
+                            status = classify_score(score, expected[metric])
+                            if status is ScoreStatus.OK:
                                 result_str = ok_str
-                            # If results are within 0.0005, just call it "OKish".
-                            # If results are actually higher, note with "OKish" also.
-                            elif abs(score-float(expected[metric])) <= 0.0005 or score > float(expected[metric]):
-                                result_str = okish_str + f' expected {expected[metric]:.4f}'
-                            # If there are bigger differences, deal with on a case-by-case basis.
-                            elif abs(score-float(expected[metric])) <= \
-                                    flaky_dict.get(FlakyKey(collection=args.collection, name=name, topic_key=topic_key, metric=metric), 0):
+                            elif status is ScoreStatus.OKISH:
                                 result_str = okish_str + f' expected {expected[metric]:.4f}'
                             else:
                                 result_str = fail_str + f' expected {expected[metric]:.4f}'

--- a/pyserini/2cr/odqa.py
+++ b/pyserini/2cr/odqa.py
@@ -16,7 +16,6 @@
 
 import argparse
 import importlib.resources
-import math
 import os
 import sys
 import time
@@ -29,9 +28,12 @@ import yaml
 from pyserini.util import run_command
 
 from ._base import (
+    ScoreStatus,
+    classify_score,
     convert_trec_run_to_dpr_retrieval_json,
     fail_str,
     ok_str,
+    okish_str,
     run_dpr_retrieval_eval_and_return_metric,
     run_fusion
 )
@@ -437,8 +439,11 @@ def run_topic_conditions(args, topic_arg, default_topics, yaml_path):
                     if not args.skip_eval and metric not in score.keys():
                         continue
                     if not args.skip_eval:
-                        if math.isclose(score[metric], float(expected_score), abs_tol=2e-2):
+                        status = classify_score(score[metric], expected_score, percentage=True)
+                        if status is ScoreStatus.OK:
                             result_str = ok_str
+                        elif status is ScoreStatus.OKISH:
+                            result_str = okish_str + f' expected {expected[metric]:.4f}'
                         else:
                             result_str = fail_str + f' expected {expected[metric]:.4f}'
                         print(f'      {metric:7}: {score[metric]:.2f} {result_str}')

--- a/tests/test_2cr_base.py
+++ b/tests/test_2cr_base.py
@@ -1,0 +1,70 @@
+#
+# Pyserini: Reproducible IR research with sparse and dense representations
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import importlib
+import math
+import unittest
+
+
+base = importlib.import_module('pyserini.2cr._base')
+
+
+class TestScoreClassification(unittest.TestCase):
+    def test_equality_and_floating_point_noise_are_ok(self):
+        self.assertEqual(base.ScoreStatus.OK, base.classify_score(0.3123, 0.3123))
+        self.assertEqual(base.ScoreStatus.OK, base.classify_score(0.1 + 0.2, 0.3))
+        self.assertEqual(
+            base.ScoreStatus.OK,
+            base.classify_score(base.NUMERICAL_TOLERANCE, 0.0)
+        )
+
+    def test_improvement_is_okish(self):
+        self.assertEqual(base.ScoreStatus.OKISH, base.classify_score(0.6, 0.5))
+
+    def test_small_regression_and_strict_boundary(self):
+        self.assertEqual(
+            base.ScoreStatus.OKISH,
+            base.classify_score(0.0, math.nextafter(base.OKISH_TOLERANCE, 0.0))
+        )
+        self.assertEqual(
+            base.ScoreStatus.FAIL,
+            base.classify_score(0.0, base.OKISH_TOLERANCE)
+        )
+        self.assertEqual(
+            base.ScoreStatus.FAIL,
+            base.classify_score(0.0, math.nextafter(base.OKISH_TOLERANCE, math.inf))
+        )
+
+    def test_fractional_and_percentage_inputs_are_equivalent(self):
+        cases = [
+            (0.5, 0.5),
+            (0.6, 0.5),
+            (0.4999, 0.5),
+            (0.4997, 0.5),
+        ]
+        for observed, expected in cases:
+            with self.subTest(observed=observed, expected=expected):
+                fractional = base.classify_score(observed, expected)
+                percentage = base.classify_score(
+                    observed * 100,
+                    expected * 100,
+                    percentage=True
+                )
+                self.assertEqual(fractional, percentage)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #2675.

This moves the OK, OKish, and FAIL decision into a shared helper in _base.py and uses it from all 11 2CR runners. The helper applies a documented 1e-9 numerical allowance, treats larger observed scores as OKish, and keeps the 0.0002 fallback strict.

DSE and ODQA mark their scores as percentage-scale so comparison happens on a 0 to 1 scale without changing their displayed values. The MS MARCO flaky exception table and all runner-specific thresholds are removed.

Validation:
- python -m pytest tests/test_2cr_base.py -q: 4 tests and 4 subtests passed
- imported all 11 modified 2CR runner modules successfully
- python -m compileall -q pyserini/2cr tests/test_2cr_base.py: passed
- git diff --check: passed